### PR TITLE
Enhances GAF adapter for gene-level annotation

### DIFF
--- a/config/adapters_config.yaml
+++ b/config/adapters_config.yaml
@@ -275,6 +275,58 @@ gaf_cellular_component_gene_product_located_in:
   nodes: False
   edges: True
 
+gaf_biological_process_gene:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/go/goa_human.gaf.gz
+      label: biological_process_gene
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
+
+gaf_molecular_function_gene:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/go/goa_human.gaf.gz
+      label: molecular_function_gene
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
+
+gaf_cellular_component_gene_part_of:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/go/goa_human.gaf.gz
+      label: cellular_component_gene_part_of
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
+
+gaf_cellular_component_gene_located_in:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/go/goa_human.gaf.gz
+      label: cellular_component_gene_located_in
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
+
 coexpression:
   adapter:
     module: biocypher_metta.adapters.coxpresdb_adapter

--- a/config/adapters_config_sample.yaml
+++ b/config/adapters_config_sample.yaml
@@ -278,6 +278,57 @@ gaf_cellular_component_gene_product_located_in:
   nodes: False
   edges: True
 
+gaf_biological_process_gene:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: ./samples/goa_human_sample.gaf.gz
+      label: biological_process_gene
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
+
+gaf_molecular_function_gene:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: ./samples/goa_human_sample.gaf.gz
+      label: molecular_function_gene
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
+
+gaf_cellular_component_gene_part_of:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: ./samples/goa_human_sample.gaf.gz
+      label: cellular_component_gene_part_of
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
+
+gaf_cellular_component_gene_located_in:
+  adapter:
+    module: biocypher_metta.adapters.gaf_adapter
+    cls: GAFAdapter
+    args:
+      filepath: ./samples/goa_human_sample.gaf.gz
+      label: cellular_component_gene_located_in
+      hgnc_to_ensembl_map: ./aux_files/hgnc_to_ensembl.pkl
+
+  outdir: gaf
+  nodes: False
+  edges: True
 
 coexpression:
   adapter:

--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -716,6 +716,60 @@ cellular component gene product located in:
   source: protein
   target: cellular component
 
+go gene:
+  is_a: annotation
+  inherit_properties: true
+  represented_as: edge
+  input_label: go_gene
+  properties:
+    qualifier: obj
+    db_reference: obj
+    evidence: str
+
+biological process gene:
+  is_a: go gene
+  inherit_properties: true
+  represented_as: edge
+  input_label: biological_process_gene
+  output_label: involved_in
+  source: gene
+  target: biological process
+
+molecular function gene:
+  is_a: go gene
+  inherit_properties: true
+  represented_as: edge
+  input_label: molecular_function_gene
+  output_label: enables
+  source: gene
+  target: molecular function
+
+cellular component gene:
+  is_a: go gene
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene
+  source: gene
+  target: cellular component
+
+cellular component gene part of:
+  is_a: cellular component gene
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_part_of
+  output_label: part_of
+  source: gene
+  target: cellular component
+
+cellular component gene located in:
+  is_a: cellular component gene
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_located_in
+  output_label: located_in
+  source: gene
+  target: cellular component
+
 biological process rna:
   is_a: annotation
   inherit_properties: true


### PR DESCRIPTION
Improves the GAF adapter by adding support for mapping HGNC gene symbols to Ensembl gene IDs, enabling gene-level annotation in addition to protein-level. 