### PR TITLE
Update roadmap: fix minor bugs and set separated output directory for each roadmap adapters

### DIFF
--- a/biocypher_metta/adapters/roadmap_dhs_adapter.py
+++ b/biocypher_metta/adapters/roadmap_dhs_adapter.py
@@ -37,7 +37,7 @@ class RoadMapDHSAdapter(Adapter):
         self.source_url = "https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz" # {0-9} indicates this dataset is split into 10 parts
         self.label = "in_dnase_I_hotspot"
 
-        super(RoadMapAdapter, self).__init__(write_properties, add_provenance)
+        super(RoadMapDHSAdapter, self).__init__(write_properties, add_provenance)
 
     def get_edges(self):
         with gzip.open(self.filepath, "rt") as fp:
@@ -56,7 +56,7 @@ class RoadMapDHSAdapter(Adapter):
                             print(f"{tissue} not found in ontology map skipping...")
                             continue
                         
-                        _source = _id,
+                        _source = _id
                         _target = biological_context
 
                         if self.write_properties and self.add_provenance:

--- a/biocypher_metta/adapters/roadmap_h3_marks_adapter.py
+++ b/biocypher_metta/adapters/roadmap_h3_marks_adapter.py
@@ -39,7 +39,7 @@ class RoadMapH3MarkAdapter(Adapter):
         self.source_url = "https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz" # {0-9} indicates this dataset is split into 10 parts
         self.label = "histone_modification"
 
-        super(RoadMapAdapter, self).__init__(write_properties, add_provenance)
+        super(RoadMapH3MarkAdapter, self).__init__(write_properties, add_provenance)
 
 
     def get_edges(self):
@@ -71,5 +71,5 @@ class RoadMapH3MarkAdapter(Adapter):
                             yield _source, _target, self.label, _props
 
                     except Exception as e:
-                        print(f"error while parsing row: {row}, error: {e} skipping...")
+                        # print(f"error while parsing row: {row}, error: {e} skipping...")
                         continue

--- a/biocypher_metta/adapters/roadmap_h3_marks_adapter.py
+++ b/biocypher_metta/adapters/roadmap_h3_marks_adapter.py
@@ -71,5 +71,5 @@ class RoadMapH3MarkAdapter(Adapter):
                             yield _source, _target, self.label, _props
 
                     except Exception as e:
-                        # print(f"error while parsing row: {row}, error: {e} skipping...")
+                        print(f"error while parsing row: {row}, error: {e} skipping...")
                         continue

--- a/biocypher_metta/adapters/roadmap_state_adapter.py
+++ b/biocypher_metta/adapters/roadmap_state_adapter.py
@@ -37,7 +37,7 @@ class RoadMapChromatinStateAdapter(Adapter):
         self.source_url = "https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz" # {0-9} indicates this dataset is split into 10 parts
         self.label = "chromatin_state"
 
-        super(RoadMapAdapter, self).__init__(write_properties, add_provenance)
+        super(RoadMapChromatinStateAdapter, self).__init__(write_properties, add_provenance)
 
     def get_edges(self):
         for file_name in os.listdir(self.filepath):
@@ -57,14 +57,13 @@ class RoadMapChromatinStateAdapter(Adapter):
                                 print(f"{tissue} not found in ontology map skipping...")
                                 continue
                             
-                            _source = _id,
+                            _source = _id
                             _target = biological_context
                             if self.write_properties:
                                 _props["state"] = row[COL_DICT['datatype']]
                                 if self.add_provenance:
                                     _props['source'] = self.source
                                     _props['source_url'] = self.source_url
-                                    
                             yield _source, _target, self.label, _props
 
                     except Exception as e:

--- a/config/adapters_config.yaml
+++ b/config/adapters_config.yaml
@@ -274,7 +274,7 @@ roadmap_chromatin_state:
       chr: chr16
       start: 53000000
       end: 56000000
-  outdir: roadmap
+  outdir: roadmap/chromatin_state
   nodes: False
   edges: True
 
@@ -289,7 +289,7 @@ roadmap_h3_mark:
       chr: chr16
       start: 53000000
       end: 56000000
-  outdir: roadmap
+  outdir: roadmap/h3_mark
   nodes: False
   edges: True
 
@@ -304,7 +304,7 @@ roadmap_dhs:
       chr: chr16
       start: 53000000
       end: 56000000
-  outdir: roadmap
+  outdir: roadmap/dhs
   nodes: False
   edges: True
 

--- a/config/adapters_config_sample.yaml
+++ b/config/adapters_config_sample.yaml
@@ -271,7 +271,7 @@ roadmap_chromatin_state:
       tissue_to_ontology_id_map: ./aux_files/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
 
-  outdir: roadmap
+  outdir: roadmap/chromatin_state
   nodes: False
   edges: True
 
@@ -284,7 +284,7 @@ roadmap_h3_mark:
       tissue_to_ontology_id_map: ./aux_files/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
 
-  outdir: roadmap
+  outdir: roadmap/h3_mark
   nodes: False
   edges: True
 
@@ -297,7 +297,7 @@ roadmap_dhs:
       tissue_to_ontology_id_map: ./aux_files/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
 
-  outdir: roadmap
+  outdir: roadmap/dhs
   nodes: False
   edges: True
 

--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -786,7 +786,6 @@ activity by contact:
 chromatin state:
   is_a: related to at instance level
   represented_as: edge
-  inherit_properties: true
   input_label: chromatin_state
   source: snp
   target: uberon #TODO replace by cell ontology
@@ -798,7 +797,6 @@ dnase I hotspot:
   description: >-
     A region of chromatin that is sensitive to cleavage by the enzyme DNase I
   represented_as: edge
-  inherit_properties: true
   input_label: in_dnase_I_hotspot
   source: snp
   target: uberon #TODO replace by cell ontology
@@ -808,7 +806,6 @@ histone modification:
   description: >-
     A post-translational modification of histone proteins e.g methylation, acetylation, phosphorylation
   represented_as: edge
-  inherit_properties: true
   input_label: histone_modification
   source: snp
   target: uberon #TODO replace by cell ontology


### PR DESCRIPTION
- `inherit property: true` is causing error for `related to at instance level`
- Addresses minor roadmap adapters bug
- Implements separate output directory for chromatin state, DHS, H3K marks 