### PR TITLE
Stabilize processor cache invalidation and speed up adapter smoke tests

### DIFF
--- a/biocypher_metta/processors/entrez_ensembl_processor.py
+++ b/biocypher_metta/processors/entrez_ensembl_processor.py
@@ -15,6 +15,7 @@ import requests
 import gzip
 import re
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 from biocypher._logger import logger
@@ -45,6 +46,38 @@ class EntrezEnsemblProcessor(BaseMappingProcessor):
 
     def get_remote_urls(self):
         return [self.NCBI_GENE_INFO_URL, self.GENCODE_URL]
+
+    def check_update_needed(self) -> bool:
+        """
+        Make cache behavior predictable for this processor.
+
+        We honor the configured time window first (default: 7 days) and only
+        allow remote metadata checks after the interval has elapsed.
+        This avoids daily rebuilds caused by frequently changing HTTP
+        Last-Modified headers on upstream files.
+        """
+        if not self.mapping_file.exists() or not self.version_file.exists():
+            logger.info(f"{self.name}: Mapping or version file not found. Update needed.")
+            return True
+
+        version_info = self._load_version_info()
+        if not version_info or "timestamp" not in version_info:
+            logger.warning(f"{self.name}: Invalid version file. Update needed.")
+            return True
+
+        if self.update_interval:
+            last_update = datetime.fromisoformat(version_info["timestamp"])
+            time_since_update = datetime.now() - last_update
+            if time_since_update <= self.update_interval:
+                days = time_since_update.days
+                hours = time_since_update.seconds // 3600
+                logger.info(
+                    f"{self.name}: Using cached mapping (age: {days} days, {hours} hours; "
+                    f"refresh window: {self.update_interval.days} days)."
+                )
+                return False
+
+        return super().check_update_needed()
 
     def fetch_data(self) -> Dict[str, Any]:
         temp_dir = Path(tempfile.mkdtemp())

--- a/biocypher_metta/processors/go_subontology_processor.py
+++ b/biocypher_metta/processors/go_subontology_processor.py
@@ -9,6 +9,8 @@ Update strategy: Dependency-based (updates when GO.owl file changes)
 """
 
 import rdflib
+import json
+from datetime import datetime
 from typing import Dict, Any, Optional
 from pathlib import Path
 from biocypher._logger import logger
@@ -40,6 +42,88 @@ class GOSubontologyProcessor(BaseMappingProcessor):
 
     def set_graph(self, graph: rdflib.Graph):
         self.graph = graph
+
+    def _read_dependency_signature(self) -> Optional[Dict[str, str]]:
+        """
+        Read stable dependency signature from go_meta.json-like files.
+
+        Uses ontology `version` and `hash` fields (ignores mutable `date`).
+        """
+        if not self.dependency_file or not self.dependency_file.exists():
+            return None
+
+        try:
+            with open(self.dependency_file, "r") as f:
+                meta = json.load(f)
+
+            version = meta.get("version")
+            content_hash = meta.get("hash")
+
+            if version is None and content_hash is None:
+                return None
+
+            return {
+                "version": version,
+                "hash": content_hash,
+            }
+        except Exception:
+            return None
+
+    def check_update_needed(self) -> bool:
+        """
+        Use dependency signature when available to avoid unnecessary rebuilds.
+
+        This prevents re-generation when go_meta.json is rewritten but ontology
+        version/hash are unchanged.
+        """
+        if not self.mapping_file.exists() or not self.version_file.exists():
+            logger.info(f"{self.name}: Mapping or version file not found. Update needed.")
+            return True
+
+        version_info = self._load_version_info()
+        if not version_info:
+            logger.warning(f"{self.name}: Invalid version file. Update needed.")
+            return True
+
+        current_sig = self._read_dependency_signature()
+        cached_sig = version_info.get("dependency_signature")
+
+        if current_sig and cached_sig:
+            if current_sig != cached_sig:
+                logger.info(f"{self.name}: Dependency signature changed. Update needed.")
+                return True
+
+            logger.info(f"{self.name}: Dependency signature unchanged. Using cached mapping.")
+            return False
+
+        if self.dependency_file and self.dependency_file.exists() and "timestamp" in version_info:
+            dep_mtime = datetime.fromtimestamp(self.dependency_file.stat().st_mtime)
+            mapping_time = datetime.fromisoformat(version_info["timestamp"])
+
+            if dep_mtime > mapping_time:
+                logger.info(f"{self.name}: Dependency file is newer. Update needed.")
+                return True
+
+        logger.info(f"{self.name}: Using cached mapping.")
+        return False
+
+    def save_version_info(self):
+        super().save_version_info()
+
+        dependency_signature = self._read_dependency_signature()
+        if not dependency_signature:
+            return
+
+        try:
+            with open(self.version_file, "r") as f:
+                version_info = json.load(f)
+
+            version_info["dependency_signature"] = dependency_signature
+
+            with open(self.version_file, "w") as f:
+                json.dump(version_info, f, indent=2)
+        except Exception as e:
+            logger.warning(f"{self.name}: Could not persist dependency signature: {e}")
 
     def fetch_data(self) -> rdflib.Graph:
         if self.graph is None:

--- a/biocypher_metta/processors/hgnc_processor.py
+++ b/biocypher_metta/processors/hgnc_processor.py
@@ -13,6 +13,7 @@ Update strategy: Time-based (every 48 hours)
 import requests
 import csv
 from io import StringIO
+from datetime import datetime
 from typing import Dict, Any, Optional
 from biocypher._logger import logger
 from .base_mapping_processor import BaseMappingProcessor
@@ -38,6 +39,36 @@ class HGNCProcessor(BaseMappingProcessor):
 
     def get_remote_urls(self):
         return [self.HGNC_API_URL]
+
+    def check_update_needed(self) -> bool:
+        """
+        Keep HGNC cache behavior predictable.
+
+        Honor the configured update interval first (default: 48h), then fall
+        back to base checks only after the interval has elapsed.
+        """
+        if not self.mapping_file.exists() or not self.version_file.exists():
+            logger.info(f"{self.name}: Mapping or version file not found. Update needed.")
+            return True
+
+        version_info = self._load_version_info()
+        if not version_info or "timestamp" not in version_info:
+            logger.warning(f"{self.name}: Invalid version file. Update needed.")
+            return True
+
+        if self.update_interval:
+            last_update = datetime.fromisoformat(version_info["timestamp"])
+            time_since_update = datetime.now() - last_update
+            if time_since_update <= self.update_interval:
+                days = time_since_update.days
+                hours = time_since_update.seconds // 3600
+                logger.info(
+                    f"{self.name}: Using cached mapping (age: {days} days, {hours} hours; "
+                    f"refresh window: {self.update_interval.days} days)."
+                )
+                return False
+
+        return super().check_update_needed()
 
     def fetch_data(self) -> str:
         logger.info(f"{self.name}: Fetching data from HGNC API...")

--- a/test/test.py
+++ b/test/test.py
@@ -244,9 +244,15 @@ def should_skip_adapter(adapter_name, module_name, test_mode):
     return False, ""
 
 
+def is_ontology_adapter(module_name):
+    return any(pattern in module_name for pattern in SMOKE_SKIP_MODULE_PATTERNS)
+
+
 def print_profile_summary(kind, timings):
     if not timings:
         return
+    total_elapsed = sum(elapsed for _, elapsed in timings)
+    print(f"[{kind}] Total runtime: {total_elapsed:.2f}s across {len(timings)} adapters")
     print(f"[{kind}] Slowest adapters:")
     for adapter_name, elapsed in sorted(timings, key=lambda x: x[1], reverse=True)[:10]:
         print(f"[{kind}]   {adapter_name}: {elapsed:.2f}s")
@@ -352,6 +358,11 @@ class TestBiocypherKG:
 
             adapter = adapter_class(**adapter_args)
 
+            # Ontology adapters pre-build a full property cache before yielding any node.
+            # For the test we only need label/id — skip the cache to avoid scanning all triples.
+            if is_ontology_adapter(module_name) and hasattr(adapter, 'cache_node_properties'):
+                adapter.cache_node_properties = lambda: None
+
             sample_node = next(adapter.get_nodes(), None)
             assert sample_node, f"No nodes found for adapter '{adapter_name}'"
 
@@ -434,6 +445,12 @@ class TestBiocypherKG:
             adapter_args['add_provenance'] = True
 
             adapter = adapter_class(**adapter_args)
+
+            if is_ontology_adapter(module_name):
+                if hasattr(adapter, 'cache_node_properties'):
+                    adapter.cache_node_properties = lambda: None
+                if hasattr(adapter, 'cache_edge_properties'):
+                    adapter.cache_edge_properties = lambda: None
 
             sample_edge = next(adapter.get_edges(), None)
 


### PR DESCRIPTION
## Summary
This PR makes cache refresh behavior more predictable across the Entrez/Ensembl, GO subontology, and HGNC processors, while also reducing unnecessary work in adapter tests.

## Changes
- Added processor-specific `check_update_needed()` logic for Entrez/Ensembl and HGNC so cached mappings are reused until the configured refresh window actually expires.
- Updated the GO subontology processor to compare stable dependency metadata (`version` and `hash`) instead of rebuilding when mutable metadata like file rewrite time changes.
- Persisted GO dependency signatures in version metadata so future runs can reliably decide whether regeneration is needed.
- Improved adapter test performance by skipping ontology property-cache population when tests only need a sample node or edge.
- Expanded profile output in tests to include total runtime across adapters.

## Why
- Prevents unnecessary cache rebuilds caused by changing remote metadata or rewritten dependency files.
- Makes refresh behavior align with each processor’s intended update strategy.
- Speeds up smoke/profile test runs, especially for ontology-heavy adapters.

## Files Touched
- `biocypher_metta/processors/entrez_ensembl_processor.py`
- `biocypher_metta/processors/go_subontology_processor.py`
- `biocypher_metta/processors/hgnc_processor.py`
- `test/test.py`
