### PR TITLE
Output file names 

### DIFF
--- a/biocypher_metta/metta_writer.py
+++ b/biocypher_metta/metta_writer.py
@@ -21,7 +21,6 @@ class MeTTaWriter(BaseWriter):
         self.label_is_ontology = self._build_label_types_map()
         self.create_type_hierarchy()
         self.excluded_properties = []
-        self.type_hierarchy = self._type_hierarchy()
 
     def _build_label_types_map(self):
         schema = self.bcy._get_ontology_mapping()._extend_schema()
@@ -222,16 +221,23 @@ class MeTTaWriter(BaseWriter):
                     label_to_use = output_label
                 else:
                     label_to_use = label
-                # Resolve source and target types from the schema (same as Neo4j writer)
-                edge_info = self.edge_node_types.get(label, {})
-                source_type = edge_info.get("source", "unknown")
-                target_type = edge_info.get("target", "unknown")
 
-                # Handle list types (take first element, same as Neo4j writer)
-                if isinstance(source_type, list):
-                    source_type = source_type[0]
-                if isinstance(target_type, list):
-                    target_type = target_type[0]
+                # Resolve source and target types
+                if isinstance(source_id, tuple):
+                    source_type = source_id[0]
+                else:
+                    edge_info = self.edge_node_types.get(label, {})
+                    source_type = edge_info.get("source", "unknown")
+                    if isinstance(source_type, list):
+                        source_type = source_type[0]
+
+                if isinstance(target_id, tuple):
+                    target_type = target_id[0]
+                else:
+                    edge_info = self.edge_node_types.get(label, {})
+                    target_type = edge_info.get("target", "unknown")
+                    if isinstance(target_type, list):
+                        target_type = target_type[0]
 
                 file_key = (label, source_type, target_type)
 
@@ -267,35 +273,6 @@ class MeTTaWriter(BaseWriter):
         def_out = f"({self.normalize_text(label)} {id})"
         return self.write_property(def_out, properties)
 
-    def _type_hierarchy(self):
-        # to use Biolink-compatible schema
-        # to not use  ontologies names but the ontologies types if their IDs occur  in edge's source/target
-        return {
-            'biolink:biologicalprocessoractivity': frozenset({'pathway', 'reaction'}),
-            'pathway': frozenset({'pathway'}),
-            'reaction': frozenset({'reaction'}),
-            'biolink:geneorgeneproduct': frozenset({'gene', 'transcript', 'protein'}),
-            'gene': frozenset({'gene'}),
-            'transcript': frozenset({'transcript'}),
-            'protein': frozenset({'protein'}),
-            'snp': frozenset({'snp'}),
-            'phenotype_set': frozenset({'phenotype_set'}),
-                        
-            'ontology_term': frozenset({'ontology_term', 'anatomy', 'developmental_stage', 'cell_type', 'cell_line', 'small_molecule', 'experimental_factor', 'phenotype', 'disease', 'sequence_type', 'tissue', }),
-            'anatomy': frozenset({'anatomy'}),
-            'developmental_stage': frozenset({'developmental_stage'}),
-            'cell_type': frozenset({'cell_type'}),
-            'cell_line': frozenset({'cell_line'}),
-            'experimental_factor': frozenset({'experimental_factor'}),
-            'phenotype': frozenset({'phenotype'}),
-            'disease': frozenset({'disease'}),
-            'sequence_type': frozenset({'sequence_type'}),
-            'small_molecule': frozenset({'small_molecule'}),
-            'biological_process': frozenset({'biological_process'}),
-            'molecular_function': frozenset({'molecular_function'}),
-            'cellular_component': frozenset({'cellular_component'}),
-            'tissue': frozenset({'tissue'}),
-        }
 
     def write_edge(self, edge):
         source_id, target_id, label, properties = edge
@@ -307,14 +284,6 @@ class MeTTaWriter(BaseWriter):
             source_type = source_id[0]
             # Pass label for ontology-aware processing
             source_id_processed = self.preprocess_id(str(source_id[1]), label=source_type)
-            if label in self.edge_node_types:
-                valid_source_types = self.edge_node_types[label]["source"]
-                if isinstance(valid_source_types, list):
-                    if source_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{source_type}' must be one of {valid_source_types}")
-                else:
-                    if source_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{source_type}' must be '{valid_source_types}'")
         else:
             if label in self.edge_node_types:
                 source_type_info = self.edge_node_types[label]["source"]
@@ -331,14 +300,6 @@ class MeTTaWriter(BaseWriter):
             target_type = target_id[0]
             # Pass label for ontology-aware processing
             target_id_processed = self.preprocess_id(str(target_id[1]), label=target_type)
-            if label in self.edge_node_types:
-                valid_target_types = self.edge_node_types[label]["target"]
-                if isinstance(valid_target_types, list):
-                    if target_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{target_type}' must be one of {valid_target_types}")
-                else:
-                    if target_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{target_type}' must be '{valid_target_types}'")
         else:
             if label in self.edge_node_types:
                 target_type_info = self.edge_node_types[label]["target"]

--- a/biocypher_metta/neo4j_csv_writer.py
+++ b/biocypher_metta/neo4j_csv_writer.py
@@ -262,14 +262,6 @@ class Neo4jCSVWriter(BaseWriter):
                 
                 if isinstance(source_id, tuple):
                     source_type = source_id[0]
-                    if isinstance(edge_info["source"], list):
-                        if source_type not in edge_info["source"]:
-                            raise TypeError(f"Type '{source_type}' must be one of {edge_info['source']}")
-                    else:
-                        pass
-                        # if source_type != edge_info["source"]:
-                        # if source_type not in self.type_hierarchy:
-                        #     raise TypeError(f"Type '{source_type}' must be '{edge_info['source']}'")
                     source_id = source_id[1]
                 else:
                     if isinstance(edge_info["source"], list):
@@ -279,14 +271,6 @@ class Neo4jCSVWriter(BaseWriter):
 
                 if isinstance(target_id, tuple):
                     target_type = target_id[0]
-                    if isinstance(edge_info["target"], list):
-                        if target_type not in edge_info["target"]:
-                            raise TypeError(f"Type '{target_type}' must be one of {edge_info['target']}")
-                    else:
-                        pass
-                        # if target_type != edge_info["target"]:
-                        # if target_type not in self.type_hierarchy:
-                        #     raise TypeError(f"Type '{target_type}' must be '{edge_info['target']}'")
                     target_id = target_id[1]
                 else:
                     if isinstance(edge_info["target"], list):

--- a/biocypher_metta/neo4j_csv_writer.py
+++ b/biocypher_metta/neo4j_csv_writer.py
@@ -20,7 +20,6 @@ class Neo4jCSVWriter(BaseWriter):
         })
 
         self.label_is_ontology = self._build_label_types_map()
-        self.type_hierarchy = self._type_hierarchy()
 
         self.create_edge_types()
         self._node_writers = {}
@@ -241,35 +240,6 @@ class Neo4jCSVWriter(BaseWriter):
         return node_freq, self._node_headers
 
 
-    def _type_hierarchy(self):
-        # to use Biolink-compatible schema
-        # to not use  ontologies names but the ontologies types if their IDs occur  in edge's source/target
-        return {
-            'biolink:Biologicalprocessoractivity': frozenset({'pathway', 'reaction'}),
-            'pathway': frozenset({'pathway'}),
-            'reaction': frozenset({'reaction'}),
-            'biolink:geneorgeneproduct': frozenset({'gene', 'transcript', 'protein'}),
-            'gene': frozenset({'gene'}),
-            'transcript': frozenset({'transcript'}),
-            'protein': frozenset({'protein'}),
-            'snp': frozenset({'snp'}),
-            'phenotype_set': frozenset({'phenotype_set'}),
-                        
-            'ontology_term': frozenset({'ontology_term', 'anatomy', 'developmental_stage', 'cell_type', 'cell_line', 'small_molecule', 'experimental_factor', 'phenotype', 'disease', 'sequence_type', 'tissue', }),
-            'anatomy': frozenset({'anatomy'}),
-            'developmental_stage': frozenset({'developmental_stage'}),
-            'cell_type': frozenset({'cell_type'}),
-            'cell_line': frozenset({'cell_line'}),
-            'experimental_factor': frozenset({'experimental_factor'}),
-            'phenotype': frozenset({'phenotype'}),
-            'disease': frozenset({'disease'}),
-            'sequence_type': frozenset({'sequence_type'}),
-            'small_molecule': frozenset({'small_molecule'}),
-            'biological_process': frozenset({'biological_process'}),
-            'molecular_function': frozenset({'molecular_function'}),
-            'cellular_component': frozenset({'cellular_component'}),
-            'tissue': frozenset({'tissue'}),
-        }
 
     def write_edges(self, edges, path_prefix=None, adapter_name=None):
         self.temp_buffer.clear()
@@ -296,9 +266,10 @@ class Neo4jCSVWriter(BaseWriter):
                         if source_type not in edge_info["source"]:
                             raise TypeError(f"Type '{source_type}' must be one of {edge_info['source']}")
                     else:
+                        pass
                         # if source_type != edge_info["source"]:
-                        if source_type not in self.type_hierarchy:
-                            raise TypeError(f"Type '{source_type}' must be '{edge_info['source']}'")
+                        # if source_type not in self.type_hierarchy:
+                        #     raise TypeError(f"Type '{source_type}' must be '{edge_info['source']}'")
                     source_id = source_id[1]
                 else:
                     if isinstance(edge_info["source"], list):
@@ -312,9 +283,10 @@ class Neo4jCSVWriter(BaseWriter):
                         if target_type not in edge_info["target"]:
                             raise TypeError(f"Type '{target_type}' must be one of {edge_info['target']}")
                     else:
+                        pass
                         # if target_type != edge_info["target"]:
-                        if target_type not in self.type_hierarchy:
-                            raise TypeError(f"Type '{target_type}' must be '{edge_info['target']}'")
+                        # if target_type not in self.type_hierarchy:
+                        #     raise TypeError(f"Type '{target_type}' must be '{edge_info['target']}'")
                     target_id = target_id[1]
                 else:
                     if isinstance(edge_info["target"], list):

--- a/biocypher_metta/prolog_writer.py
+++ b/biocypher_metta/prolog_writer.py
@@ -15,7 +15,6 @@ class PrologWriter(BaseWriter):
         self.create_edge_types()
         #self.excluded_properties = ["license", "version", "source"]
         self.excluded_properties = []
-        self.type_hierarchy = self._type_hierarchy()
 
 
     def create_edge_types(self):
@@ -55,35 +54,6 @@ class PrologWriter(BaseWriter):
         return prev_id.lower().strip().translate(str.maketrans({' ': '_', ':': '_'}))
 
 
-    def _type_hierarchy(self):
-        # to use Biolink-compatible schema
-        # to not use  ontologies names but the ontologies types if their IDs occur  in edge's source/target
-        return {
-            'biolink:biologicalprocessoractivity': frozenset({'pathway', 'reaction'}),
-            'pathway': frozenset({'pathway'}),
-            'reaction': frozenset({'reaction'}),
-            'biolink:geneorgeneproduct': frozenset({'gene', 'transcript', 'protein'}),
-            'gene': frozenset({'gene'}),
-            'transcript': frozenset({'transcript'}),
-            'protein': frozenset({'protein'}),
-            'snp': frozenset({'snp'}),
-            'phenotype_set': frozenset({'phenotype_set'}),
-
-            'ontology_term': frozenset({'ontology_term', 'anatomy', 'developmental_stage', 'cell_type', 'cell_line', 'small_molecule', 'experimental_factor', 'phenotype', 'disease', 'sequence_type', 'tissue', }),
-            'anatomy': frozenset({'anatomy'}),
-            'developmental_stage': frozenset({'developmental_stage'}),
-            'cell_type': frozenset({'cell_type'}),
-            'cell_line': frozenset({'cell_line'}),
-            'experimental_factor': frozenset({'experimental_factor'}),
-            'phenotype': frozenset({'phenotype'}),
-            'disease': frozenset({'disease'}),
-            'sequence_type': frozenset({'sequence_type'}),
-            'small_molecule': frozenset({'small_molecule'}),
-            'biological_process': frozenset({'biological_process'}),
-            'molecular_function': frozenset({'molecular_function'}),
-            'cellular_component': frozenset({'cellular_component'}),
-            'tissue': frozenset({'tissue'}),
-        }
 
     def write_nodes(self, nodes, path_prefix=None, create_dir=True):
         if path_prefix is not None:
@@ -153,14 +123,6 @@ class PrologWriter(BaseWriter):
             if source_id_processed is None:
                 logger.warning(f"Edge '{label}': skipping because source ID is None")
                 return []
-            if label in self.edge_node_types:
-                valid_source_types = self.edge_node_types[label]["source"]
-                if isinstance(valid_source_types, list):
-                    if source_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{source_type}' must be one of {valid_source_types}")
-                else:
-                    if source_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{source_type}' must be '{valid_source_types}'")
 
             # if label in self.edge_node_types:
             #     valid_source_types = self.edge_node_types[label]["source"]
@@ -190,14 +152,6 @@ class PrologWriter(BaseWriter):
             if target_id_processed is None:
                 logger.warning(f"Edge '{label}': skipping because target ID is None")
                 return []
-            if label in self.edge_node_types:
-                valid_source_types = self.edge_node_types[label]["source"]
-                if isinstance(valid_source_types, list):
-                    if source_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{source_type}' must be one of {valid_source_types}")
-                else:
-                    if source_type not in self.type_hierarchy:
-                        raise TypeError(f"Type '{source_type}' must be '{valid_source_types}'")
 
             # if label in self.edge_node_types:
             #     valid_target_types = self.edge_node_types[label]["target"]


### PR DESCRIPTION
Summary

#246 

Standardized **MeTTaWriter** output filenames to use specific biological types instead of **Biolink supertypes** and removed redundant legacy type-checking code across writers.

Changes

Dynamic File Naming: Refactored **MeTTaWriter.write_edges** to resolve source and target types directly from edge data, ensuring filenames like edges_protein_enables_reaction.metta accurately reflect their content.

Code Cleanup: Removed the unused, hardcoded **_type_hierarchy** dictionary and redundant TypeError checks from MeTTaWriter, Neo4jCSVWriter, and PrologWriter.

Improved Segmentation: Ensured that edges are correctly segmented into separate files based on effective types, facilitating easier integration with downstream tools.