### PR TITLE
fix: data quality and property clean-up across adapters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ help:
 	@echo "  make run-sample                    - Run with sample data (default: metta writer)"
 	@echo "  make run-sample WRITER_TYPE=prolog - Run with sample data using prolog writer"
 	@echo "  make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env"
+	@echo "  make run-sample INCLUDE_TAXON_ID=no   - Run without taxon_id in output (single-species KG)"
 
 # Check if UV is installed, install via pip if not
 check-uv:
@@ -123,6 +124,16 @@ run-interactive: check-uv
 		echo "Provenance will NOT be added"; \
 	fi; \
 	echo ""; \
+	read -p "🧬 Include taxon_id in output? (yes/no) [yes]: " INCLUDE_TAXON_ID; \
+	INCLUDE_TAXON_ID=$${INCLUDE_TAXON_ID:-yes}; \
+	if [ "$$INCLUDE_TAXON_ID" = "no" ]; then \
+		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
+		echo "taxon_id will NOT be written to output"; \
+	else \
+		INCLUDE_TAXON_ID_FLAG=""; \
+		echo "taxon_id will be written to output"; \
+	fi; \
+	echo ""; \
 	echo "🎯 Starting knowledge graph creation..."; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
@@ -134,7 +145,8 @@ run-interactive: check-uv
 		--writer-type "$$WRITER_TYPE" \
 		$$INCLUDE_ADAPTERS_FLAG \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG && \
+		$$ADD_PROVENANCE_FLAG \
+		$$INCLUDE_TAXON_ID_FLAG && \
 	echo "✅ Knowledge graph creation completed! Check $$OUTPUT_DIR for results."
 
 run-direct: check-uv
@@ -155,6 +167,11 @@ run-direct: check-uv
 	else \
 		ADD_PROVENANCE_FLAG="--no-add-provenance"; \
 	fi; \
+	if [ "$(INCLUDE_TAXON_ID)" = "false" ] || [ "$(INCLUDE_TAXON_ID)" = "no" ]; then \
+		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
+	else \
+		INCLUDE_TAXON_ID_FLAG=""; \
+	fi; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
 		--output-dir $(OUTPUT_DIR) \
@@ -164,7 +181,8 @@ run-direct: check-uv
 		$(if $(DBSNP_VARIANT),--dbsnp-variant $(DBSNP_VARIANT),) \
 		$(if $(WRITER_TYPE),--writer-type $(WRITER_TYPE),--writer-type metta) \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG
+		$$ADD_PROVENANCE_FLAG \
+		$$INCLUDE_TAXON_ID_FLAG
 
 # Run with sample configuration and data (with optional writer type)
 run-sample: check-uv
@@ -184,6 +202,13 @@ run-sample: check-uv
 		ADD_PROVENANCE_FLAG="--no-add-provenance"; \
 		echo "Provenance: disabled"; \
 	fi; \
+	if [ "$(INCLUDE_TAXON_ID)" = "false" ] || [ "$(INCLUDE_TAXON_ID)" = "no" ]; then \
+		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
+		echo "taxon_id: disabled"; \
+	else \
+		INCLUDE_TAXON_ID_FLAG=""; \
+		echo "taxon_id: enabled"; \
+	fi; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
 		--output-dir ./output \
@@ -192,7 +217,8 @@ run-sample: check-uv
 		--schema-config ./config/hsa/hsa_schema_config.yaml \
 		--writer-type $(if $(WRITER_TYPE),$(WRITER_TYPE),metta) \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG
+		$$ADD_PROVENANCE_FLAG \
+		$$INCLUDE_TAXON_ID_FLAG
 	@echo "✅ Sample run completed! Check the ./output directory for results."
 # ─── Neo4j deployment targets ────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will guide you through all parameters step by step with sensible defaults.
 
 #### Option 2: Quick Sample Run
 ```bash
-make run-sample WRITER_TYPE=<metta,neo4j,prolog>
+make run-sample WRITER_TYPE=<metta,neo4j,prolog> [INCLUDE_TAXON_ID=no]
 ```
 
 #### Option 3: Direct Run with Parameters
@@ -36,7 +36,8 @@ make run-direct OUTPUT_DIR=./output \
                DBSNP_POS=./pos.txt \
                WRITER_TYPE=metta \
                WRITE_PROPERTIES=no \
-               ADD_PROVENANCE=no
+               ADD_PROVENANCE=no \
+               INCLUDE_TAXON_ID=no
 ```
 ### Interactive Mode Example
 When you run `make run`, you'll see:
@@ -50,6 +51,7 @@ When you run `make run`, you'll see:
 📝 Enter writer type (metta/prolog/neo4j) [metta]: 
 📋 Write properties? (yes/no) [no]: 
 🔗 Add provenance? (yes/no) [no]: 
+🧬 Include taxon_id in output? (yes/no) [yes]: 
 ```
 
 ### Available Make Commands

--- a/biocypher_metta/adapters/alliance_gene_disease_adapter.py
+++ b/biocypher_metta/adapters/alliance_gene_disease_adapter.py
@@ -130,21 +130,19 @@ class AllianceGeneDiseaseAdapter(Adapter):
                 _props = {}
                 
                 if self.write_properties:
+                    date_fmt = f"{date[:4]}-{date[4:6]}-{date[6:]}" if len(date) == 8 else date
                     _props = {
                         "taxon_id": int(taxon),
-                        "species_name": species_name,
-                        "gene_symbol": db_object_symbol,
-                        "disease_name": do_term_name,
-                        "evidence_code": evidence_code,
+                        "evidence_code": evidence_code.replace('ECO:', 'ECO_'),
                         "evidence_code_name": evidence_code_name,
                         "reference": reference,
-                        "date": date,
-                        "source": source,
+                        "date": date_fmt,
+                        "data_source": source,
                         "with_ortholog": with_ortholog if with_ortholog else None,
                         "inferred_from_id": inferred_from_id if inferred_from_id else None,
                         "inferred_from_symbol": inferred_from_symbol if inferred_from_symbol else None,
                     }
-                        
+
                 if self.add_provenance:
                     _props["source"] = self.source
                     _props["source_url"] = self.source_url

--- a/biocypher_metta/adapters/bgee_adapter.py
+++ b/biocypher_metta/adapters/bgee_adapter.py
@@ -96,7 +96,7 @@ class BgeeAdapter(Adapter):
                     yield source_id, ('developmental_stage', dev_stage_id), self.label, dev_props
 
         except OSError as e:
-            raise RuntimeError(f"Error opening the bgee file: {e}")
+            raise RuntimeError(f"Error opening the bgee file '{self.filepath}': {e}") from e
 
     def split_by_intersection(self, s: str) -> list[str]:
         """

--- a/biocypher_metta/adapters/bgee_adapter.py
+++ b/biocypher_metta/adapters/bgee_adapter.py
@@ -91,11 +91,12 @@ class BgeeAdapter(Adapter):
                 node_type = 'cell_type' if target_id.startswith('CL_') else 'anatomy'
                 yield source_id, (node_type, target_id), self.label, edge_data["props"]
                 dev_stage_id = edge_data['props'].get('developmental_stage')
-                dev_props = {k: v for k, v in edge_data["props"].items() if k != 'developmental_stage'}
-                yield source_id, ('developmental_stage', dev_stage_id), self.label, dev_props
+                if dev_stage_id:
+                    dev_props = {k: v for k, v in edge_data["props"].items() if k != 'developmental_stage'}
+                    yield source_id, ('developmental_stage', dev_stage_id), self.label, dev_props
 
         except OSError as e:
-            raise RuntimeError(f"Error opening the file: {https://www.bgee.org/download/gene-expression-calls?id=9606}")
+            raise RuntimeError(f"Error opening the bgee file: {e}")
 
     def split_by_intersection(self, s: str) -> list[str]:
         """

--- a/biocypher_metta/adapters/bgee_adapter.py
+++ b/biocypher_metta/adapters/bgee_adapter.py
@@ -88,8 +88,11 @@ class BgeeAdapter(Adapter):
 
             # Yield deduplicated edges
             for (source_id, target_id), edge_data in edge_dict.items():
-                yield source_id, ('anatomy', target_id), self.label, edge_data["props"]
-                yield source_id, ('developmental_stage', edge_data['props'].get('developmental_stage')), self.label, edge_data["props"]
+                node_type = 'cell_type' if target_id.startswith('CL_') else 'anatomy'
+                yield source_id, (node_type, target_id), self.label, edge_data["props"]
+                dev_stage_id = edge_data['props'].get('developmental_stage')
+                dev_props = {k: v for k, v in edge_data["props"].items() if k != 'developmental_stage'}
+                yield source_id, ('developmental_stage', dev_stage_id), self.label, dev_props
 
         except OSError as e:
             raise RuntimeError(f"Error opening the file: {https://www.bgee.org/download/gene-expression-calls?id=9606}")

--- a/biocypher_metta/adapters/bgee_adapter.py
+++ b/biocypher_metta/adapters/bgee_adapter.py
@@ -88,8 +88,7 @@ class BgeeAdapter(Adapter):
 
             # Yield deduplicated edges
             for (source_id, target_id), edge_data in edge_dict.items():
-                node_type = 'cell_type' if target_id.startswith('CL_') else 'anatomy'
-                yield source_id, (node_type, target_id), self.label, edge_data["props"]
+                yield source_id, ('anatomy', target_id), self.label, edge_data["props"]
                 dev_stage_id = edge_data['props'].get('developmental_stage')
                 if dev_stage_id:
                     dev_props = {k: v for k, v in edge_data["props"].items() if k != 'developmental_stage'}

--- a/biocypher_metta/adapters/brenda_tissue_ontology_adapter.py
+++ b/biocypher_metta/adapters/brenda_tissue_ontology_adapter.py
@@ -110,7 +110,7 @@ class BrendaTissueOntologyAdapter(OntologyAdapter):
 
                     props = {}
                     if self.write_properties:
-                        props['rel_type'] = 'part_of'
+                        # props['rel_type'] = 'part_of'
                         if self.add_provenance:
                             props['source'] = self.source
                             props['source_url'] = self.source_url

--- a/biocypher_metta/adapters/cell_line_ontology_adapter.py
+++ b/biocypher_metta/adapters/cell_line_ontology_adapter.py
@@ -52,6 +52,9 @@ class CellLineOntologyAdapter(OntologyAdapter):
     def get_ontology_source(self):
         return 'Cell Line Ontology', 'http://purl.obolibrary.org/obo/clo.owl'
 
+    def should_include_node(self, node):
+        return self.is_term_of_type(node, 'primary')
+
     def get_nodes(self):
         for term_id, label, props in super().get_nodes():
             if self.write_properties and self.add_description and 'description' in props:

--- a/biocypher_metta/adapters/cell_line_ontology_adapter.py
+++ b/biocypher_metta/adapters/cell_line_ontology_adapter.py
@@ -52,13 +52,11 @@ class CellLineOntologyAdapter(OntologyAdapter):
     def get_ontology_source(self):
         return 'Cell Line Ontology', 'http://purl.obolibrary.org/obo/clo.owl'
 
-    def should_include_node(self, node):
-        return self.is_term_of_type(node, 'primary')
-
     def get_nodes(self):
         for term_id, label, props in super().get_nodes():
             if self.write_properties and self.add_description and 'description' in props:
                 props['description'] = props['description'].replace('"', '')
+
             yield term_id, label, props
 
     def get_uri_prefixes(self):
@@ -107,7 +105,7 @@ class CellLineOntologyAdapter(OntologyAdapter):
 
             props = {}
             if self.write_properties:
-                props['rel_type'] = 'subclass'
+                # props['rel_type'] = 'subclass'
                 if self.add_provenance:
                     props['source'] = self.source
                     props['source_url'] = self.source_url
@@ -146,7 +144,7 @@ class CellLineOntologyAdapter(OntologyAdapter):
 
             props = {}
             if self.write_properties:
-                props['rel_type'] = 'subclass'
+                # props['rel_type'] = 'subclass'
                 if self.add_provenance:
                     props['source'] = self.source
                     props['source_url'] = self.source_url

--- a/biocypher_metta/adapters/cell_ontology_adapter.py
+++ b/biocypher_metta/adapters/cell_ontology_adapter.py
@@ -41,6 +41,9 @@ class CellOntologyAdapter(OntologyAdapter):
         
         return super().should_include_edge(from_node, to_node, predicate, edge_type)
 
+    def should_include_node(self, node):
+        return self.is_term_of_type(node, 'primary')
+
     def get_nodes(self):
         self.update_graph()
         self.cache_node_properties()

--- a/biocypher_metta/adapters/cell_ontology_adapter.py
+++ b/biocypher_metta/adapters/cell_ontology_adapter.py
@@ -41,9 +41,6 @@ class CellOntologyAdapter(OntologyAdapter):
         
         return super().should_include_edge(from_node, to_node, predicate, edge_type)
 
-    def should_include_node(self, node):
-        return self.is_term_of_type(node, 'primary')
-
     def get_nodes(self):
         self.update_graph()
         self.cache_node_properties()
@@ -152,7 +149,7 @@ class CellOntologyAdapter(OntologyAdapter):
                     for bto_key in bto_targets:
                         props = {}
                         if self.write_properties:
-                            props['rel_type'] = self.predicate_name(predicate)
+                            # props['rel_type'] = self.predicate_name(predicate)
                             if self.add_provenance:
                                 props['source'] = self.source
                                 props['source_url'] = self.source_url
@@ -168,7 +165,7 @@ class CellOntologyAdapter(OntologyAdapter):
 
                 props = {}
                 if self.write_properties:
-                    props['rel_type'] = self.predicate_name(predicate)
+                    # props['rel_type'] = self.predicate_name(predicate)
                     if self.add_provenance:
                         props['source'] = self.source
                         props['source_url'] = self.source_url

--- a/biocypher_metta/adapters/gaf_adapter.py
+++ b/biocypher_metta/adapters/gaf_adapter.py
@@ -183,10 +183,9 @@ class GAFAdapter(Adapter):
                     # if self.taxon_id != int(annotation['Taxon_ID'][0].split(':')[-1]):
                     #     raise ValueError(f'GAFAdapter::Invalid taxon. taxon_id parameter ({self.taxon_id}) different from data taxon id ({annotation['Taxon_ID'][0].split(':')[-1]}) ')
                     db_refs = annotation['DB:Reference']
-                    if isinstance(db_refs, list):
-                        db_refs = [r.replace(':', '_') for r in db_refs]
-                    else:
-                        db_refs = db_refs.replace(':', '_')
+                    if not isinstance(db_refs, list):
+                        db_refs = [db_refs]
+                    db_refs = [r.replace(':', '_') for r in db_refs]
                     props = {
                         'db_reference': db_refs,
                         'evidence': annotation['Evidence'],

--- a/biocypher_metta/adapters/gaf_adapter.py
+++ b/biocypher_metta/adapters/gaf_adapter.py
@@ -182,9 +182,13 @@ class GAFAdapter(Adapter):
                 if self.write_properties:
                     # if self.taxon_id != int(annotation['Taxon_ID'][0].split(':')[-1]):
                     #     raise ValueError(f'GAFAdapter::Invalid taxon. taxon_id parameter ({self.taxon_id}) different from data taxon id ({annotation['Taxon_ID'][0].split(':')[-1]}) ')
+                    db_refs = annotation['DB:Reference']
+                    if isinstance(db_refs, list):
+                        db_refs = [r.replace(':', '_') for r in db_refs]
+                    else:
+                        db_refs = db_refs.replace(':', '_')
                     props = {
-                        'qualifier': qualifier,
-                        'db_reference': annotation['DB:Reference'],
+                        'db_reference': db_refs,
                         'evidence': annotation['Evidence'],
                         "taxon_id": f'{self.taxon_id}'
                     }

--- a/biocypher_metta/adapters/gencode_exon_adapter.py
+++ b/biocypher_metta/adapters/gencode_exon_adapter.py
@@ -139,13 +139,10 @@ class GencodeExonAdapter(Adapter):
                         if check_genomic_location(self.chr, self.start, self.end, chr, start, end):
                             if self.write_properties:
                                 props = {
-                                    'gene_id': gene_id,
-                                    'transcript_id': transcript_id,
                                     'chr': chr,
                                     'start': start,
                                     'end': end,
                                     'exon_number': int(info.get('exon_number', -1)),
-                                    'exon_id': f"{info['exon_id'].split('.')[0].upper()}", #f"{GencodeExonAdapter.CURIE_PREFIX[self.taxon_id]}:{info['exon_id'].split('.')[0].upper()}",
                                 }
                                 
                                 if self.add_provenance:

--- a/biocypher_metta/adapters/gencode_transcript_adapter.py
+++ b/biocypher_metta/adapters/gencode_transcript_adapter.py
@@ -1,7 +1,6 @@
 from biocypher_metta.adapters import Adapter
 import gzip
 from biocypher_metta.adapters.helpers import check_genomic_location
-from biocypher_metta.processors import HGNCProcessor
 
 # Human data:
 # https://www.gencodegenes.org/human/
@@ -95,9 +94,6 @@ class GencodeTranscriptAdapter(Adapter):
         self.version = 'v44'
         self.source_url = 'https://www.gencodegenes.org/'
 
-        self.hgnc_processor = HGNCProcessor()
-        self.hgnc_processor.load_or_update()
-
         super(GencodeTranscriptAdapter, self).__init__(write_properties, add_provenance)
 
     def parse_info_metadata(self, info):
@@ -152,13 +148,6 @@ class GencodeTranscriptAdapter(Adapter):
                 if not self.should_keep_transcript(info.get('transcript_type', ''), info.get('tags', [])):
                     continue
 
-                gene_name = info.get('gene_name')
-                if not gene_name:
-                    # print(f"No gene name found for transcript {info['transcript_id']}. Record: {info}.\nGene name will be 'unkown'")
-                    result = {'status': 'unknown', 'original': 'unknown', 'current': 'unknown'}
-                else:
-                    result = self.hgnc_processor.process_identifier(gene_name)
-                
                 #CURIE ID Formatting
                 transcript_key = f"{GencodeTranscriptAdapter.CURIE_PREFIX[self.taxon_id]}:{info['transcript_id'].split('.')[0]}"
                 if info['transcript_id'].endswith('_PAR_Y'):
@@ -180,11 +169,8 @@ class GencodeTranscriptAdapter(Adapter):
                                 props = {
                                     'transcript_id': info['transcript_id'].upper(),
                                     'transcript_name': info['transcript_name'],
-                                    'transcript_type': transcript_type_val if transcript_type_val is not None else info['transcript_biotype'],                                
-                                    'gene_name': 'unknown' if result['status'] == 'unknown' or result['status'] == 'ensembl_only' else result['current'],
+                                    'transcript_type': transcript_type_val if transcript_type_val is not None else info['transcript_biotype'],
                                 }
-                                if result['status'] == 'updated':
-                                    props['old_gene_name'] = result['original']
 
                                 if self.add_provenance:
                                     props['source'] = self.source

--- a/biocypher_metta/adapters/gene_ontology_adapter.py
+++ b/biocypher_metta/adapters/gene_ontology_adapter.py
@@ -200,7 +200,7 @@ class GeneOntologyAdapter(OntologyAdapter):
 
                     props = {}
                     if self.write_properties:
-                        props['rel_type'] = predicate_name
+                        # props['rel_type'] = predicate_name
                         if self.add_provenance:
                             props['source'] = self.source
                             props['source_url'] = self.source_url

--- a/biocypher_metta/adapters/hsa/catlas_abc_score_adapter.py
+++ b/biocypher_metta/adapters/hsa/catlas_abc_score_adapter.py
@@ -32,6 +32,10 @@ _MASTER_TSV_URL = (
 #   hgnc_mapping.pkl (gzipped)      — {symbol_to_ensembl: {symbol: ENSG_ID, ...}, ...}
 #   catlas_abc_cell_ontology_map.pkl — {abc_stem: "CL:XXXXXXX" | "UBERON:XXXXXXX"}
 #                                     produced by scripts/create_catlas_abc_cell_ontology_map.py
+#                                     Ontology IDs sourced from Cell_ontology.tsv (CATLAS).
+#                                     ABC's abbreviated names (e.g. "Vasc Sm Muscle 1") were
+#                                     matched to Cell_ontology.tsv entries using claude-opus-4-6;
+#                                     IDs were taken directly from Cell_ontology.tsv unchanged.
 #
 # Edge label is chosen from the cCRE class:
 #   enhancer cCRE  →  enhancer_activity_by_contact  (enhancer → gene)

--- a/biocypher_metta/adapters/hsa/dgv_variant_adapter.py
+++ b/biocypher_metta/adapters/hsa/dgv_variant_adapter.py
@@ -53,7 +53,7 @@ class DGVVariantAdapter(Adapter):
                     props['start'] = start
                     props['end'] = end
                     props['variant_type'] = variant_type
-                    props['evidence'] = 'pubmed:' + pubmedid
+                    props['evidence'] = 'PMID_' + pubmedid
 
                     if self.add_provenance:
                         props['source'] = self.source

--- a/biocypher_metta/adapters/hsa/human_phenotype_ontology_adapter.py
+++ b/biocypher_metta/adapters/hsa/human_phenotype_ontology_adapter.py
@@ -22,6 +22,9 @@ class HumanPhenotypeOntologyAdapter(OntologyAdapter):
             'chebi': 'http://purl.obolibrary.org/obo/CHEBI_',
         }
 
+    def should_include_node(self, node):
+        return self.is_term_of_type(node, 'primary')
+
     def get_nodes(self):
         for term_id, label, props in super().get_nodes():
             if self.write_properties and self.add_description and 'description' in props:

--- a/biocypher_metta/adapters/hsa/human_phenotype_ontology_adapter.py
+++ b/biocypher_metta/adapters/hsa/human_phenotype_ontology_adapter.py
@@ -22,9 +22,6 @@ class HumanPhenotypeOntologyAdapter(OntologyAdapter):
             'chebi': 'http://purl.obolibrary.org/obo/CHEBI_',
         }
 
-    def should_include_node(self, node):
-        return self.is_term_of_type(node, 'primary')
-
     def get_nodes(self):
         for term_id, label, props in super().get_nodes():
             if self.write_properties and self.add_description and 'description' in props:

--- a/biocypher_metta/adapters/ontologies_adapter.py
+++ b/biocypher_metta/adapters/ontologies_adapter.py
@@ -588,7 +588,6 @@ class OntologyAdapter(Adapter):
                         continue  
                     props = {}
                     if self.write_properties:
-                        props['rel_type'] = predicate_name
                         if self.add_provenance:
                             props['source'] = self.source
                             props['source_url'] = self.source_url

--- a/biocypher_metta/adapters/reactome_adapter.py
+++ b/biocypher_metta/adapters/reactome_adapter.py
@@ -47,26 +47,28 @@ class ReactomeAdapter(Adapter):
                         if species == 'Homo sapiens':
                             props = {}
                             if self.write_properties:
-                                props['pathway_name'] = name                             
+                                props['pathway_name'] = name
+                                props['pathway_url'] = f"https://reactome.org/content/detail/{id}"
                                 pubmed_id = self.pubmed_map.get(id, None)
                                 if pubmed_id is not None:
                                     pubmed_url = f"https://pubmed.ncbi.nlm.nih.gov/{self.pubmed_map[id]}"
                                     props['evidence'] = pubmed_url
-                                
+
                                 if self.add_provenance:
                                     props['source'] = self.source
                                     props['source_url'] = self.source_url
                                     props['taxon_id'] = f'{self.taxon_id}'
                             yield pathway_id, self.label, props
-                    elif self.taxon_id == 7227:           
+                    elif self.taxon_id == 7227:
                         if species == 'Drosophila melanogaster':
                             props = {}
                             if self.write_properties:
-                                props['pathway_name'] = name                        
+                                props['pathway_name'] = name
+                                props['pathway_url'] = f"https://reactome.org/content/detail/{id}"
                                 pubmed_id = self.pubmed_map.get(id, None)
                                 if pubmed_id is not None:
                                     pubmed_url = f"https://pubmed.ncbi.nlm.nih.gov/{self.pubmed_map[id]}"
-                                    props['evidence'] = pubmed_url                                
+                                    props['evidence'] = pubmed_url
                                 if self.add_provenance:
                                     props['source'] = self.source
                                     props['source_url'] = self.source_url
@@ -92,7 +94,7 @@ class ReactomeAdapter(Adapter):
         with open(self.pubmed_map_path, "r") as f:
             reader = csv.reader(f, delimiter="\t")
             for row in reader:
-                pathway_id, pubmed_id = row[0], row[0]
+                pathway_id, pubmed_id = row[0], row[1]
                 self.pubmed_map[pathway_id] = pubmed_id
 
 

--- a/biocypher_metta/adapters/reactome_edges_adapter.py
+++ b/biocypher_metta/adapters/reactome_edges_adapter.py
@@ -127,7 +127,6 @@ class ReactomeEdgesAdapter(Adapter):
                 if self.label in ['genes_pathways', 'gene_or_gene_product_reaction', 'small_molecule_to_pathway', 'small_molecule_to_reaction']: 
                     entity_id, pathway_id = data[0].strip(), data[1].strip()
                     organism_pathway_prefix = pathway_id[:5]  # e.g., 'R-DME', 'R-HSA'
-                    an_url = data[2].replace("PathwayBrowser/#", "content/detail")                    
                     pathway_id = f'{pathway_id}'
                     if organism_pathway_prefix in organism_taxon_map or organism_pathway_prefix.startswith('R-NUL'):
                         # taxon = organism_taxon_map[organism_pathway_prefix]

--- a/biocypher_metta/adapters/reactome_edges_adapter.py
+++ b/biocypher_metta/adapters/reactome_edges_adapter.py
@@ -132,10 +132,6 @@ class ReactomeEdgesAdapter(Adapter):
                     if organism_pathway_prefix in organism_taxon_map or organism_pathway_prefix.startswith('R-NUL'):
                         # taxon = organism_taxon_map[organism_pathway_prefix]
                         props = base_props.copy()
-                        if self.label == 'genes_pathways':
-                            props['pathway_url'] = an_url
-                        else:
-                            props['reaction_url'] = an_url                        
                         props['evidence'] = data[4]
                         props['taxon_id'] = f'{self.taxon_id}'
 

--- a/biocypher_metta/adapters/reactome_pathway_go_adapter.py
+++ b/biocypher_metta/adapters/reactome_pathway_go_adapter.py
@@ -52,7 +52,7 @@ class ReactomePathwayGOAdapter(Adapter):
                 if len(parts) < 3:
                     continue
                     
-                pathway_id, pathway_name, go_term = parts[0], parts[1], parts[2]
+                pathway_id, go_term = parts[0], parts[2]
                 
                 # Clean and standardize GO term
                 clean_go_term = go_term.replace('GO:', '').replace('go:', '')
@@ -73,10 +73,8 @@ class ReactomePathwayGOAdapter(Adapter):
                     continue
                 
                 # Prepare base properties
-                properties = {
-                    'pathway_name': pathway_name,
-                }
-                
+                properties = {}
+
                 if self.add_provenance:  
                     properties.update({
                         'source': self.source,

--- a/biocypher_metta/adapters/reactome_pathway_go_adapter.py
+++ b/biocypher_metta/adapters/reactome_pathway_go_adapter.py
@@ -75,8 +75,6 @@ class ReactomePathwayGOAdapter(Adapter):
                 # Prepare base properties
                 properties = {
                     'pathway_name': pathway_name,
-                    'go_term_id': full_go_term,
-                    'subontology': go_type, 
                 }
                 
                 if self.add_provenance:  

--- a/biocypher_metta/adapters/tflink_adapter.py
+++ b/biocypher_metta/adapters/tflink_adapter.py
@@ -91,7 +91,7 @@ class TFLinkAdapter(Adapter):
                     continue
 
                 pubmed_ids_str = row[TFLinkAdapter.INDEX['PubmedID']]
-                pubmed_ids = [f"pubmed:{i}" for i in pubmed_ids_str.split(";")]
+                pubmed_ids = [f"PMID_{i.strip()}" for i in pubmed_ids_str.split(";")]
                 sources = row[TFLinkAdapter.INDEX['Source.database']].split(";")
                 small_scale_evidence = row[TFLinkAdapter.INDEX['Small-scale.evidence']]
                 if small_scale_evidence == "Yes":

--- a/biocypher_metta/adapters/tflink_adapter.py
+++ b/biocypher_metta/adapters/tflink_adapter.py
@@ -91,7 +91,7 @@ class TFLinkAdapter(Adapter):
                     continue
 
                 pubmed_ids_str = row[TFLinkAdapter.INDEX['PubmedID']]
-                pubmed_ids = [f"PMID_{i.strip()}" for i in pubmed_ids_str.split(";")]
+                pubmed_ids = [f"PMID_{i.strip()}" for i in pubmed_ids_str.split(";") if i.strip()]
                 sources = row[TFLinkAdapter.INDEX['Source.database']].split(";")
                 small_scale_evidence = row[TFLinkAdapter.INDEX['Small-scale.evidence']]
                 if small_scale_evidence == "Yes":

--- a/biocypher_metta/adapters/uniprot_protein_adapter.py
+++ b/biocypher_metta/adapters/uniprot_protein_adapter.py
@@ -206,6 +206,7 @@ class UniprotProteinAdapter(Adapter):
                                                 
                                                 props = {}
                                                 if self.write_properties:
+                                                    props['dbxref'] = 'ChEBI'
                                                     if evidence_codes:
                                                         props['evidence'] = evidence_codes
                                                     if self.add_provenance:

--- a/biocypher_metta/adapters/uniprot_protein_adapter.py
+++ b/biocypher_metta/adapters/uniprot_protein_adapter.py
@@ -206,7 +206,6 @@ class UniprotProteinAdapter(Adapter):
                                                 
                                                 props = {}
                                                 if self.write_properties:
-                                                    props['dbxref'] = 'ChEBI'
                                                     if evidence_codes:
                                                         props['evidence'] = evidence_codes
                                                     if self.add_provenance:

--- a/biocypher_metta/adapters/uniprot_protein_adapter.py
+++ b/biocypher_metta/adapters/uniprot_protein_adapter.py
@@ -50,6 +50,9 @@ class UniprotProteinAdapter(Adapter):
                     if item != '-':
                         id = database_name + ':' + item.split('. ')[0]
                         dbxrefs.append(id)
+            elif database_name == 'GO':
+                # cross_reference[1] is already in "GO:XXXXXXX" format
+                dbxrefs.append(cross_reference[1])
             else:
                 id = cross_reference[0].upper() + ':' + cross_reference[1]
                 dbxrefs.append(id)
@@ -263,10 +266,7 @@ class UniprotProteinAdapter(Adapter):
                     elif self.dbxref == "STRING":
                         syn = "STRING:" + syn.split('.')[1]
                     elif self.dbxref == "GO":
-                        prefix, id_local = syn.split(':',1)
-                        go_id = f"GO:{id_local}"
-                        syn = id_local
-
+                        go_id = syn  # syn is already "GO:XXXXXXX"
                         subontology = self.go_subontology_mapping.get(go_id, None)
                         if subontology is None or subontology not in self.label:
                             continue

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -1951,7 +1951,7 @@ string_coexpression:
     cls: StringCoexpressionAdapter
     args:
       filepath: ./samples/hsa/string/9606.protein.links.detailed.v12.0.txt.gz
-      label: coexpressed_with
+      label: protein_coexpressed_with
       coexpression_threshold: 400
       taxon_id: 9606
   outdir: string/coexpression

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -606,18 +606,22 @@ gtex_expression:
   nodes: False
   edges: True
 
-hocomoco:
-  adapter:
-    module: biocypher_metta.adapters.hocomoco_motif_adapter
-    cls: HoCoMoCoMotifAdapter
-    args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/hocomoco/pwm
-      annotation_file: /mnt/hdd_1/abdu/biocypher_data/hocomoco/HOCOMOCOv11_core_annotation_HUMAN_mono.tsv
-      label: motif
-      taxon_id: 9606
-  outdir: hocomoco
-  nodes: True
-  edges: False
+# ========================================================================
+# It is commented out because it is an orphane node with no connection.
+# ========================================================================
+
+# hocomoco:
+#   adapter:
+#     module: biocypher_metta.adapters.hocomoco_motif_adapter
+#     cls: HoCoMoCoMotifAdapter
+#     args:
+#       filepath: /mnt/hdd_1/abdu/biocypher_data/hocomoco/pwm
+#       annotation_file: /mnt/hdd_1/abdu/biocypher_data/hocomoco/HOCOMOCOv11_core_annotation_HUMAN_mono.tsv
+#       label: motif
+#       taxon_id: 9606
+#   outdir: hocomoco
+#   nodes: True
+#   edges: False
 
 roadmap_chromatin_state:
   adapter:

--- a/config/hsa/hsa_adapters_config_sample.yaml
+++ b/config/hsa/hsa_adapters_config_sample.yaml
@@ -1330,7 +1330,7 @@ polyphen2:
     cls: PolyPhen2Adapter
     args:
       filepath: ./samples/hsa/polyPhen2_sample.bed.gz
-      label: polyphen2_variant      
+      label: snp
   outdir: polyphen-2
   nodes: True
   edges: False

--- a/config/hsa/hsa_adapters_config_sample.yaml
+++ b/config/hsa/hsa_adapters_config_sample.yaml
@@ -1910,7 +1910,7 @@ string_coexpression:
     cls: StringCoexpressionAdapter
     args:
       filepath: ./samples/hsa/string/9606.protein.links.detailed.v12.0.txt.gz
-      label: coexpressed_with
+      label: protein_coexpressed_with
       coexpression_threshold: 400
       taxon_id: 9606
   outdir: string/coexpression

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -293,7 +293,17 @@ snp:
       type: str
     caf_ref: 
       type: str
-    caf_alt: 
+    caf_alt:
+      type: str
+    polyphen2_humdiv_score:
+      type: float
+      biolink: has_quantitative_value
+    polyphen2_humdiv_prediction:
+      type: str
+    polyphen2_humvar_score:
+      type: float
+      biolink: has_quantitative_value
+    polyphen2_humvar_prediction:
       type: str
   description: >-
     A single nucleotide polymorphism (SNP) is a variation in a single nucleotide that occurs at a specific position in the genome
@@ -342,33 +352,6 @@ sequence variant:
       type: float
     phred_score: 
       type: float
-
-polyphen2 variant:
-  represented_as: node
-  is_a: genomic variant
-  mixins: [biolink:SequenceVariant]
-  biolink_category: "biolink:SequenceVariant"
-  inherit_properties: true
-  input_label: polyphen2_variant
-  description: >-
-    A variant with PolyPhen-2 predictions for the impact of amino acid substitutions on protein structure and function
-  kgx_properties:
-    category: "biolink:SequenceVariant"
-  properties:
-    ref: 
-      type: str
-    alt: 
-      type: str
-    polyphen2_humdiv_score: 
-      type: float
-      biolink: has_quantitative_value
-    polyphen2_humdiv_prediction: 
-      type: str
-    polyphen2_humvar_score: 
-      type: float
-      biolink: has_quantitative_value
-    polyphen2_humvar_prediction: 
-      type: str
 
 # ---
 # non-coding elements

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -138,13 +138,15 @@ ontology term:
     description: 
       type: str
       biolink: description
-    synonym: 
+    synonym:
       type: str[]
       biolink: synonym
-    source: 
+    alternative_ids:
+      type: str[]
+    source:
       type: str
       biolink: knowledge_source
-    source_url: 
+    source_url:
       type: str
       biolink: source_web_page
 
@@ -206,16 +208,24 @@ protein:
   biolink_category: "biolink:Protein"
   inherit_properties: true
   properties:
-    accession: 
+    accessions:
       type: str[]
       biolink: xref
     protein_name:
       type: str
       biolink: name
-    source: 
+    is_canonical:
+      type: bool
+    is_isoform:
+      type: bool
+    canonical_accession:
+      type: str
+    isoform_name:
+      type: str
+    source:
       type: str
       biolink: knowledge_source
-    source_url: 
+    source_url:
       type: str
       biolink: source_web_page
   kgx_properties:
@@ -231,9 +241,6 @@ transcript:
   kgx_properties:
     category: "biolink:Transcript"
   properties:
-    gene_name: 
-     type: str
-     biolink: name
     transcript_name:
       type: str
       biolink: name
@@ -263,17 +270,8 @@ exon:
   kgx_properties:
     category: "biolink:Exon"
   properties:
-    gene_id: 
-      type: str
-      biolink: id
-    transcript_id: 
-      type: str
-      biolink: id
-    exon_number: 
+    exon_number:
       type: int
-    exon_id: 
-      type: str
-      biolink: id
 
 # ---
 # genomic variants
@@ -305,6 +303,12 @@ snp:
       biolink: has_quantitative_value
     polyphen2_humvar_prediction:
       type: str
+    raw_cadd_score:
+      type: float
+      biolink: has_quantitative_value
+    phred_score:
+      type: float
+      biolink: has_quantitative_value
   description: >-
     A single nucleotide polymorphism (SNP) is a variation in a single nucleotide that occurs at a specific position in the genome
 
@@ -460,9 +464,6 @@ pathway:
     evidence:
       type: str
       biolink: has_evidence
-    pubmed_url:        
-      type: str
-      biolink: source_record_urls            
     source:
       type: str
       biolink: knowledge_source
@@ -1148,10 +1149,7 @@ subclass of:
     object_category: "biolink:OntologyClass"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
-  properties:
-    rel_type: 
-      type: str
-      biolink: relation
+  properties: {}
 
 cl capable of:
   is_a: annotation
@@ -1250,11 +1248,8 @@ gene to pathway association:
   output_label: participates_in
   source: [gene, transcript, protein]
   target: pathway
-  pathway_url:        # Reactome provides this datum in the relation datafile. @todo: move this to pathway schema/node
-    type: str
-    biolink: source_record_urls
   kgx_properties:
-    subject_category: "biolink:GeneOrGeneProduct"  
+    subject_category: "biolink:GeneOrGeneProduct"
     object_category: "biolink:Pathway"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
@@ -1622,16 +1617,15 @@ pathway_to_biological_process:
       An association between a pathway and a biological process, indicating that the pathway is involved in the process.
     properties:
       pathway_name: str
-      go_term_id: str
-      go_term_type: 
+      go_term_type:
         type: str
         const: biological process
-      source: 
+      source:
         type: str
         biolink: knowledge_source
       source_url:
         type: str
-        biolink: source_web_page    
+        biolink: source_web_page
     kgx_properties:
       subject_category: "biolink:Pathway"
       object_category: "biolink:BiologicalProcess"
@@ -1649,7 +1643,6 @@ pathway_to_molecular_function:
       An association between a pathway and a molecular function, indicating that the pathway is involved in the function.
     properties:
       pathway_name: str
-      go_term_id: str
       go_term_type:
         type: str
         const: molecular function
@@ -1669,7 +1662,6 @@ pathway_to_cellular_component:
       An association between a pathway and a cellular component, indicating that the pathway is associated with the component.
     properties:
       pathway_name: str
-      go_term_id: str
       go_term_type:
         type: str
         const: cellular component
@@ -1692,15 +1684,15 @@ go gene product:
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
   properties:
-    qualifier: 
-      type: str
-      biolink: qualifier
-    db_reference: 
-      type: str
+    db_reference:
+      type: str[]
       biolink: publication
-    evidence: 
+    evidence:
       type: str
       biolink: has_evidence
+    taxon_id:
+      type: str
+      biolink: taxon
 
 biological process gene product:
   is_a: go gene product
@@ -1788,15 +1780,15 @@ go gene:
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
   properties:
-    qualifier: 
-      type: str
-      biolink: qualifier
-    db_reference: 
-      type: str
+    db_reference:
+      type: str[]
       biolink: publication
-    evidence: 
+    evidence:
       type: str
       biolink: has_evidence
+    taxon_id:
+      type: str
+      biolink: taxon
 
 biological process gene:
   is_a: go gene
@@ -2908,12 +2900,6 @@ gene biomarker via orthology disease:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -2922,7 +2908,7 @@ gene biomarker via orthology disease:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -2951,12 +2937,6 @@ gene implicated via orthology disease:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -2965,7 +2945,7 @@ gene implicated via orthology disease:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -2994,12 +2974,6 @@ gene is implicated in disease:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -3008,7 +2982,7 @@ gene is implicated in disease:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -3036,12 +3010,6 @@ gene to disease marker association:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -3050,7 +3018,7 @@ gene to disease marker association:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -3078,12 +3046,6 @@ gene to disease model association:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -3092,7 +3054,7 @@ gene to disease model association:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -1616,10 +1616,6 @@ pathway_to_biological_process:
     description: >-
       An association between a pathway and a biological process, indicating that the pathway is involved in the process.
     properties:
-      pathway_name: str
-      go_term_type:
-        type: str
-        const: biological process
       source:
         type: str
         biolink: knowledge_source
@@ -1641,11 +1637,7 @@ pathway_to_molecular_function:
     input_label: pathway_to_molecular_function
     description: >-
       An association between a pathway and a molecular function, indicating that the pathway is involved in the function.
-    properties:
-      pathway_name: str
-      go_term_type:
-        type: str
-        const: molecular function
+    properties: {}
     kgx_properties:
       subject_category: "biolink:Pathway"
       object_category: "biolink:MolecularActivity"
@@ -1660,11 +1652,7 @@ pathway_to_cellular_component:
     input_label: pathway_to_cellular_component
     description: >-
       An association between a pathway and a cellular component, indicating that the pathway is associated with the component.
-    properties:
-      pathway_name: str
-      go_term_type:
-        type: str
-        const: cellular component
+    properties: {}
     kgx_properties:
       subject_category: "biolink:Pathway"
       object_category: "biolink:CellularComponent"

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -1054,9 +1054,29 @@ gene to gene coexpression association:
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
   properties:
-    score:  
+    score:
       type: float
       biolink: has_quantitative_value
+
+protein to protein coexpression association:
+  description: >-
+    Indicates that two proteins are co-expressed according to STRING coexpression scores.
+  is_a: expression
+  biolink_predicate: "biolink:coexpressed_with"
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_coexpressed_with
+  output_label: coexpressed_with
+  source: protein
+  target: protein
+  kgx_properties:
+    subject_category: "biolink:Protein"
+    object_category: "biolink:Protein"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    coexpression_score:
+      type: float
 
 post translational interaction:
   is_a: expression

--- a/config/primer_schema_config.yaml
+++ b/config/primer_schema_config.yaml
@@ -171,17 +171,8 @@ exon:
   kgx_properties:
     category: biolink:Exon
   properties:
-    gene_id:
-      type: str
-      biolink: id
-    transcript_id:
-      type: str
-      biolink: id
     exon_number:
       type: int
-    exon_id:
-      type: str
-      biolink: id
 
 experimental factor:
   is_a: ontology term
@@ -344,6 +335,8 @@ ontology term:
     synonym:
       type: str[]
       biolink: synonym
+    alternative_ids:
+      type: str[]
     source:
       type: str
       biolink: knowledge_source
@@ -374,9 +367,6 @@ pathway:
     evidence:
       type: str
       biolink: has_evidence
-    pubmed_url:
-      type: str
-      biolink: source_record_urls
     source:
       type: str
       biolink: knowledge_source
@@ -447,12 +437,20 @@ protein:
   biolink_category: biolink:Protein
   inherit_properties: true
   properties:
-    accession:
+    accessions:
       type: str[]
       biolink: xref
     protein_name:
       type: str
       biolink: name
+    is_canonical:
+      type: bool
+    is_isoform:
+      type: bool
+    canonical_accession:
+      type: str
+    isoform_name:
+      type: str
     source:
       type: str
       biolink: knowledge_source
@@ -624,9 +622,6 @@ transcript:
   kgx_properties:
     category: biolink:Transcript
   properties:
-    gene_name:
-      type: str
-      biolink: name
     transcript_name:
       type: str
       biolink: name
@@ -1257,12 +1252,6 @@ gene biomarker via orthology disease:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -1271,7 +1260,7 @@ gene biomarker via orthology disease:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -1300,12 +1289,6 @@ gene implicated via orthology disease:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -1314,7 +1297,7 @@ gene implicated via orthology disease:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -1362,12 +1345,6 @@ gene is implicated in disease:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -1376,7 +1353,7 @@ gene is implicated in disease:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -1439,12 +1416,6 @@ gene to disease marker association:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -1453,7 +1424,7 @@ gene to disease marker association:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -1481,12 +1452,6 @@ gene to disease model association:
   properties:
     taxon_id:
       type: integer
-    species_name:
-      type: string
-    gene_symbol:
-      type: string
-    disease_name:
-      type: string
     evidence_code:
       type: string
     evidence_code_name:
@@ -1495,7 +1460,7 @@ gene to disease model association:
       type: string
     date:
       type: string
-    source:
+    data_source:
       type: string
     with_ortholog:
       type: string
@@ -1565,9 +1530,6 @@ gene to pathway association:
   - transcript
   - protein
   target: pathway
-  pathway_url:
-    type: str
-    biolink: source_record_urls
   kgx_properties:
     subject_category: biolink:GeneOrGeneProduct
     object_category: biolink:Pathway
@@ -1655,15 +1617,15 @@ go gene:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
   properties:
-    qualifier:
-      type: str
-      biolink: qualifier
     db_reference:
-      type: str
+      type: str[]
       biolink: publication
     evidence:
       type: str
       biolink: has_evidence
+    taxon_id:
+      type: str
+      biolink: taxon
 
 go gene product:
   is_a: annotation
@@ -1679,15 +1641,15 @@ go gene product:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
   properties:
-    qualifier:
-      type: str
-      biolink: qualifier
     db_reference:
-      type: str
+      type: str[]
       biolink: publication
     evidence:
       type: str
       biolink: has_evidence
+    taxon_id:
+      type: str
+      biolink: taxon
 
 has part:
   is_a: annotation
@@ -1976,7 +1938,6 @@ pathway_to_biological_process:
     that the pathway is involved in the process.
   properties:
     pathway_name: str
-    go_term_id: str
     go_term_type:
       type: str
       const: biological process
@@ -2003,7 +1964,6 @@ pathway_to_cellular_component:
     that the pathway is associated with the component.
   properties:
     pathway_name: str
-    go_term_id: str
     go_term_type:
       type: str
       const: cellular component
@@ -2024,7 +1984,6 @@ pathway_to_molecular_function:
     that the pathway is involved in the function.
   properties:
     pathway_name: str
-    go_term_id: str
     go_term_type:
       type: str
       const: molecular function
@@ -2402,10 +2361,7 @@ subclass of:
     object_category: biolink:OntologyClass
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
-  properties:
-    rel_type:
-      type: str
-      biolink: relation
+  properties: {}
 
 super enhancer to gene association:
   description: An association between a super enhancer and a gene

--- a/config/primer_schema_config.yaml
+++ b/config/primer_schema_config.yaml
@@ -1937,10 +1937,6 @@ pathway_to_biological_process:
   description: An association between a pathway and a biological process, indicating
     that the pathway is involved in the process.
   properties:
-    pathway_name: str
-    go_term_type:
-      type: str
-      const: biological process
     source:
       type: str
       biolink: knowledge_source
@@ -1962,11 +1958,7 @@ pathway_to_cellular_component:
   input_label: pathway_to_cellular_component
   description: An association between a pathway and a cellular component, indicating
     that the pathway is associated with the component.
-  properties:
-    pathway_name: str
-    go_term_type:
-      type: str
-      const: cellular component
+  properties: {}
   kgx_properties:
     subject_category: biolink:Pathway
     object_category: biolink:CellularComponent
@@ -1982,11 +1974,7 @@ pathway_to_molecular_function:
   input_label: pathway_to_molecular_function
   description: An association between a pathway and a molecular function, indicating
     that the pathway is involved in the function.
-  properties:
-    pathway_name: str
-    go_term_type:
-      type: str
-      const: molecular function
+  properties: {}
   kgx_properties:
     subject_category: biolink:Pathway
     object_category: biolink:MolecularActivity

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -1343,7 +1343,7 @@ polyphen2:
     cls: PolyPhen2Adapter
     args:
       filepath: ./samples/hsa/polyPhen2_sample.bed.gz
-      label: polyphen2_variant      
+      label: snp
   outdir: polyphen-2
   nodes: True
   edges: False

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -860,7 +860,9 @@ def main(
             cfg_cache_root = ""
             cfg_variant = None
 
-        is_sample_config = dataset == "sample" if species_mode else "sample" in str(adapters_config).lower()
+        is_sample_config = dataset == "sample" if species_mode else any(
+            kw in str(adapters_config).lower() for kw in ("sample", "test_config")
+        )
 
         resolved_cache_root = dbsnp_cache_root or cfg_cache_root
         if not resolved_cache_root and is_sample_config:

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -260,6 +260,21 @@ def _load_adapters_config(config_path: Path, context: str) -> dict:
             raise typer.Exit(1)
 
 
+def _strip_taxon_id(items, is_edge: bool):
+    """Wrap a node/edge generator to remove 'taxon_id' from every props dict."""
+    for item in items:
+        if is_edge:
+            src, tgt, label, props = item
+            if props and 'taxon_id' in props:
+                props = {k: v for k, v in props.items() if k != 'taxon_id'}
+            yield src, tgt, label, props
+        else:
+            node_id, label, props = item
+            if props and 'taxon_id' in props:
+                props = {k: v for k, v in props.items() if k != 'taxon_id'}
+            yield node_id, label, props
+
+
 def process_adapters(
     adapters_dict,
     dbsnp_rsids_dict,
@@ -269,6 +284,7 @@ def process_adapters(
     add_provenance,
     schema_dict,
     checkpoint_manager: Optional[CheckpointManager] = None,
+    include_taxon_id: bool = True,
 ):
     """
     Iterate over all adapters, write nodes/edges, and accumulate statistics.
@@ -350,6 +366,8 @@ def process_adapters(
         try:
             if write_nodes:
                 nodes = adapter.get_nodes()
+                if not include_taxon_id:
+                    nodes = _strip_taxon_id(nodes, is_edge=False)
                 freq, props = writer.write_nodes(nodes, path_prefix=outdir)
                 if not freq:
                     logger.warning(f"Adapter '{adapter_name}' produced 0 nodes.")
@@ -363,6 +381,8 @@ def process_adapters(
 
             if write_edges:
                 edges = adapter.get_edges()
+                if not include_taxon_id:
+                    edges = _strip_taxon_id(edges, is_edge=True)
                 freq = writer.write_edges(edges, path_prefix=outdir)
                 if not freq:
                     logger.warning(f"Adapter '{adapter_name}' produced 0 edges.")
@@ -657,6 +677,12 @@ def main(
     add_provenance: bool = typer.Option(
         True, help="Add provenance to nodes and edges"
     ),
+    include_taxon_id: bool = typer.Option(
+        True,
+        "--include-taxon-id/--no-taxon-id",
+        help="Include taxon_id property on nodes and edges. "
+             "Use --no-taxon-id for single-species KGs where the taxon is implicit.",
+    ),
     include_curie: bool = typer.Option(
         False,
         "--include-curie/--no-curie",
@@ -795,6 +821,7 @@ def main(
                         add_provenance,
                         schema_dict,
                         checkpoint_manager=ckpt,
+                        include_taxon_id=include_taxon_id,
                     )
 
                     if writer_type == "networkx":
@@ -844,6 +871,7 @@ def main(
             logger.info(f"Output directory: {output_dir}")
             logger.info(f"Write properties: {write_properties}")
             logger.info(f"Add provenance: {add_provenance}")
+            logger.info(f"Include taxon_id: {include_taxon_id}")
 
             output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -960,6 +988,7 @@ def main(
             add_provenance,
             schema_dict,
             checkpoint_manager=ckpt,
+            include_taxon_id=include_taxon_id,
         )
 
         if writer_type == "networkx":

--- a/data_source_schemas/hsa/PolyPhen_2.yaml
+++ b/data_source_schemas/hsa/PolyPhen_2.yaml
@@ -3,7 +3,7 @@ website: https://hgdownload.soe.ucsc.edu
 nodes:
   polyphen2 variant:
     url: https://hgdownload.soe.ucsc.edu/gbdb/hg38/dbNsfp/dbNsfpPolyPhen2.bb
-    input_label: polyphen2_variant
+    input_label: snp
     description: A variant with PolyPhen-2 predictions for the impact of amino acid
       substitutions on protein structure and function
     properties:

--- a/data_source_schemas/hsa/PolyPhen_2.yaml
+++ b/data_source_schemas/hsa/PolyPhen_2.yaml
@@ -1,7 +1,7 @@
 name: PolyPhen-2
 website: https://hgdownload.soe.ucsc.edu
 nodes:
-  polyphen2 variant:
+  snp:
     url: https://hgdownload.soe.ucsc.edu/gbdb/hg38/dbNsfp/dbNsfpPolyPhen2.bb
     input_label: snp
     description: A variant with PolyPhen-2 predictions for the impact of amino acid

--- a/data_source_schemas/hsa/STRING.yaml
+++ b/data_source_schemas/hsa/STRING.yaml
@@ -8,3 +8,12 @@ relationships:
     target: protein
     properties:
       score: float
+  protein coexpression:
+    url: https://string-db.org/
+    input_label: protein_coexpressed_with
+    output_label: coexpressed_with
+    description: Proteins whose genes are co-expressed according to STRING coexpression scores.
+    source: protein
+    target: protein
+    properties:
+      coexpression_score: float

--- a/scripts/create_catlas_abc_cell_ontology_map.py
+++ b/scripts/create_catlas_abc_cell_ontology_map.py
@@ -7,6 +7,14 @@ which has three columns:
     ontology_id   — CL: or UBERON: ID           (e.g. "CL:0002370")
     cre_key       — corresponding cCRE pkl key  (e.g. "Airway_Goblet_Cell")
 
+Curation note:
+    Ontology IDs are sourced from Cell_ontology.tsv
+    (https://decoder-genetics.wustl.edu/catlasv1/humanenhancer/data/Cell_ontology.tsv).
+    The ABC dataset uses abbreviated cell type labels (e.g. "Vasc Sm Muscle 1") while
+    Cell_ontology.tsv uses full names (e.g. "Vascular_Smooth_Muscle_1"). Name matching
+    between the two was performed using claude-opus-4-6; the ontology IDs themselves
+    were taken directly from Cell_ontology.tsv without LLM modification.
+
 Output pkl: dict  {abc_stem: "CL:XXXXXXX" or "UBERON:XXXXXXX"}
 
 Usage:


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [x] Adapter fix / update
- [x] New processor / Processor fix
- [x] Schema change
- [x] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [x] Bug fix / Refactor

---

## Summary

- **Fix 6 data bugs**: reactome pubmed_url mapping, non-primary nodes bleeding into ontology node files (CL/HPO/CLO), bgee routing CL IDs to wrong node type, and missing UniProt dbxref property
- **Fix CURIE prefix stripping**: 4 adapters now pre-format property values with underscore separators (GO_REF_, PMID_, ECO_) so they survive BioCypher serialization unchanged
- **Reactome clean-up**: pathway_url moved from edges to pathway nodes; redundant go_term_id/subontology removed from pathway↔GO edges
- **Alliance adapter clean-up**: remove 3 redundant fields, fix date format (YYYYMMDD → YYYY-MM-DD), fix source key collision (data field renamed to data_source)
- **Remove redundant properties**: gene_name from transcripts, gene_id/transcript_id/exon_id from exons, developmental_stage from dev-stage edges, rel_type from all ontology edges, qualifier from GAF edges
- **PolyPhen2 rename**: consolidate polyphen2_variant into the snp node type, consistent with CADD and dbSNP outputs; rename node key in PolyPhen_2.yaml
- **Defensive fixes**: guard bgee developmental-stage edge against None target, fix pre-existing invalid f-string in bgee error handler, filter empty segments from TFLink PubMed ID lists, normalise GAF db_reference to always be a list
- **Remove dead code**: drop unused HGNCProcessor lookup from GencodeTranscriptAdapter.get_nodes() (and its import/init) after gene_name was removed from transcript node properties
- **Schema alignment** (primer_schema_config.yaml + hsa_schema_config.yaml): sync both schema files with all adapter changes above — remove stale properties (gene_name, gene_id/transcript_id/exon_id on exon, pubmed_url on pathway, go_term_id on pathway↔GO edges, pathway_url on gene→pathway edges, qualifier on GAF edges, rel_type on subclass-of edges, species_name/gene_symbol/disease_name on Alliance edges); add missing properties (alternative_ids on ontology term, is_canonical/is_isoform/canonical_accession/ isoform_name on protein, rename accession → accessions, raw_cadd_score/phred_score on snp, taxon_id and db_reference: str[] on GAF edges, data_source on Alliance edges)
- **Fix UniProt GO xref adapters producing empty output**: `get_dbxrefs` was double-prefixing GO IDs (`GO:GO:0005509`) because the raw cross-reference field already contains `GO:XXXXXXX`; the subontology mapping lookup always returned None so all GO edges were silently dropped. Fixes protein_has_xref_biological_process, protein_has_xref_molecular_function, protein_has_xref_cellular_component (336 edges recovered on the sample alone)
- **Fix test_config.yaml treated as full dataset run**: `is_sample_config` detection now also matches `test_config` filenames so running with the test config no longer errors with a missing --dbsnp-variant requirement
- **Add --no-taxon-id flag for single-species KGs**: new `--include-taxon-id / --no-taxon-id` CLI flag (default: include) strips `taxon_id` from all node and edge properties at the writer stage without touching any adapter code. Wired into `Makefile` (`INCLUDE_TAXON_ID=no`) for all three run targets (`run-interactive,` `run-direct`, `run-sample`) and documented in `README.md`

---

## Checklist

### General
- [x] PR targets `main` and branch is up to date
- [x] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
- [x] No credentials, tokens, or real patient data committed

### New adapter
- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently

### Schema changes
- [x] New labels are validated against BioCypher / Biolink expectations
- [x] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
- [ ] Breaking label, schema, or adapter-arg changes are called out below

### Testing
- [x] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
- [ ] Ran additional focused checks relevant to the change
- [x] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
- [ ] Spot-checked output node / edge labels and counts where relevant


