### PR TITLE
feat: add DAS MeTTa loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ run-interactive: check-uv
 		--writer-type "$$WRITER_TYPE" \
 		$$INCLUDE_ADAPTERS_FLAG \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG; \
+		$$ADD_PROVENANCE_FLAG && \
 	echo "✅ Knowledge graph creation completed! Check $$OUTPUT_DIR for results."
 
 run-direct: check-uv
@@ -170,7 +170,6 @@ run-sample: check-uv
 		$$WRITE_PROPERTIES_FLAG \
 		$$ADD_PROVENANCE_FLAG
 	@echo "✅ Sample run completed! Check the ./output directory for results."
-#		# --dbsnp-pos ./aux_files/hsa/sample_dbsnp_pos.pkl 
 # Run tests
 test: check-uv
 	@export PATH="$$HOME/.local/bin:$$PATH"; uv run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,7 @@ dependencies = [
     "yoyo-migrations==9.0.0",
     "zipp==3.23.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["test"]
+python_files = ["test.py", "test_*.py", "*_test.py"]

--- a/scripts/das_metta_loader.py
+++ b/scripts/das_metta_loader.py
@@ -1,0 +1,112 @@
+"""
+das_metta_loader.py — Load MeTTa files into DAS (Distributed AtomSpace) via das-cli.
+
+OVERVIEW
+--------
+This script recursively walks a directory for all `.metta` files and loads each
+one into a running DAS instance using the `das-cli metta load` command.
+
+
+PREREQUISITES
+-------------
+1. **das-cli**
+   The `das-cli` tool must be installed and accessible on your PATH.
+   Setup guide: https://github.com/singnet/das-toolbox/blob/master/das-cli/README.md
+
+2. **DAS (Distributed AtomSpace)**
+   DAS must be installed and running before executing this script.
+   Setup guide: https://github.com/singnet/das/blob/master/README.md
+
+3. **DAS server must be running**
+   Start your local DAS instance before running this script:
+       das-cli server start
+   Then confirm it is reachable:
+       das-cli server ping
+
+USAGE
+-----
+    python scripts/das_metta_loader.py <directory>
+
+Arguments:
+    <directory>   Path to the root directory containing .metta files.
+                  The script walks subdirectories recursively.
+
+Examples:
+    # Load all .metta files from the default output directory
+    python scripts/das_metta_loader.py ./output
+
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+
+def load_metta_files(root_dir):
+    start_time = time.time()
+
+    success = []
+    failed = []
+    total = 0
+
+    for dirpath, _, filenames in os.walk(root_dir):
+        for filename in filenames:
+            if filename.endswith(".metta"):
+                total += 1
+                file_path = os.path.abspath(os.path.join(dirpath, filename))
+                print(f"\nProcessing: {file_path}")
+
+                cmd = ["das-cli", "metta", "load", file_path]
+
+                try:
+                    result = subprocess.run(
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+
+                    if result.returncode == 0:
+                        print("✅ SUCCESS")
+                        success.append(file_path)
+                    else:
+                        print("❌ FAILED")
+                        print(result.stderr)
+                        failed.append(file_path)
+
+                except Exception as e:
+                    print(f"❌ EXCEPTION: {e}")
+                    failed.append(file_path)
+
+    end_time = time.time()
+    total_time = end_time - start_time
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"Total files found:    {total}")
+    print(f"Successfully loaded:  {len(success)}")
+    print(f"Failed:               {len(failed)}")
+
+    if failed:
+        print("\nFailed files:")
+        for f in failed:
+            print(f"  - {f}")
+
+    print(f"\nTotal execution time: {total_time:.2f} seconds")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python scripts/das_metta_loader.py <directory>")
+        sys.exit(1)
+
+    directory = sys.argv[1]
+
+    if not os.path.isdir(directory):
+        print(f"Error: '{directory}' is not a valid directory.")
+        sys.exit(1)
+
+    load_metta_files(directory)

--- a/scripts/das_metta_loader.py
+++ b/scripts/das_metta_loader.py
@@ -62,7 +62,7 @@ def load_metta_files(root_dir):
                 try:
                     result = subprocess.run(
                         cmd,
-                        stdout=subprocess.PIPE,
+                        stdout=subprocess.DEVNULL,
                         stderr=subprocess.PIPE,
                         text=True,
                     )
@@ -98,6 +98,15 @@ def load_metta_files(root_dir):
     print("=" * 60)
 
 
+def check_das_cli():
+    try:
+        subprocess.run(["das-cli", "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except FileNotFoundError:
+        print("Error: 'das-cli' is not installed or not on PATH.")
+        print("Install it using the setup guide: https://github.com/singnet/das-toolbox/blob/master/das-cli/README.md")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python scripts/das_metta_loader.py <directory>")
@@ -109,4 +118,5 @@ if __name__ == "__main__":
         print(f"Error: '{directory}' is not a valid directory.")
         sys.exit(1)
 
+    check_das_cli()
     load_metta_files(directory)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,14 @@
+import sys
+from pathlib import Path
+
+
+# Ensure tests can import the local package when the project is run
+# directly from the repository without an editable install.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--adapters-config",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,8 +5,13 @@ from pathlib import Path
 # Ensure tests can import the local package when the project is run
 # directly from the repository without an editable install.
 ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+ROOT_STR = str(ROOT)
+EXISTING_PATHS = {
+    str((Path.cwd() if entry in ("", ".") else Path(entry)).resolve())
+    for entry in sys.path
+}
+if ROOT_STR not in EXISTING_PATHS:
+    sys.path.insert(0, ROOT_STR)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [x] New processor / Processor fix
- [ ] Schema change
- [ ] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [ ] Bug fix / Refactor

---

## Summary

* Adds scripts/das_metta_loader.py — a utility that recursively discovers all .metta files under a given directory and loads them into a running DAS (Distributed AtomSpace) instance via das-cli metta load.
* The script reports per-file success/failure status with stderr output on failure and prints a final summary (total / loaded / failed / wall-clock time).
* Includes comprehensive module-level docstring covering prerequisites, setup links, usage examples, and behavioral notes — no separate doc file needed.

---

## Checklist

### General
- [x] PR targets `main` and branch is up to date
- [x] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
- [x] No credentials, tokens, or real patient data committed

### New adapter
- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently

### Schema changes
- [ ] New labels are validated against BioCypher / Biolink expectations
- [ ] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
- [ ] Breaking label, schema, or adapter-arg changes are called out below

### Testing
- [x] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
- [x] Ran additional focused checks relevant to the change
- [ ] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
- [ ] Spot-checked output node / edge labels and counts where relevant


