### PR TITLE
Extend Writers & Enhancements in CI/CD

### DIFF
--- a/biocypher_metta/adapters/gencode_adapter.py
+++ b/biocypher_metta/adapters/gencode_adapter.py
@@ -15,8 +15,8 @@ from biocypher_metta.adapters.hgnc_processor import HGNCSymbolProcessor
 # chr1    HAVANA  exon    12613   12721   .       +       .       gene_id "ENSG00000290825.1"; transcript_id "ENST00000456328.2"; gene_type "lncRNA"; gene_name "DDX11L2"; transcript_type "lncRNA"; transcript_name "DDX11L2-202"; exon_number 2; exon_id "ENSE00003582793.1"; level 2; transcript_support_level "1"; tag "basic"; tag "Ensembl_canonical"; havana_transcript "OTTHUMT00000362751.1";
 
 class GencodeAdapter(Adapter):
-    ALLOWED_TYPES = ['transcript', 'transcribed to', 'transcribed from']
-    ALLOWED_LABELS = ['transcript', 'transcribed_to', 'transcribed_from']
+    ALLOWED_TYPES = ['transcript', 'transcribes to', 'transcribed from']
+    ALLOWED_LABELS = ['transcript', 'transcribes_to', 'transcribed_from']
     ALLOWED_KEYS = ['gene_id', 'gene_type', 'gene_name',
                     'transcript_id', 'transcript_type', 'transcript_name', 'tag']
 
@@ -195,7 +195,7 @@ class GencodeAdapter(Adapter):
                     _props['source_url'] = self.source_url
                
                 try:
-                    if self.type == 'transcribed to':
+                    if self.type == 'transcribes to':
                         _id = gene_key + '_' + transcript_key
                         _source = f"ENSEMBL:{gene_key}"
                         _target = f"ENSEMBL:{transcript_key}"

--- a/config/adapters_config.yaml
+++ b/config/adapters_config.yaml
@@ -23,14 +23,14 @@ gencode_transcripts:
   nodes: True
   edges: False
 
-transcribed_to:
+transcribes_to:
   adapter:
     module: biocypher_metta.adapters.gencode_adapter
     cls: GencodeAdapter
     args:
       filepath: /mnt/hdd_2/abdu/biocypher_data/gencode/gencode.annotation.gtf.gz
-      type: transcribed to
-      label: transcribed_to
+      type: transcribes to
+      label: transcribes_to
 
   outdir: gencode/transcript
   nodes: False

--- a/config/adapters_config_sample.yaml
+++ b/config/adapters_config_sample.yaml
@@ -26,14 +26,14 @@ gencode_transcripts:
   edges: False
 
 
-transcribed_to:
+transcribes_to:
   adapter:
     module: biocypher_metta.adapters.gencode_adapter
     cls: GencodeAdapter
     args:
       filepath: ./samples/gencode_sample.gtf.gz
-      type: transcribed to
-      label: transcribed_to
+      type: transcribes to
+      label: transcribes_to
 
   outdir: gencode/transcript
   nodes: False

--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -711,12 +711,12 @@ association:
 # ---
 # expression
 
-transcribed to:
+transcribes to:
   represented_as: edge
   is_a: expression
-  biolink_predicate: "biolink:transcribed_to"
+  biolink_predicate: "biolink:TranscriptToGeneRelationship"
   inherit_properties: true
-  input_label: transcribed_to
+  input_label: transcribes_to
   source: gene
   target: transcript
   kgx_properties:

--- a/data_source_schemas/gencode.yaml
+++ b/data_source_schemas/gencode.yaml
@@ -48,10 +48,10 @@ relationships:
     source: transcript
     target: gene
 
-  transcribed to:
+  transcribes to:
     url: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_44/gencode.v44.annotation.gtf.gz
     description: inverse of transcribed from
-    input_label: transcribed_to
+    input_label: transcribes_to
     source: gene
     target: transcript
 


### PR DESCRIPTION
# Description:
This PR adds support for additional writers in the CI/CD workflow — parquet_writer, kgx_writer, and networkx_writer.
It also extends parquet_writer and kgx_writer to handle list-type source and target fields from the schema, ensuring broader data compatibility and consistency across writer outputs.

# Key updates:

Integrated new writers into existing GitHub Actions workflow

Enhanced schema handling in parquet_writer and kgx_writer

Improved multi-writer CI coverage and consistency