### PR TITLE
Add Reactome Pathway-GO Term Associations

### DIFF
--- a/config/adapters_config.yaml
+++ b/config/adapters_config.yaml
@@ -139,7 +139,7 @@ pathway_to_biological_process:
     module: biocypher_metta.adapters.reactome_pathway_go_adapter
     cls: ReactomePathwayGOAdapter
     args:
-      filepath: ./samples/reactome/Pathways2GoTerms_human.txt
+      filepath: /mnt/hdd_2/abdu/biocypher_data/reactome/Pathways2GoTerms_human.txt
       write_properties: true
       add_provenance: true
       subontology: biological_process


### PR DESCRIPTION
This PR adds support for Reactome Pathway to GO Term mappings with:

- New schema definitions for pathway-GO term associations
- ReactomePathwayGOAdapter implementation with subontology filtering
- Updated adapter configs for all three GO categories (BP/MF/CC)
- Proper GO term normalization and source attribution

Key features:
✔️ Strict subontology classification
✔️ Configurable provenance tracking
✔️ Handles all GO term formats