### PR TITLE
ENCODE-rE2G Adapter

### DIFF
--- a/biocypher_metta/adapters/encode_re2g_adapter.py
+++ b/biocypher_metta/adapters/encode_re2g_adapter.py
@@ -1,0 +1,72 @@
+import gzip
+from biocypher_metta.adapters import Adapter
+from biocypher_metta.adapters.helpers import build_regulatory_region_id, check_genomic_location
+
+class ENCODERe2GAdapter(Adapter):
+    def __init__(self, filepath, write_properties, add_provenance, label='enhancer',
+                 chr=None, start=None, end=None):
+        self.filepath = filepath
+        self.chr = chr
+        self.start = start
+        self.end = end
+        self.label = label
+        
+        self.source = "ENCODE-rE2G"
+        self.version = "1.0"
+        self.source_url = "https://www.encodeproject.org/"
+        
+        super().__init__(write_properties, add_provenance)
+
+    def get_nodes(self):
+        with gzip.open(self.filepath, "rt") as f:
+            for line in f:
+                if line.startswith("#"):
+                    continue
+                
+                fields = line.strip().split("\t")
+                chr = fields[0]
+                start = int(fields[1])
+                end = int(fields[2])
+                region_id = build_regulatory_region_id(chr, start, end)
+                
+                if not check_genomic_location(self.chr, self.start, self.end, chr, start, end):
+                    continue
+                
+                props = {
+                    "chr": chr,
+                    "start": start,
+                    "end": end,
+                }
+                
+                if self.add_provenance:
+                    props['source'] = self.source
+                    props['source_url'] = self.source_url
+                
+                yield region_id, self.label, props
+
+    def get_edges(self):
+        with gzip.open(self.filepath, "rt") as f:
+            for line in f:
+                if line.startswith("#"):
+                    continue
+                
+                fields = line.strip().split("\t")
+                chr = fields[0]
+                start = int(fields[1])
+                end = int(fields[2])
+                gene_id = fields[6]  
+                score = float(fields[-1])
+                region_id = build_regulatory_region_id(chr, start, end)
+                
+                if not check_genomic_location(self.chr, self.start, self.end, chr, start, end):
+                    continue
+                
+                props = {
+                    "score": score,  
+                }
+                
+                if self.add_provenance:
+                    props['source'] = self.source
+                    props['source_url'] = self.source_url
+                
+                yield region_id, gene_id, self.label, props

--- a/config/adapters_config.yaml
+++ b/config/adapters_config.yaml
@@ -1078,3 +1078,26 @@ enhancer_ccre_associates_with_gene:
   outdir: ccre/enhancer_ccre
   nodes: False
   edges: True
+
+encode_re2g:
+  adapter:
+    module: biocypher_metta.adapters.encode_re2g_adapter
+    cls: ENCODERe2GAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/encode_re2g/ENCODE_rE2G_K562.bed.gz
+
+  outdir: encode_re2g
+  nodes: True
+  edges: False
+
+encode_re2g_gene_associates:
+  adapter:
+    module: biocypher_metta.adapters.encode_re2g_adapter
+    cls: ENCODERe2GAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/encode_re2g/ENCODE_rE2G_K562.bed.gz
+      label: enhancer_gene
+
+  outdir: encode_re2g
+  nodes: False
+  edges: True

--- a/config/adapters_config_sample.yaml
+++ b/config/adapters_config_sample.yaml
@@ -1024,3 +1024,26 @@ enhancer_ccre_associates_with_gene:
   outdir: ccre/enhancer_ccre
   nodes: False
   edges: True
+
+encode_re2g:
+  adapter:
+    module: biocypher_metta.adapters.encode_re2g_adapter
+    cls: ENCODERe2GAdapter
+    args:
+      filepath: ./samples/ENCODE_rE2G_K562.bed.gz
+
+  outdir: encode_re2g
+  nodes: True
+  edges: False
+
+encode_re2g_gene_associates:
+  adapter:
+    module: biocypher_metta.adapters.encode_re2g_adapter
+    cls: ENCODERe2GAdapter
+    args:
+      filepath: ./samples/ENCODE_rE2G_K562.bed.gz
+      label: enhancer_gene
+
+  outdir: encode_re2g
+  nodes: False
+  edges: True


### PR DESCRIPTION
Imports the extended thresholded ENCODE-rE2G predictions for K562 cell line dataset into Biocypher-KG