### PR TITLE
"make run" doesn't run neo4j writer, but metta writer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,10 @@ run-interactive: check-uv
 	if [ "$$INCLUDE_ADAPTERS" = "all" ]; then \
 		INCLUDE_ADAPTERS_FLAG=""; \
 	else \
-		INCLUDE_ADAPTERS_FLAG="--include-adapters $$INCLUDE_ADAPTERS"; \
+		INCLUDE_ADAPTERS_FLAG=""; \
+		for adapter in $$INCLUDE_ADAPTERS; do \
+			INCLUDE_ADAPTERS_FLAG="$$INCLUDE_ADAPTERS_FLAG --include-adapters $$adapter"; \
+		done; \
 	fi; \
 	echo "Including adapters: $$INCLUDE_ADAPTERS"; \
 	echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,15 @@ run-interactive: check-uv
 	WRITER_TYPE=$${WRITER_TYPE:-metta}; \
 	echo "Using writer type: $$WRITER_TYPE"; \
 	echo ""; \
+	read -p "🔌 Enter adapters to include [all]: " INCLUDE_ADAPTERS; \
+	INCLUDE_ADAPTERS=$${INCLUDE_ADAPTERS:-all}; \
+	if [ "$$INCLUDE_ADAPTERS" = "all" ]; then \
+		INCLUDE_ADAPTERS_FLAG=""; \
+	else \
+		INCLUDE_ADAPTERS_FLAG="--include-adapters $$INCLUDE_ADAPTERS"; \
+	fi; \
+	echo "Including adapters: $$INCLUDE_ADAPTERS"; \
+	echo ""; \
 	read -p "📋 Write properties? (yes/no) [yes]: " WRITE_PROPERTIES; \
 	WRITE_PROPERTIES=$${WRITE_PROPERTIES:-yes}; \
 	if [ "$$WRITE_PROPERTIES" = "no" ]; then \
@@ -95,8 +104,8 @@ run-interactive: check-uv
 		--adapters-config "$$ADAPTERS_CONFIG" \
 		--schema-config "$$SCHEMA_CONFIG" \
 		--dbsnp-cache-dir "$$DBSNP_CACHE_DIR" \
-		# --dbsnp-pos "$$DBSNP_POS" \
 		--writer-type "$$WRITER_TYPE" \
+		$$INCLUDE_ADAPTERS_FLAG \
 		$$WRITE_PROPERTIES_FLAG \
 		$$ADD_PROVENANCE_FLAG; \
 	echo "✅ Knowledge graph creation completed! Check $$OUTPUT_DIR for results."


### PR DESCRIPTION
**Description**
#244 

This PR resolves a critical bug in the interactive make run workflow where the selected writer type was being ignored and adds support for selecting multiple specific adapters during knowledge graph generation.

**Key Changes**
1. Fix Writer Type Handling
Bug

- A commented-out line in the Makefile with a trailing backslash was causing bash to treat the subsequent --writer-type argument as a comment. This resulted in the user-selected writer (e.g., neo4j) being ignored and the script defaulting to 
metta.

Fix: Removed the problematic comment, restoring the correct passing of the @WRITER_TYPE variable to the CLI.

2. Interactive Adapter Selection
Feature

- Added a new interactive prompt  Enter adapters to include [all] to the make run command.
- Improved Flag Generation: Updated the Makefile to handle space-separated lists of adapters. It now correctly iterates through the input string and generates individual --include-adapters flags for each name (e.g., adapter1 adapter2 becomes --include-adapters adapter1 --include-adapters adapter2).
