### PR TITLE
optimize: CI test workflow efficiency and contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Type of change
+
+- [ ] New adapter
+- [ ] Adapter fix / update
+- [ ] New processor / Processor fix
+- [ ] Schema change
+- [ ] Adapters config change
+- [ ] Writer fix / update
+- [ ] CI / workflow change
+- [ ] Bug fix / Refactor
+
+---
+
+## Summary
+
+<!-- What changed, why it changed, and any important context for reviewers -->
+
+---
+
+## Checklist
+
+### General
+- [ ] PR targets `main` and branch is up to date
+- [ ] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
+- [ ] No credentials, tokens, or real patient data committed
+
+### New adapter
+- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
+- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
+- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
+- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
+- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently
+
+### Schema changes
+- [ ] New labels are validated against BioCypher / Biolink expectations
+- [ ] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
+- [ ] Breaking label, schema, or adapter-arg changes are called out below
+
+### Testing
+- [ ] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
+- [ ] Ran additional focused checks relevant to the change
+- [ ] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
+- [ ] Spot-checked output node / edge labels and counts where relevant
+
+

--- a/.github/scripts/detect_heavy_adapter_changes.py
+++ b/.github/scripts/detect_heavy_adapter_changes.py
@@ -4,7 +4,11 @@ Detect if any heavy ontology adapter was affected by changes to the adapters con
 
 Instead of grepping diff text (which misses changes to nested fields like filepaths),
 this script maps changed line numbers back to their top-level YAML key by scanning
-upward for the nearest unindented key. That key is the adapter name.
+upward for the nearest unindented key, then reads the adapter.module field within
+that block and checks it against the heavy-adapter pattern list.
+
+The heavy-adapter patterns are read at runtime from SMOKE_SKIP_MODULE_PATTERNS in
+test/test.py — that is the single source of truth. No separate list to maintain here.
 
 Usage:
     python detect_heavy_adapter_changes.py <base_sha> <head_sha>
@@ -12,31 +16,34 @@ Usage:
 Prints:
     HEAVY_CHANGE:<adapter_name>  — if a heavy adapter block was modified
     NO_HEAVY_CHANGE              — otherwise
-
-Must stay in sync with SMOKE_SKIP_MODULE_PATTERNS in test/test.py.
 """
+import ast
+import pathlib
 import sys
 import subprocess
 import re
 
-HEAVY_PATTERNS = [
-    "ontologies_adapter",
-    "gene_ontology_adapter",
-    "uberon_adapter",
-    "cell_ontology_adapter",
-    "cell_line_ontology_adapter",
-    "experimental_factor_ontology_adapter",
-    "brenda_tissue_ontology_adapter",
-    "human_phenotype_ontology_adapter",
-    "chebi_ontology_adapter",
-    "disease_ontology_adapter",
-]
-
 CONFIG_FILE = "config/hsa/hsa_adapters_config_sample.yaml"
 
 
-def is_heavy_adapter(name):
-    return any(p in name for p in HEAVY_PATTERNS)
+def load_heavy_patterns():
+    """
+    Read SMOKE_SKIP_MODULE_PATTERNS from test/test.py at runtime.
+    This makes test/test.py the single source of truth for what counts as a
+    heavy adapter — no duplicate list to keep in sync.
+    """
+    source = pathlib.Path("test/test.py").read_text()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "SMOKE_SKIP_MODULE_PATTERNS":
+                    return ast.literal_eval(node.value)
+    raise RuntimeError("Could not find SMOKE_SKIP_MODULE_PATTERNS in test/test.py")
+
+
+def is_heavy_adapter(name, heavy_patterns):
+    return any(p in name for p in heavy_patterns)
 
 
 def find_top_level_key(lines, line_num_1indexed):
@@ -96,7 +103,7 @@ def parse_diff_hunks(diff_text):
     return old_ranges, new_ranges
 
 
-def check_ranges(lines, ranges):
+def check_ranges(lines, ranges, heavy_patterns):
     """
     Return the first heavy adapter found in the given line ranges, or None.
     Detection is done via the adapter.module value (not the top-level key name),
@@ -108,7 +115,7 @@ def check_ranges(lines, ranges):
             key = find_top_level_key(lines, line_num)
             if not key:
                 continue
-            # Find the 0-based index of the top-level key line so we can scan its block
+            # Find the 0-based index of the top-level key line to scan its block
             key_line_idx = None
             for i in range(line_num - 1, -1, -1):
                 line = lines[i]
@@ -117,7 +124,7 @@ def check_ranges(lines, ranges):
                     break
             if key_line_idx is not None:
                 module = find_module_for_block(lines, key_line_idx)
-                if module and is_heavy_adapter(module):
+                if module and is_heavy_adapter(module, heavy_patterns):
                     return key
     return None
 
@@ -128,6 +135,13 @@ def main():
         sys.exit(1)
 
     base_sha, head_sha = sys.argv[1], sys.argv[2]
+
+    try:
+        heavy_patterns = load_heavy_patterns()
+    except Exception as e:
+        # Can't load patterns — be conservative
+        print(f"HEAVY_CHANGE:unknown (could not load SMOKE_SKIP_MODULE_PATTERNS: {e})")
+        return
 
     try:
         diff_text = subprocess.check_output(
@@ -149,7 +163,7 @@ def main():
     # Check added/modified lines using the new file content
     new_lines = get_file_lines(head_sha, CONFIG_FILE)
     if new_lines:
-        hit = check_ranges(new_lines, new_ranges)
+        hit = check_ranges(new_lines, new_ranges, heavy_patterns)
         if hit:
             print(f"HEAVY_CHANGE:{hit}")
             return
@@ -157,7 +171,7 @@ def main():
     # Check removed lines using the old file content
     old_lines = get_file_lines(base_sha, CONFIG_FILE)
     if old_lines:
-        hit = check_ranges(old_lines, old_ranges)
+        hit = check_ranges(old_lines, old_ranges, heavy_patterns)
         if hit:
             print(f"HEAVY_CHANGE:{hit}")
             return

--- a/.github/scripts/detect_heavy_adapter_changes.py
+++ b/.github/scripts/detect_heavy_adapter_changes.py
@@ -48,6 +48,23 @@ def find_top_level_key(lines, line_num_1indexed):
     return None
 
 
+def find_module_for_block(lines, top_key_line_0indexed):
+    """
+    Scan forward from the top-level key to find the adapter.module value within
+    that block. Stops when the next top-level key is encountered.
+    Returns the module string or None.
+    """
+    for i in range(top_key_line_0indexed + 1, len(lines)):
+        line = lines[i]
+        # Next unindented key means we've left the block
+        if line and not line[0].isspace() and ":" in line and not line.startswith("#"):
+            break
+        stripped = line.strip()
+        if stripped.startswith("module:"):
+            return stripped.split("module:", 1)[1].strip()
+    return None
+
+
 def get_file_lines(sha, path):
     """Get file content at a specific git commit. Returns [] if not found."""
     try:
@@ -80,12 +97,28 @@ def parse_diff_hunks(diff_text):
 
 
 def check_ranges(lines, ranges):
-    """Return the first heavy adapter key found in the given line ranges, or None."""
+    """
+    Return the first heavy adapter found in the given line ranges, or None.
+    Detection is done via the adapter.module value (not the top-level key name),
+    because top-level keys like 'uberon' or 'cell_ontology' don't contain the
+    pattern 'uberon_adapter' / 'cell_ontology_adapter' — but their module field does.
+    """
     for start, count in ranges:
         for line_num in range(start, start + count):
             key = find_top_level_key(lines, line_num)
-            if key and is_heavy_adapter(key):
-                return key
+            if not key:
+                continue
+            # Find the 0-based index of the top-level key line so we can scan its block
+            key_line_idx = None
+            for i in range(line_num - 1, -1, -1):
+                line = lines[i]
+                if line and not line[0].isspace() and line.split(":")[0].strip() == key:
+                    key_line_idx = i
+                    break
+            if key_line_idx is not None:
+                module = find_module_for_block(lines, key_line_idx)
+                if module and is_heavy_adapter(module):
+                    return key
     return None
 
 

--- a/.github/scripts/detect_heavy_adapter_changes.py
+++ b/.github/scripts/detect_heavy_adapter_changes.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Detect if any heavy ontology adapter was affected by changes to the adapters config.
+
+Instead of grepping diff text (which misses changes to nested fields like filepaths),
+this script maps changed line numbers back to their top-level YAML key by scanning
+upward for the nearest unindented key. That key is the adapter name.
+
+Usage:
+    python detect_heavy_adapter_changes.py <base_sha> <head_sha>
+
+Prints:
+    HEAVY_CHANGE:<adapter_name>  — if a heavy adapter block was modified
+    NO_HEAVY_CHANGE              — otherwise
+
+Must stay in sync with SMOKE_SKIP_MODULE_PATTERNS in test/test.py.
+"""
+import sys
+import subprocess
+import re
+
+HEAVY_PATTERNS = [
+    "ontologies_adapter",
+    "gene_ontology_adapter",
+    "uberon_adapter",
+    "cell_ontology_adapter",
+    "cell_line_ontology_adapter",
+    "experimental_factor_ontology_adapter",
+    "brenda_tissue_ontology_adapter",
+    "human_phenotype_ontology_adapter",
+    "chebi_ontology_adapter",
+    "disease_ontology_adapter",
+]
+
+CONFIG_FILE = "config/hsa/hsa_adapters_config_sample.yaml"
+
+
+def is_heavy_adapter(name):
+    return any(p in name for p in HEAVY_PATTERNS)
+
+
+def find_top_level_key(lines, line_num_1indexed):
+    """Scan backward from line_num to find the nearest unindented YAML key."""
+    for i in range(line_num_1indexed - 1, -1, -1):
+        line = lines[i]
+        if line and not line[0].isspace() and ":" in line and not line.startswith("#"):
+            return line.split(":")[0].strip()
+    return None
+
+
+def get_file_lines(sha, path):
+    """Get file content at a specific git commit. Returns [] if not found."""
+    try:
+        content = subprocess.check_output(
+            ["git", "show", f"{sha}:{path}"], text=True, stderr=subprocess.DEVNULL
+        )
+        return content.splitlines()
+    except subprocess.CalledProcessError:
+        return []
+
+
+def parse_diff_hunks(diff_text):
+    """
+    Parse @@ hunk headers from git diff --unified=0 output.
+    Returns (old_ranges, new_ranges) where each is a list of (start, count) tuples.
+    """
+    old_ranges, new_ranges = [], []
+    for line in diff_text.splitlines():
+        m = re.match(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@", line)
+        if m:
+            old_start = int(m.group(1))
+            old_count = int(m.group(2)) if m.group(2) is not None else 1
+            new_start = int(m.group(3))
+            new_count = int(m.group(4)) if m.group(4) is not None else 1
+            if old_count > 0:
+                old_ranges.append((old_start, old_count))
+            if new_count > 0:
+                new_ranges.append((new_start, new_count))
+    return old_ranges, new_ranges
+
+
+def check_ranges(lines, ranges):
+    """Return the first heavy adapter key found in the given line ranges, or None."""
+    for start, count in ranges:
+        for line_num in range(start, start + count):
+            key = find_top_level_key(lines, line_num)
+            if key and is_heavy_adapter(key):
+                return key
+    return None
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: detect_heavy_adapter_changes.py <base_sha> <head_sha>", file=sys.stderr)
+        sys.exit(1)
+
+    base_sha, head_sha = sys.argv[1], sys.argv[2]
+
+    try:
+        diff_text = subprocess.check_output(
+            ["git", "diff", "--unified=0", base_sha, head_sha, "--", CONFIG_FILE],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        # Cannot diff — be conservative and treat as a heavy change
+        print("HEAVY_CHANGE:unknown (git diff failed — conservative fallback)")
+        return
+
+    if not diff_text.strip():
+        print("NO_HEAVY_CHANGE")
+        return
+
+    old_ranges, new_ranges = parse_diff_hunks(diff_text)
+
+    # Check added/modified lines using the new file content
+    new_lines = get_file_lines(head_sha, CONFIG_FILE)
+    if new_lines:
+        hit = check_ranges(new_lines, new_ranges)
+        if hit:
+            print(f"HEAVY_CHANGE:{hit}")
+            return
+
+    # Check removed lines using the old file content
+    old_lines = get_file_lines(base_sha, CONFIG_FILE)
+    if old_lines:
+        hit = check_ranges(old_lines, old_ranges)
+        if hit:
+            print(f"HEAVY_CHANGE:{hit}")
+            return
+
+    print("NO_HEAVY_CHANGE")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -70,7 +70,8 @@ jobs:
           echo "$CHANGED_FILES"
 
           ADAPTERS=$(echo "$CHANGED_FILES" | grep -oP 'biocypher_metta/adapters/\K[^/]+(?=_adapter\.py)' | sort -u | tr '\n' ',' | sed 's/,$//')
-          WRITERS=$(echo "$CHANGED_FILES" | grep -oP 'biocypher_metta/\K(metta|neo4j_csv|prolog|parquet|kgx|networkx)(?=_writer\.py)' | sort -u | tr '\n' ',' | sed 's/,$//')
+          # Match both neo4j_writer.py and neo4j_csv_writer.py and normalise to 'neo4j'
+          WRITERS=$(echo "$CHANGED_FILES" | grep -oP 'biocypher_metta/\K(metta|neo4j_csv|neo4j|prolog|parquet|kgx|networkx)(?=_writer\.py)' | sed 's/^neo4j_csv$/neo4j/' | sort -u | tr '\n' ',' | sed 's/,$//')
           ALL_WRITERS="metta,neo4j,prolog,parquet,kgx,networkx"
 
           echo "adapters=$ADAPTERS" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -18,6 +18,10 @@ on:
       - "config/hsa/hsa_adapters_config_sample.yaml"
       - "create_knowledge_graph.py"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   determine_changes:
     runs-on: ubuntu-latest
@@ -25,6 +29,7 @@ jobs:
       changed_adapters: ${{ steps.get-changes.outputs.adapters }}
       changed_writers: ${{ steps.get-changes.outputs.writers }}
       all_writers: ${{ steps.get-changes.outputs.all_writers }}
+      test_writers: ${{ steps.get-changes.outputs.test_writers }}
       changes_detected: ${{ steps.get-changes.outputs.changes_detected }}
       config_changed: ${{ steps.get-changes.outputs.config_changed }}
       changed_config_items: ${{ steps.get-changes.outputs.changed_config_items }}
@@ -99,6 +104,15 @@ jobs:
           fi
           echo "changes_detected=$CHANGES_DETECTED" >> $GITHUB_OUTPUT
 
+          # On PRs with no writer changes, only test with metta to avoid spinning up 6 identical writer jobs.
+          # On pushes to main or when a writer file changed, test all writers.
+          if [ "${{ github.event_name }}" == "pull_request" ] && [ -z "$WRITERS" ]; then
+            TEST_WRITERS='["metta"]'
+          else
+            TEST_WRITERS='["metta","neo4j","prolog","parquet","kgx","networkx"]'
+          fi
+          echo "test_writers=$TEST_WRITERS" >> $GITHUB_OUTPUT
+
   prepare_config:
     needs: determine_changes
     runs-on: ubuntu-latest
@@ -130,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        writer-type: [metta, neo4j, prolog, parquet, kgx, networkx]
+        writer-type: ${{ fromJson(needs.determine_changes.outputs.test_writers) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -70,8 +70,9 @@ jobs:
           echo "$CHANGED_FILES"
 
           ADAPTERS=$(echo "$CHANGED_FILES" | grep -oP 'biocypher_metta/adapters/\K[^/]+(?=_adapter\.py)' | sort -u | tr '\n' ',' | sed 's/,$//')
-          # Match both neo4j_writer.py and neo4j_csv_writer.py and normalise to 'neo4j'
-          WRITERS=$(echo "$CHANGED_FILES" | grep -oP 'biocypher_metta/\K(metta|neo4j_csv|neo4j|prolog|parquet|kgx|networkx)(?=_writer\.py)' | sed 's/^neo4j_csv$/neo4j/' | sort -u | tr '\n' ',' | sed 's/,$//')
+          # neo4j_writer.py is not used by create_knowledge_graph.py (it maps 'neo4j' → Neo4jCSVWriter).
+          # Only neo4j_csv_writer.py is exercised by CI, so only match that file and normalise to 'neo4j'.
+          WRITERS=$(echo "$CHANGED_FILES" | grep -oP 'biocypher_metta/\K(metta|neo4j_csv|prolog|parquet|kgx|networkx)(?=_writer\.py)' | sed 's/^neo4j_csv$/neo4j/' | sort -u | tr '\n' ',' | sed 's/,$//')
           ALL_WRITERS="metta,neo4j,prolog,parquet,kgx,networkx"
 
           echo "adapters=$ADAPTERS" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -105,12 +105,18 @@ jobs:
           fi
           echo "changes_detected=$CHANGES_DETECTED" >> $GITHUB_OUTPUT
 
-          # On PRs with no writer changes, only test with metta to avoid spinning up 6 identical writer jobs.
-          # On pushes to main or when a writer file changed, test all writers.
-          if [ "${{ github.event_name }}" == "pull_request" ] && [ -z "$WRITERS" ]; then
+          # Use all writers when: push to main, a writer file changed, the main script
+          # changed (output format could be affected), or change detection fell back to
+          # git ls-files (can't tell what's safe to skip).
+          # Only narrow to metta on PRs where the change is isolated to adapter logic.
+          ALL_WRITERS_JSON='["metta","neo4j","prolog","parquet","kgx","networkx"]'
+          if [ "${{ github.event_name }}" == "pull_request" ] \
+            && [ -z "$WRITERS" ] \
+            && [ "$MAIN_SCRIPT_CHANGED" != "true" ] \
+            && [ "$ALL_FILES_USED" != "true" ]; then
             TEST_WRITERS='["metta"]'
           else
-            TEST_WRITERS='["metta","neo4j","prolog","parquet","kgx","networkx"]'
+            TEST_WRITERS="$ALL_WRITERS_JSON"
           fi
           echo "test_writers=$TEST_WRITERS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -106,18 +106,21 @@ jobs:
           fi
           echo "changes_detected=$CHANGES_DETECTED" >> $GITHUB_OUTPUT
 
-          # Use all writers when: push to main, a writer file changed, the main script
-          # changed (output format could be affected), or change detection fell back to
-          # git ls-files (can't tell what's safe to skip).
-          # Only narrow to metta on PRs where the change is isolated to adapter logic.
+          # Determine which writers to include in the matrix:
+          # - push to main or fallback (all_files_used): all 6 writers
+          # - main script changed: all 6 writers (orchestration change could affect any writer)
+          # - writer file(s) changed on PR: only the changed writer(s)
+          # - adapter/config only change on PR: only metta (adapter logic is writer-agnostic)
           ALL_WRITERS_JSON='["metta","neo4j","prolog","parquet","kgx","networkx"]'
-          if [ "${{ github.event_name }}" == "pull_request" ] \
-            && [ -z "$WRITERS" ] \
-            && [ "$MAIN_SCRIPT_CHANGED" != "true" ] \
-            && [ "$ALL_FILES_USED" != "true" ]; then
-            TEST_WRITERS='["metta"]'
-          else
+          if [ "${{ github.event_name }}" != "pull_request" ] \
+            || [ "$ALL_FILES_USED" == "true" ] \
+            || [ "$MAIN_SCRIPT_CHANGED" == "true" ]; then
             TEST_WRITERS="$ALL_WRITERS_JSON"
+          elif [ -n "$WRITERS" ]; then
+            # Build a JSON array from the comma-separated changed writers
+            TEST_WRITERS=$(echo "$WRITERS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip().split(',')))")
+          else
+            TEST_WRITERS='["metta"]'
           fi
           echo "test_writers=$TEST_WRITERS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -9,6 +9,9 @@ on:
       - "biocypher_metta/*.py"
       - "config/hsa/hsa_adapters_config_sample.yaml"
       - "create_knowledge_graph.py"
+      - ".github/workflows/test-adapters.yml"
+      - ".github/scripts/detect_config_changes.py"
+      - ".github/scripts/prepare_config.py"
   pull_request:
     branches: ["main"]
     paths:
@@ -17,6 +20,9 @@ on:
       - "biocypher_metta/*.py"
       - "config/hsa/hsa_adapters_config_sample.yaml"
       - "create_knowledge_graph.py"
+      - ".github/workflows/test-adapters.yml"
+      - ".github/scripts/detect_config_changes.py"
+      - ".github/scripts/prepare_config.py"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-schema.yml
+++ b/.github/workflows/test-schema.yml
@@ -23,6 +23,10 @@ on:
       - "test/test.py"
       - "test/conftest.py"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -30,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -56,8 +62,47 @@ jobs:
       - name: Run tests
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)
+
+          # Default: full mode (used on push to main)
+          SMOKE_FLAG=""
+
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+
+            CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA 2>/dev/null || git ls-files)
+
+            HEAVY_CHANGED=false
+
+            # Check if any changed adapter .py file is a heavy ontology adapter
+            # (pattern match on file path is sufficient here — file names match module names)
+            HEAVY_FILE_PATTERNS="ontologies_adapter|gene_ontology_adapter|uberon_adapter|cell_ontology_adapter|cell_line_ontology_adapter|experimental_factor_ontology_adapter|brenda_tissue_ontology_adapter|human_phenotype_ontology_adapter|chebi_ontology_adapter|disease_ontology_adapter"
+            if echo "$CHANGED_FILES" | grep -qE "($HEAVY_FILE_PATTERNS)"; then
+              HEAVY_CHANGED=true
+              echo "Heavy ontology adapter .py file changed — running full mode"
+            fi
+
+            # Check if the config file changed: use the Python script which maps changed
+            # line numbers → top-level YAML key, so changes to nested fields (args, filepath, etc.)
+            # are correctly attributed to their adapter block — not just a grep on diff text.
+            if [ "$HEAVY_CHANGED" == "false" ] && echo "$CHANGED_FILES" | grep -q "hsa_adapters_config_sample.yaml"; then
+              DETECTION=$(python .github/scripts/detect_heavy_adapter_changes.py $BASE_SHA $HEAD_SHA)
+              echo "Config change detection: $DETECTION"
+              if [[ "$DETECTION" == HEAVY_CHANGE* ]]; then
+                HEAVY_CHANGED=true
+                echo "Heavy ontology adapter config block changed — running full mode"
+              fi
+            fi
+
+            if [ "$HEAVY_CHANGED" == "false" ]; then
+              SMOKE_FLAG="--adapter-test-mode=smoke"
+              echo "No heavy ontology adapter changes detected — running smoke mode"
+            fi
+          fi
+
           uv run pytest test/test.py \
             --adapters-config=./config/hsa/hsa_adapters_config_sample.yaml \
             --primer-schema-config=./config/primer_schema_config.yaml \
             --species-schema-config=./config/hsa/hsa_schema_config.yaml \
+            $SMOKE_FLAG \
             -v -s

--- a/.github/workflows/test-schema.yml
+++ b/.github/workflows/test-schema.yml
@@ -11,6 +11,8 @@ on:
       - "biocypher_metta/processors/**"
       - "test/test.py"
       - "test/conftest.py"
+      - ".github/workflows/test-schema.yml"
+      - ".github/scripts/detect_heavy_adapter_changes.py"
 
   pull_request:
     branches: ["main"]
@@ -22,6 +24,8 @@ on:
       - "biocypher_metta/processors/**"
       - "test/test.py"
       - "test/conftest.py"
+      - ".github/workflows/test-schema.yml"
+      - ".github/scripts/detect_heavy_adapter_changes.py"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -93,14 +97,15 @@ except Exception as e:
     sys.exit(1)
 PY
             )
-            if [ $? -ne 0 ]; then
+            if [ $? -ne 0 ] || [ -z "$HEAVY_FILE_PATTERNS" ]; then
               echo "Warning: could not read SMOKE_SKIP_MODULE_PATTERNS from test/test.py — defaulting to full mode"
               HEAVY_CHANGED=true
             fi
 
             # Check if any changed adapter .py file is a heavy ontology adapter
             # (file names match module names so the pattern works directly on paths)
-            if [ "$HEAVY_CHANGED" == "false" ] && echo "$CHANGED_FILES" | grep -qE "($HEAVY_FILE_PATTERNS)"; then
+            # Guard: skip grep if pattern is empty to avoid matching everything
+            if [ "$HEAVY_CHANGED" == "false" ] && [ -n "$HEAVY_FILE_PATTERNS" ] && echo "$CHANGED_FILES" | grep -qE "($HEAVY_FILE_PATTERNS)"; then
               HEAVY_CHANGED=true
               echo "Heavy ontology adapter .py file changed — running full mode"
             fi

--- a/.github/workflows/test-schema.yml
+++ b/.github/workflows/test-schema.yml
@@ -74,10 +74,33 @@ jobs:
 
             HEAVY_CHANGED=false
 
+            # Build the heavy-adapter pattern from SMOKE_SKIP_MODULE_PATTERNS in test/test.py
+            # — single source of truth, no duplicate list to maintain here.
+            HEAVY_FILE_PATTERNS=$(python - <<'PY'
+import ast, pathlib, sys
+try:
+    source = pathlib.Path("test/test.py").read_text()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "SMOKE_SKIP_MODULE_PATTERNS":
+                    print("|".join(ast.literal_eval(node.value)))
+                    sys.exit(0)
+    sys.exit(1)
+except Exception as e:
+    print(f"ERROR:{e}", file=sys.stderr)
+    sys.exit(1)
+PY
+            )
+            if [ $? -ne 0 ]; then
+              echo "Warning: could not read SMOKE_SKIP_MODULE_PATTERNS from test/test.py — defaulting to full mode"
+              HEAVY_CHANGED=true
+            fi
+
             # Check if any changed adapter .py file is a heavy ontology adapter
-            # (pattern match on file path is sufficient here — file names match module names)
-            HEAVY_FILE_PATTERNS="ontologies_adapter|gene_ontology_adapter|uberon_adapter|cell_ontology_adapter|cell_line_ontology_adapter|experimental_factor_ontology_adapter|brenda_tissue_ontology_adapter|human_phenotype_ontology_adapter|chebi_ontology_adapter|disease_ontology_adapter"
-            if echo "$CHANGED_FILES" | grep -qE "($HEAVY_FILE_PATTERNS)"; then
+            # (file names match module names so the pattern works directly on paths)
+            if [ "$HEAVY_CHANGED" == "false" ] && echo "$CHANGED_FILES" | grep -qE "($HEAVY_FILE_PATTERNS)"; then
               HEAVY_CHANGED=true
               echo "Heavy ontology adapter .py file changed — running full mode"
             fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This guide covers how to add a new adapter for a biological dataset, update the 
 ## 1. Setup
 
 ```bash
-git clone https://github.com/your-org/biocypher-kg.git
+git clone https://github.com/rejuve-bio/biocypher-kg.git
 cd biocypher-kg
 pip install uv
 uv sync

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,7 @@ uv run python create_knowledge_graph.py \
   --adapters-config config/hsa/hsa_adapters_config_sample.yaml \
   --schema-config config/hsa/hsa_schema_config.yaml \
   --writer-type metta \
-  --dbsnp-mapping-path aux_files/hsa/sample_dbsnp/dbsnp_mapping.pkl
+  --dbsnp-cache-dir aux_files/hsa/sample_dbsnp
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,13 +133,11 @@ def get_edges(self):
 
 ### 3.5 Heavy ontology adapters
 
-If your adapter downloads and parses OWL/ontology files at runtime it is considered a **heavy adapter**. These are skipped during PR smoke tests to keep CI fast. You must update three places when adding one:
+If your adapter downloads and parses OWL/ontology files at runtime it is considered a **heavy adapter**. These are skipped during PR smoke tests to keep CI fast.
 
-1. `SMOKE_SKIP_MODULE_PATTERNS` in `test/test.py`
-2. The heavy-adapter detection logic used by CI helper scripts (for example `.github/scripts/detect_heavy_adapter_changes.py`)
-3. Any workflow or helper config that maintains a separate list of heavy ontology adapters
+Add your adapter's module name to `SMOKE_SKIP_MODULE_PATTERNS` in `test/test.py` — that is the **single source of truth**. CI workflows and helper scripts read this list at runtime, so no other files need updating.
 
-Keep these lists and detection rules in sync so local tests and CI treat heavy adapters consistently.
+Only touch `.github/scripts/detect_heavy_adapter_changes.py` or the workflow files if the pattern-parsing mechanism itself needs to change.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,314 @@
+# Contributing to biocypher-kg
+
+This guide covers how to add a new adapter for a biological dataset, update the schema, and get your changes through CI. Read the relevant sections for your contribution type.
+
+---
+
+## Table of contents
+
+1. [Setup](#1-setup)
+2. [Project structure](#2-project-structure)
+3. [Implementing a new adapter](#3-implementing-a-new-adapter)
+4. [Registering the adapter](#4-registering-the-adapter)
+5. [Updating the schema](#5-updating-the-schema)
+6. [Adding sample data for tests](#6-adding-sample-data-for-tests)
+7. [Running tests locally](#7-running-tests-locally)
+8. [Opening a PR](#8-opening-a-pr)
+
+---
+
+## 1. Setup
+
+```bash
+git clone https://github.com/your-org/biocypher-kg.git
+cd biocypher-kg
+pip install uv
+uv sync
+```
+
+---
+
+## 2. Project structure
+
+```
+biocypher_metta/
+  adapters/               # One file per adapter
+    __init__.py           # Base Adapter class
+    helpers.py            # Shared utilities (check_genomic_location, to_float, …)
+    gencode_gene_adapter.py
+    string_ppi_adapter.py
+    …
+  processors/             # Reusable ID-mapping processors (HGNC, dbSNP, Ensembl↔UniProt, …)
+  *_writer.py             # Output writers (metta, neo4j, prolog, parquet, kgx, networkx)
+
+config/
+  primer_schema_config.yaml          # Species-agnostic node/edge schema (shared base)
+  hsa/
+    hsa_schema_config.yaml           # Human-specific schema overrides
+    hsa_adapters_config_sample.yaml  # Adapter registry used by tests
+    hsa_adapters_config.yaml         # Full adapter registry used in production
+    hsa_data_source_config.yaml      # Data source names and download URLs
+
+samples/hsa/                         # Small sample files used by tests (committed to repo)
+aux_files/hsa/                       # Larger generated/cached assets (not committed)
+
+test/
+  test.py                            # Test suite (schema validation + adapter smoke tests)
+  conftest.py                        # Pytest fixtures and CLI options
+```
+
+---
+
+## 3. Implementing a new adapter
+
+### 3.1 Create the adapter file
+
+Create `biocypher_metta/adapters/<datasource>_adapter.py`. Every adapter inherits from `Adapter` and implements `get_nodes()`, `get_edges()`, or both.
+
+```python
+from biocypher_metta.adapters import Adapter
+
+class MyDatasetAdapter(Adapter):
+    def __init__(self, filepath, label, write_properties, add_provenance):
+        self.filepath = filepath
+        self.label = label
+        self.source = 'MyDataset'
+        self.source_url = 'https://mydataset.org/'
+        self.version = 'v1.0'
+        super().__init__(write_properties, add_provenance)
+
+    def get_nodes(self):
+        # yield (node_id, label, props_dict)
+        ...
+
+    def get_edges(self):
+        # yield (source_id, target_id, label, props_dict)
+        ...
+```
+
+### 3.2 Node adapter — yield format
+
+```python
+def get_nodes(self):
+    for record in self.parse_file():
+        node_id = f"PREFIX:{record['id']}"   # use a CURIE prefix (ENSEMBL:, UniProtKB:, …)
+        props = {}
+        if self.write_properties:
+            props = {
+                'name': record['name'],
+                'description': record['description'],
+            }
+            if self.add_provenance:
+                props['source'] = self.source
+                props['source_url'] = self.source_url
+        yield node_id, self.label, props
+```
+
+### 3.3 Edge adapter — yield format
+
+```python
+def get_edges(self):
+    for record in self.parse_file():
+        source_id = f"UniProtKB:{record['protein_a']}"
+        target_id = f"UniProtKB:{record['protein_b']}"
+        props = {}
+        if self.write_properties:
+            props = {'score': record['score']}
+            if self.add_provenance:
+                props['source'] = self.source
+                props['source_url'] = self.source_url
+        yield source_id, target_id, self.label, props
+```
+
+### 3.4 Key conventions
+
+| Convention | Detail |
+|---|---|
+| **Node IDs** | Always use CURIE format: `PREFIX:id` (e.g. `ENSEMBL:ENSG00000139618`, `UniProtKB:P04637`) |
+| **`write_properties`** | Gate all property collection behind this flag — the KG pipeline controls it |
+| **`add_provenance`** | Gate `source` and `source_url` behind this flag — always nest it inside `write_properties` |
+| **`self.source` / `self.source_url`** | Set these in `__init__` so provenance is consistent across all output formats |
+| **File parsing** | Prefer streaming (generators, line-by-line) over loading the full file into memory |
+| **Processors** | Reuse existing processors from `biocypher_metta/processors/` for common ID mappings (HGNC, Ensembl↔UniProt, dbSNP, …) instead of rolling your own |
+
+### 3.5 Heavy ontology adapters
+
+If your adapter downloads and parses OWL/ontology files at runtime it is considered a **heavy adapter**. These are skipped during PR smoke tests to keep CI fast. You must update three places when adding one:
+
+1. `SMOKE_SKIP_MODULE_PATTERNS` in `test/test.py`
+2. The heavy-adapter detection logic used by CI helper scripts (for example `.github/scripts/detect_heavy_adapter_changes.py`)
+3. Any workflow or helper config that maintains a separate list of heavy ontology adapters
+
+Keep these lists and detection rules in sync so local tests and CI treat heavy adapters consistently.
+
+---
+
+## 4. Registering the adapter
+
+### 4.1 Adapters config (`hsa_adapters_config_sample.yaml`)
+
+Add an entry so CI can find and test your adapter. The key is a short descriptive name used throughout the pipeline.
+
+```yaml
+my_dataset:
+  adapter:
+    module: biocypher_metta.adapters.my_dataset_adapter
+    cls: MyDatasetAdapter
+    args:
+      filepath: ./samples/hsa/my_dataset_sample.tsv
+      label: my_node_label
+  outdir: my_dataset
+  nodes: true
+  edges: false
+```
+
+For adapters that use dbSNP mappings:
+
+```yaml
+args:
+  filepath: ./samples/hsa/my_dataset_sample.tsv
+  dbsnp_rsid_map: null   # injected automatically by the test harness
+  dbsnp_pos_map: null    # injected automatically by the test harness
+```
+
+### 4.2 Data source config (`hsa_data_source_config.yaml`)
+
+Add an entry with the canonical download URL. This is the source of truth for where the full data comes from.
+
+```yaml
+my_dataset:
+  name: My Dataset
+  url: https://mydataset.org/download/my_dataset_v1.tsv.gz
+```
+
+If the source has multiple files:
+
+```yaml
+my_dataset:
+  name: My Dataset
+  url:
+    - https://mydataset.org/download/file1.tsv.gz
+    - https://mydataset.org/download/file2.tsv.gz
+```
+
+---
+
+## 5. Updating the schema
+
+Node and edge labels your adapter yields must be declared in the schema. Species-agnostic labels go in `config/primer_schema_config.yaml`; human-specific ones go in `config/hsa/hsa_schema_config.yaml`.
+
+### 5.1 Adding a node
+
+```yaml
+my entity:
+  represented_as: node
+  is_a: biological entity          # must be a valid Biolink parent class
+  mixins:
+    - biolink:BiologicalEntity
+  biolink_category: biolink:BiologicalEntity
+  input_label: my_node_label       # must match the label you yield in get_nodes()
+  inherit_properties: true
+  properties:
+    name:
+      type: str
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+```
+
+### 5.2 Adding an edge
+
+```yaml
+my relationship:
+  represented_as: edge
+  is_a: related to
+  label_as_edge: my_relationship   # used in graph databases
+  input_label: my_relationship     # must match the label you yield in get_edges()
+  source: my entity                # must match a declared node input_label
+  target: gene                     # must match a declared node input_label
+  properties:
+    score:
+      type: float
+    source:
+      type: str
+    source_url:
+      type: str
+```
+
+### 5.3 Finding valid Biolink parent classes
+
+Browse the [Biolink model](https://biolink.github.io/biolink-model/) or look at existing entries in `primer_schema_config.yaml` for examples of how other biological entities are mapped.
+
+---
+
+## 6. Adding sample data for tests
+
+Tests run against small sample files committed under `samples/hsa/`. The sample must be representative enough that `get_nodes()` or `get_edges()` yields at least one record.
+
+- Keep sample files small — a few hundred rows is enough
+- Match the exact format the adapter expects (same columns, same compression)
+- Point `filepath` in `hsa_adapters_config_sample.yaml` to `./samples/hsa/your_sample_file`
+- Large generated or cached assets (e.g. downloaded OWL files) go under `aux_files/` and are **not** committed
+
+---
+
+## 7. Running tests locally
+
+**Smoke test** (fast — skips heavy ontology adapters and uses the configured smoke cap):
+```bash
+uv run pytest test/test.py --adapter-test-mode=smoke -v -s
+```
+
+**Full test** (required if you changed a heavy ontology adapter or the schema broadly):
+```bash
+uv run pytest test/test.py -v -s
+```
+
+**Test only your adapter** by temporarily limiting the config:
+```bash
+uv run pytest test/test.py \
+  --adapters-config=config/hsa/hsa_adapters_config_sample.yaml \
+  --adapter-test-mode=smoke \
+  -v -s -k "test_adapter_nodes_in_schema or test_adapter_edges_in_schema"
+```
+
+**Run the full KG pipeline** for your adapter:
+```bash
+uv run python create_knowledge_graph.py \
+  --output-dir output \
+  --adapters-config config/hsa/hsa_adapters_config_sample.yaml \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --writer-type metta \
+  --dbsnp-mapping-path aux_files/hsa/sample_dbsnp/dbsnp_mapping.pkl
+```
+
+---
+
+## 8. Opening a PR
+
+**Branch naming:**
+```
+feat/add-<datasource>-adapter
+fix/<adapter-name>-<short-description>
+optimize/<area>
+```
+
+**Before pushing:**
+- All items in the PR template checklist are complete
+- `uv run pytest test/test.py --adapter-test-mode=smoke` passes locally
+- Sample file is committed and `filepath` in the config points to it
+- `hsa_data_source_config.yaml` has an entry with the download URL
+
+**CI behaviour:**
+- Pushing to a PR cancels any in-progress run for that branch automatically
+- `test-schema` and `test-adapters` are separate workflows with different scopes
+- CI may narrow the adapter/config set it runs based on detected file changes
+- Writer tests may still run as a matrix, depending on which files changed
+- Merge-to-`main` runs are intentionally broader than PR validation runs
+
+When in doubt, open the current workflow files for the exact behavior:
+- `.github/workflows/test-schema.yml`
+- `.github/workflows/test-adapters.yml`


### PR DESCRIPTION
## Summary

This PR reduces CI runtime on PRs, eliminates redundant test runs from rapid pushes, and adds contribution infrastructure (PR template + guide) for new contributors.

---

## CI Optimizations

### Concurrency — cancel stale runs on new pushes
Both `test-schema` and `test-adapters` now use a concurrency group scoped to the workflow + branch ref. When you push a second commit to a PR, the in-progress run is cancelled before the new one starts.

### Smart smoke mode in `test-schema`
On PRs, the schema test defaults to smoke mode (skips expensive ontology adapters).
It switches to full mode automatically if the diff touches a heavy ontology adapter — detected in two ways:
- **Adapter `.py` file changed** — filename pattern match against the file path
- **Config file changed** — uses `.github/scripts/detect_heavy_adapter_changes.py` which maps changed line numbers → top-level YAML key by scanning upward in the file, then reads the block's `adapter.module` field to check against heavy patterns. This correctly catches changes to nested fields like `filepath` or `args` that don't mention the adapter name on the changed line itself.

Full mode always runs on push to `main`.

### Single source of truth for heavy adapter patterns
`SMOKE_SKIP_MODULE_PATTERNS` in `test/test.py` is the only place that defines which adapters are "heavy". Both `detect_heavy_adapter_changes.py` and `test-schema.yml` read this list at runtime via `ast.parse` — no duplicate list to keep in sync.
Both fall back conservatively to full mode if parsing fails.

### Dynamic writer matrix in `test-adapters`
The matrix is now scoped precisely to what actually changed:

| Scenario | Writer jobs |
|---|---|
| PR — adapter/config change only | `["metta"]` |
| PR — `prolog_writer.py` changed | `["prolog"]` |
| PR — `prolog_writer.py` + `kgx_writer.py` changed | `["prolog", "kgx"]` |
| PR — `create_knowledge_graph.py` changed | all 6 |
| PR — change detection fell back to `git ls-files` | all 6 |
| Push to `main` | all 6 |

Note: `neo4j_writer.py` is not wired into `create_knowledge_graph.py` (the `neo4j` writer type maps to `Neo4jCSVWriter` from `neo4j_csv_writer.py`). Changes to `neo4j_writer.py` are excluded from writer detection to avoid false triggers.

### Impact summary

| Scenario | Before | After |
|---|---|---|
| PR push (adapter change) | 6 writer jobs + full schema, no cancellation | 1 writer job + smoke schema, previous run cancelled |
| PR push (heavy adapter change) | 6 writer jobs + full schema, no cancellation | 1 writer job + full schema, previous run cancelled |
| PR push (single writer change) | 6 writer jobs, no cancellation | 1 writer job, previous run cancelled |
| Push to `main` | unchanged | unchanged |

---

## Contribution Infrastructure

### PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
Structured checklist covering the most common contribution types with specific items for: new adapters, schema changes, config registration, data source URL, sample data, and the heavy adapter sync requirement.

### Contributing guide (`CONTRIBUTING.md`)
End-to-end walkthrough for implementing a new adapter — base class interface, node/edge yield format, CURIE conventions, provenance flags, schema and config registration, sample data, and how to run tests locally.

---

## Files changed

| File | Change |
|---|---|
| `.github/workflows/test-schema.yml` | Concurrency group + smart smoke mode; patterns read from `test/test.py` |
| `.github/workflows/test-adapters.yml` | Concurrency group + dynamic writer matrix scoped to changed writers |
| `.github/scripts/detect_heavy_adapter_changes.py` | New — line-aware config diff detection; reads patterns from `test/test.py` |
| `.github/PULL_REQUEST_TEMPLATE.md` | New — PR checklist template |
| `CONTRIBUTING.md` | New — adapter implementation guide |
