### PR TITLE
Resolves #119 exon-part_of-gene/transcript

### DIFF
--- a/config/adapters_config.yaml
+++ b/config/adapters_config.yaml
@@ -36,6 +36,43 @@ transcribes_to:
   nodes: False
   edges: True
 
+gencode_exon:
+  adapter:
+    module: biocypher_metta.adapters.gencode_exon_adapter
+    cls: GencodeExonAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/gencode/gencode.annotation.gtf.gz
+      target_type: exon   # it could be anything here
+      taxon_id: 9606      # multi-species version needs this
+  outdir: gencode/exon
+  nodes: True
+  edges: False
+
+exon_part_of_transcript: # replaces transcript_includes_exon
+  adapter:
+    module: biocypher_metta.adapters.gencode_exon_adapter
+    cls: GencodeExonAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/gencode/gencode.annotation.gtf.gz
+      label: part_of_transcript
+      target_type: transcript
+      taxon_id: 9606      
+  outdir: gencode/exon
+  nodes: False
+  edges: True
+
+exon_part_of_gene:
+  adapter:
+    module: biocypher_metta.adapters.gencode_exon_adapter
+    cls: GencodeExonAdapter
+    args:
+      filepath: /mnt/hdd_2/abdu/biocypher_data/gencode/gencode.annotation.gtf.gz
+      label: part_of_gene
+      target_type: gene
+      taxon_id: 9606      
+  outdir: gencode/exon
+  nodes: False
+  edges: True
 
 uniprotkb_sprot:
   adapter:
@@ -545,37 +582,38 @@ refseq_closest_gene:
   nodes: False
   edges: True
 
-#topld_afr:
-#    adapter:
-#        module: biocypher_metta.adapters.topld_adapter
-#        cls: TopLDAdapter
-#        args:
-#            filepath: /mnt/hdd_2/abdu/biocypher_data/topld/AFR/AFR_chr16_no_filter_0.2_1000000_LD.csv.gz
-#            ancestry: AFR
-#            dbsnp_pos_map: None # will be provided by import script
-#            chr: chr16
-#            start: 53000000
-#            end:  56000000
-#
-#    outdir: top_ld/afr
-#    nodes: False
-#    edges: True
-#
-#topld_eas:
-#    adapter:
-#        module: biocypher_metta.adapters.topld_adapter
-#        cls: TopLDAdapter
-#        args:
-#            filepath: /mnt/hdd_2/abdu/biocypher_data/topld/EAS/EAS_chr16_no_filter_0.2_1000000_LD.csv.gz
-#            ancestry: EAS
-#            dbsnp_pos_map: None # will be provided by import script
-#            chr: chr16
-#            start: 53000000
-#            end:  56000000
-#
-#    outdir: top_ld/EAS
-#    nodes: False
-#    edges: True
+# There is no adapter config for topld SAMPLE data
+topld_afr:
+   adapter:
+       module: biocypher_metta.adapters.topld_adapter
+       cls: TopLDAdapter
+       args:
+           filepath: /mnt/hdd_2/abdu/biocypher_data/topld/AFR/AFR_chr16_no_filter_0.2_1000000_LD.csv.gz
+           ancestry: AFR
+           dbsnp_pos_map: None # will be provided by import script
+           chr: chr16
+           start: 53000000
+           end:  56000000
+
+   outdir: top_ld/afr
+   nodes: False
+   edges: True
+
+topld_eas:
+   adapter:
+       module: biocypher_metta.adapters.topld_adapter
+       cls: TopLDAdapter
+       args:
+           filepath: /mnt/hdd_2/abdu/biocypher_data/topld/EAS/EAS_chr16_no_filter_0.2_1000000_LD.csv.gz
+           ancestry: EAS
+           dbsnp_pos_map: None # will be provided by import script
+           chr: chr16
+           start: 53000000
+           end:  56000000
+
+   outdir: top_ld/EAS
+   nodes: False
+   edges: True
 
 topld_eur:
   adapter:
@@ -593,44 +631,21 @@ topld_eur:
   nodes: False
   edges: True
 
-#topld_sas:
-#    adapter:
-#        module: biocypher_metta.adapters.topld_adapter
-#        cls: TopLDAdapter
-#        args:
-#            filepath: /mnt/hdd_2/abdu/biocypher_data/topld/SAS/SAS_chr16_no_filter_0.2_1000000_LD.csv.gz
-#            ancestry: SAS
-#            dbsnp_pos_map: None # will be provided by import script
-#            chr: chr16
-#            start: 53000000
-#            end:  56000000
-#
-#    outdir: top_ld/SAS
-#    nodes: False
-#    edges: True
+topld_sas:
+   adapter:
+       module: biocypher_metta.adapters.topld_adapter
+       cls: TopLDAdapter
+       args:
+           filepath: /mnt/hdd_2/abdu/biocypher_data/topld/SAS/SAS_chr16_no_filter_0.2_1000000_LD.csv.gz
+           ancestry: SAS
+           dbsnp_pos_map: None # will be provided by import script
+           chr: chr16
+           start: 53000000
+           end:  56000000
 
-gencode_exon:
-  adapter:
-    module: biocypher_metta.adapters.gencode_exon_adapter
-    cls: GencodeExonAdapter
-    args:
-      filepath: /mnt/hdd_2/abdu/biocypher_data/gencode/gencode.annotation.gtf.gz
-
-  outdir: gencode/exon
-  nodes: True
-  edges: False
-
-transcript_includes_exon:
-  adapter:
-    module: biocypher_metta.adapters.gencode_exon_adapter
-    cls: GencodeExonAdapter
-    args:
-      filepath: /mnt/hdd_2/abdu/biocypher_data/gencode/gencode.annotation.gtf.gz
-      label: includes
-  outdir: gencode/exon
-  nodes: False
-  edges: True
-
+   outdir: top_ld/SAS
+   nodes: False
+   edges: True
 
 rna_central_non_coding_rna:
   adapter:

--- a/config/adapters_config_sample.yaml
+++ b/config/adapters_config_sample.yaml
@@ -38,6 +38,43 @@ transcribes_to:
   nodes: False
   edges: True
 
+gencode_exon:
+  adapter:
+    module: biocypher_metta.adapters.gencode_exon_adapter
+    cls: GencodeExonAdapter
+    args:
+      filepath: ./samples/gencode_sample.gtf.gz
+      target_type: exon   # it could be anything here
+      taxon_id: 9606
+  outdir: gencode/exon
+  nodes: True
+  edges: False
+
+exon_part_of_transcript:
+  adapter:
+    module: biocypher_metta.adapters.gencode_exon_adapter
+    cls: GencodeExonAdapter
+    args:
+      filepath: ./samples/gencode_sample.gtf.gz
+      label: part_of_transcript
+      target_type: transcript
+      taxon_id: 9606      
+  outdir: gencode/exon
+  nodes: False
+  edges: True
+
+exon_part_of_gene:
+  adapter:
+    module: biocypher_metta.adapters.gencode_exon_adapter
+    cls: GencodeExonAdapter
+    args:
+      filepath: ./samples/gencode_sample.gtf.gz
+      label: part_of_gene
+      target_type: gene
+      taxon_id: 9606      
+  outdir: gencode/exon
+  nodes: False
+  edges: True
 
 uniprotkb_sprot:
   adapter:
@@ -45,7 +82,6 @@ uniprotkb_sprot:
     cls: UniprotProteinAdapter
     args:
       filepath: ./samples/uniprot_sprot_human_sample.dat.gz
-
   outdir: uniprot
   nodes: True
   edges: False
@@ -553,27 +589,6 @@ topld_eur:
     nodes: False
     edges: True
 
-gencode_exon:
-  adapter:
-    module: biocypher_metta.adapters.gencode_exon_adapter
-    cls: GencodeExonAdapter
-    args:
-      filepath: ./samples/gencode_sample.gtf.gz
-
-  outdir: gencode/exon
-  nodes: True
-  edges: False
-
-transcript_includes_exon:
-  adapter:
-    module: biocypher_metta.adapters.gencode_exon_adapter
-    cls: GencodeExonAdapter
-    args:
-      filepath: ./samples/gencode_sample.gtf.gz
-      label: includes
-  outdir: gencode/exon
-  nodes: False
-  edges: True
 
 rna_central_non_coding_rna:
   adapter:

--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -1893,25 +1893,61 @@ histone modification:
       type: str
       biolink: phenotypic_state
 
-transcript to exon:
-  is_a: related to at instance
-  mixins: [biolink:ExonToTranscriptRelationship]
-  biolink_predicate: "biolink:has_part"
-  description: >-
-    An association between a transcript and its exons
+
+exon part_of gene:
+  is_a: related to at instance # corrected from "related to at instance"
+  mixins: [biolink:SequenceFeatureRelationship]   # https://biolink.github.io/biolink-model/SequenceFeatureRelationship/
+  biolink_predicate: "biolink:part_of"            # https://biolink.github.io/biolink-model/part_of/
+  description: >-                                 # https://biolink.github.io/biolink-model/SequenceFeatureRelationship/
+    Description: For example, a particular exon is part of a particular transcript or gene    
   represented_as: edge
-  input_label: includes
-  source: transcript
-  target: exon
+  input_label: part_of_gene
+  output_label: part_of
+  source: exon
+  target: gene
+  properties:
+    source:
+      type: str
+      biolink: provided_by
+    source_url:
+      type: str
+      biolink: source_web_page
+    taxon_id:
+      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
   kgx_properties:
     subject_category: "biolink:Transcript"
     object_category: "biolink:Exon"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
-  properties: 
-    source: 
+
+exon part_of transcript:
+  is_a: related to at instance # corrected from "related to at instance"
+  mixins: [biolink:ExonToTranscriptRelationship]
+  biolink_predicate: "biolink:has_part"
+  description: >-
+    An association between an exon and its gene
+  represented_as: edge
+  input_label: part_of_transcript
+  output_label: part_of
+  source: exon
+  target: transcript
+  properties:
+    source:
       type: str
       biolink: provided_by
-    source_url: 
+    source_url:
       type: str
       biolink: source_web_page
+    taxon_id:
+      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: "biolink:Transcript"
+    object_category: "biolink:Exon"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"


### PR DESCRIPTION
Changed biocypher_metta/adapters/gencode_exon_adapter.py to create 'part_of' edges from exon to gene and from exon to transcript. In order to do that, two schemata 
exon part_of transcript
exon part_of gene
were created and added to config/schema_config.yaml. Besides,
config/adapters_config.yaml
config/adapters_config_samples.yaml
were changed accordingly.
