### PR TITLE
feat: detect and report adapters with empty output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup check-uv run run-interactive run-sample test clean distclean
+.PHONY: help setup check-uv run run-interactive run-sample run-direct check-paths test clean distclean
 
 # Default target
 help:
@@ -7,6 +7,7 @@ help:
 	@echo "  make run            - Run with interactive prompts for parameters"
 	@echo "  make run-sample     - Run with sample configuration and data"
 	@echo "  make run-direct     - Run with explicit parameters (non-interactive)"
+	@echo "  make check-paths    - Validate file paths in an adapters config (no adapters run)"
 	@echo "  make test           - Run tests"
 	@echo "  make clean          - Clean temporary files"
 	@echo "  make distclean      - Full clean including virtual environment"
@@ -14,8 +15,12 @@ help:
 	@echo "Usage examples:"
 	@echo "  make run            - Interactive mode (recommended)"
 	@echo "  make run-interactive - Same as 'make run'"
-	@echo "  make run-sample                    - Run with sample data (default: metta writer)"
-	@echo "  make run-sample WRITER_TYPE=prolog - Run with sample data using prolog writer"
+	@echo "  make run-sample                         - Run with sample data (default: metta writer)"
+	@echo "  make run-sample WRITER_TYPE=prolog       - Run with sample data using prolog writer"
+	@echo "  make run-sample INCLUDE_TAXON_ID=no      - Run without taxon_id in output (single-species KG)"
+	@echo "  make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml"
+	@echo "  make run-direct ... SKIP_PREFLIGHT=yes   - Skip pre-flight file path validation"
+	@echo "  make run-sample     SKIP_PREFLIGHT=yes   - Same, for sample runs"
 
 # Check if UV is installed, install via pip if not
 check-uv:
@@ -65,6 +70,15 @@ run-interactive: check-uv
 	DBSNP_CACHE_ROOT=$${DBSNP_CACHE_ROOT:-./aux_files/hsa/sample_dbsnp}; \
 	echo "Using dbSNP cache root: $$DBSNP_CACHE_ROOT"; \
 	echo ""; \
+	read -p "🧬 Enter dbSNP variant (common/full/leave blank for sample) []: " DBSNP_VARIANT; \
+	if [ -n "$$DBSNP_VARIANT" ]; then \
+		DBSNP_VARIANT_FLAG="--dbsnp-variant $$DBSNP_VARIANT"; \
+		echo "Using dbSNP variant: $$DBSNP_VARIANT"; \
+	else \
+		DBSNP_VARIANT_FLAG=""; \
+		echo "dbSNP variant: not set (sample mode)"; \
+	fi; \
+	echo ""; \
 	read -p "📝 Enter writer type (metta/prolog/neo4j) [metta]: " WRITER_TYPE; \
 	WRITER_TYPE=$${WRITER_TYPE:-metta}; \
 	echo "Using writer type: $$WRITER_TYPE"; \
@@ -101,6 +115,26 @@ run-interactive: check-uv
 		echo "Provenance will NOT be added"; \
 	fi; \
 	echo ""; \
+	read -p "🧬 Include taxon_id in output? (yes/no) [yes]: " INCLUDE_TAXON_ID; \
+	INCLUDE_TAXON_ID=$${INCLUDE_TAXON_ID:-yes}; \
+	if [ "$$INCLUDE_TAXON_ID" = "no" ]; then \
+		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
+		echo "taxon_id will NOT be written to output"; \
+	else \
+		INCLUDE_TAXON_ID_FLAG=""; \
+		echo "taxon_id will be written to output"; \
+	fi; \
+	echo ""; \
+	read -p "🚦 Skip pre-flight path validation? (yes/no) [no]: " SKIP_PREFLIGHT; \
+	SKIP_PREFLIGHT=$${SKIP_PREFLIGHT:-no}; \
+	if [ "$$SKIP_PREFLIGHT" = "yes" ]; then \
+		SKIP_PREFLIGHT_FLAG="--skip-preflight"; \
+		echo "Pre-flight validation will be skipped"; \
+	else \
+		SKIP_PREFLIGHT_FLAG=""; \
+		echo "Pre-flight validation enabled"; \
+	fi; \
+	echo ""; \
 	echo "🎯 Starting knowledge graph creation..."; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
@@ -108,10 +142,13 @@ run-interactive: check-uv
 		--adapters-config "$$ADAPTERS_CONFIG" \
 		--schema-config "$$SCHEMA_CONFIG" \
 		--dbsnp-cache-root "$$DBSNP_CACHE_ROOT" \
+		$$DBSNP_VARIANT_FLAG \
 		--writer-type "$$WRITER_TYPE" \
 		$$INCLUDE_ADAPTERS_FLAG \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG && \
+		$$ADD_PROVENANCE_FLAG \
+		$$INCLUDE_TAXON_ID_FLAG \
+		$$SKIP_PREFLIGHT_FLAG && \
 	echo "✅ Knowledge graph creation completed! Check $$OUTPUT_DIR for results."
 
 run-direct: check-uv
@@ -132,6 +169,11 @@ run-direct: check-uv
 	else \
 		ADD_PROVENANCE_FLAG="--no-add-provenance"; \
 	fi; \
+	if [ "$(INCLUDE_TAXON_ID)" = "false" ] || [ "$(INCLUDE_TAXON_ID)" = "no" ]; then \
+		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
+	else \
+		INCLUDE_TAXON_ID_FLAG=""; \
+	fi; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
 		--output-dir $(OUTPUT_DIR) \
@@ -141,7 +183,9 @@ run-direct: check-uv
 		$(if $(DBSNP_VARIANT),--dbsnp-variant $(DBSNP_VARIANT),) \
 		$(if $(WRITER_TYPE),--writer-type $(WRITER_TYPE),--writer-type metta) \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG
+		$$ADD_PROVENANCE_FLAG \
+		$$INCLUDE_TAXON_ID_FLAG \
+		$(if $(filter yes true,$(SKIP_PREFLIGHT)),--skip-preflight,)
 
 # Run with sample configuration and data (with optional writer type)
 run-sample: check-uv
@@ -161,6 +205,13 @@ run-sample: check-uv
 		ADD_PROVENANCE_FLAG="--no-add-provenance"; \
 		echo "Provenance: disabled"; \
 	fi; \
+	if [ "$(INCLUDE_TAXON_ID)" = "false" ] || [ "$(INCLUDE_TAXON_ID)" = "no" ]; then \
+		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
+		echo "taxon_id: disabled"; \
+	else \
+		INCLUDE_TAXON_ID_FLAG=""; \
+		echo "taxon_id: enabled"; \
+	fi; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
 		--output-dir ./output \
@@ -169,8 +220,30 @@ run-sample: check-uv
 		--schema-config ./config/hsa/hsa_schema_config.yaml \
 		--writer-type $(if $(WRITER_TYPE),$(WRITER_TYPE),metta) \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG
+		$$ADD_PROVENANCE_FLAG \
+		$$INCLUDE_TAXON_ID_FLAG \
+		$(if $(filter yes true,$(SKIP_PREFLIGHT)),--skip-preflight,)
 	@echo "✅ Sample run completed! Check the ./output directory for results."
+# Validate file paths in an adapters config without running any adapters
+check-paths: check-uv
+	@if [ -z "$(ADAPTERS_CONFIG)" ]; then \
+		echo "❌ Error: ADAPTERS_CONFIG is required"; \
+		echo "Usage: make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml"; \
+		echo "       make check-paths ADAPTERS_CONFIG=... INCLUDE_ADAPTERS='gencode_gene uniprotkb_sprot'"; \
+		exit 1; \
+	fi
+	@export PATH="$$HOME/.local/bin:$$PATH"; \
+	INCLUDE_ADAPTERS_FLAG=""; \
+	if [ -n "$(INCLUDE_ADAPTERS)" ]; then \
+		for adapter in $(INCLUDE_ADAPTERS); do \
+			INCLUDE_ADAPTERS_FLAG="$$INCLUDE_ADAPTERS_FLAG --include-adapters $$adapter"; \
+		done; \
+	fi; \
+	uv run python create_knowledge_graph.py \
+		--adapters-config $(ADAPTERS_CONFIG) \
+		$$INCLUDE_ADAPTERS_FLAG \
+		--check-only
+
 # Run tests
 test: check-uv
 	@export PATH="$$HOME/.local/bin:$$PATH"; uv run pytest -v

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup check-uv run run-interactive run-sample run-direct check-paths test clean distclean
+.PHONY: help setup check-uv run run-interactive run-sample run-direct test clean distclean
 
 # Default target
 help:
@@ -7,7 +7,6 @@ help:
 	@echo "  make run            - Run with interactive prompts for parameters"
 	@echo "  make run-sample     - Run with sample configuration and data"
 	@echo "  make run-direct     - Run with explicit parameters (non-interactive)"
-	@echo "  make check-paths    - Validate file paths in an adapters config (no adapters run)"
 	@echo "  make test           - Run tests"
 	@echo "  make clean          - Clean temporary files"
 	@echo "  make distclean      - Full clean including virtual environment"
@@ -17,10 +16,6 @@ help:
 	@echo "  make run-interactive - Same as 'make run'"
 	@echo "  make run-sample                         - Run with sample data (default: metta writer)"
 	@echo "  make run-sample WRITER_TYPE=prolog       - Run with sample data using prolog writer"
-	@echo "  make run-sample INCLUDE_TAXON_ID=no      - Run without taxon_id in output (single-species KG)"
-	@echo "  make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml"
-	@echo "  make run-direct ... SKIP_PREFLIGHT=yes   - Skip pre-flight file path validation"
-	@echo "  make run-sample     SKIP_PREFLIGHT=yes   - Same, for sample runs"
 
 # Check if UV is installed, install via pip if not
 check-uv:
@@ -115,26 +110,6 @@ run-interactive: check-uv
 		echo "Provenance will NOT be added"; \
 	fi; \
 	echo ""; \
-	read -p "🧬 Include taxon_id in output? (yes/no) [yes]: " INCLUDE_TAXON_ID; \
-	INCLUDE_TAXON_ID=$${INCLUDE_TAXON_ID:-yes}; \
-	if [ "$$INCLUDE_TAXON_ID" = "no" ]; then \
-		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
-		echo "taxon_id will NOT be written to output"; \
-	else \
-		INCLUDE_TAXON_ID_FLAG=""; \
-		echo "taxon_id will be written to output"; \
-	fi; \
-	echo ""; \
-	read -p "🚦 Skip pre-flight path validation? (yes/no) [no]: " SKIP_PREFLIGHT; \
-	SKIP_PREFLIGHT=$${SKIP_PREFLIGHT:-no}; \
-	if [ "$$SKIP_PREFLIGHT" = "yes" ]; then \
-		SKIP_PREFLIGHT_FLAG="--skip-preflight"; \
-		echo "Pre-flight validation will be skipped"; \
-	else \
-		SKIP_PREFLIGHT_FLAG=""; \
-		echo "Pre-flight validation enabled"; \
-	fi; \
-	echo ""; \
 	echo "🎯 Starting knowledge graph creation..."; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
@@ -146,9 +121,7 @@ run-interactive: check-uv
 		--writer-type "$$WRITER_TYPE" \
 		$$INCLUDE_ADAPTERS_FLAG \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG \
-		$$INCLUDE_TAXON_ID_FLAG \
-		$$SKIP_PREFLIGHT_FLAG && \
+		$$ADD_PROVENANCE_FLAG && \
 	echo "✅ Knowledge graph creation completed! Check $$OUTPUT_DIR for results."
 
 run-direct: check-uv
@@ -169,11 +142,6 @@ run-direct: check-uv
 	else \
 		ADD_PROVENANCE_FLAG="--no-add-provenance"; \
 	fi; \
-	if [ "$(INCLUDE_TAXON_ID)" = "false" ] || [ "$(INCLUDE_TAXON_ID)" = "no" ]; then \
-		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
-	else \
-		INCLUDE_TAXON_ID_FLAG=""; \
-	fi; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
 		--output-dir $(OUTPUT_DIR) \
@@ -183,9 +151,7 @@ run-direct: check-uv
 		$(if $(DBSNP_VARIANT),--dbsnp-variant $(DBSNP_VARIANT),) \
 		$(if $(WRITER_TYPE),--writer-type $(WRITER_TYPE),--writer-type metta) \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG \
-		$$INCLUDE_TAXON_ID_FLAG \
-		$(if $(filter yes true,$(SKIP_PREFLIGHT)),--skip-preflight,)
+		$$ADD_PROVENANCE_FLAG
 
 # Run with sample configuration and data (with optional writer type)
 run-sample: check-uv
@@ -205,13 +171,6 @@ run-sample: check-uv
 		ADD_PROVENANCE_FLAG="--no-add-provenance"; \
 		echo "Provenance: disabled"; \
 	fi; \
-	if [ "$(INCLUDE_TAXON_ID)" = "false" ] || [ "$(INCLUDE_TAXON_ID)" = "no" ]; then \
-		INCLUDE_TAXON_ID_FLAG="--no-taxon-id"; \
-		echo "taxon_id: disabled"; \
-	else \
-		INCLUDE_TAXON_ID_FLAG=""; \
-		echo "taxon_id: enabled"; \
-	fi; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python create_knowledge_graph.py \
 		--output-dir ./output \
@@ -220,30 +179,8 @@ run-sample: check-uv
 		--schema-config ./config/hsa/hsa_schema_config.yaml \
 		--writer-type $(if $(WRITER_TYPE),$(WRITER_TYPE),metta) \
 		$$WRITE_PROPERTIES_FLAG \
-		$$ADD_PROVENANCE_FLAG \
-		$$INCLUDE_TAXON_ID_FLAG \
-		$(if $(filter yes true,$(SKIP_PREFLIGHT)),--skip-preflight,)
+		$$ADD_PROVENANCE_FLAG
 	@echo "✅ Sample run completed! Check the ./output directory for results."
-# Validate file paths in an adapters config without running any adapters
-check-paths: check-uv
-	@if [ -z "$(ADAPTERS_CONFIG)" ]; then \
-		echo "❌ Error: ADAPTERS_CONFIG is required"; \
-		echo "Usage: make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml"; \
-		echo "       make check-paths ADAPTERS_CONFIG=... INCLUDE_ADAPTERS='gencode_gene uniprotkb_sprot'"; \
-		exit 1; \
-	fi
-	@export PATH="$$HOME/.local/bin:$$PATH"; \
-	INCLUDE_ADAPTERS_FLAG=""; \
-	if [ -n "$(INCLUDE_ADAPTERS)" ]; then \
-		for adapter in $(INCLUDE_ADAPTERS); do \
-			INCLUDE_ADAPTERS_FLAG="$$INCLUDE_ADAPTERS_FLAG --include-adapters $$adapter"; \
-		done; \
-	fi; \
-	uv run python create_knowledge_graph.py \
-		--adapters-config $(ADAPTERS_CONFIG) \
-		$$INCLUDE_ADAPTERS_FLAG \
-		--check-only
-
 # Run tests
 test: check-uv
 	@export PATH="$$HOME/.local/bin:$$PATH"; uv run pytest -v

--- a/biocypher_metta/processors/dbsnp_processor.py
+++ b/biocypher_metta/processors/dbsnp_processor.py
@@ -58,7 +58,8 @@ class DBSNPProcessor:
         )
 
         started = time.time()
-        self._conn = sqlite3.connect(str(self.db_file))
+        db_uri = f"file:{self.db_file}?immutable=1"
+        self._conn = sqlite3.connect(db_uri, uri=True)
         self._conn.execute("PRAGMA query_only=ON")
         self._backend = 'sqlite'
         logger.info(f"{self.name}: SQLite connection ready in {time.time() - started:.1f}s")

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -416,8 +416,9 @@ def process_adapters(
             logger.info(f"Checkpoint updated after adapter: {adapter_name}")
 
     if empty_output_adapters:
+        empty_adapter_count = len({name for name, _ in empty_output_adapters})
         logger.warning(
-            f"{len(empty_output_adapters)} adapter(s) produced empty output:"
+            f"{empty_adapter_count} adapter(s) produced empty output:"
         )
         for name, output_type in empty_output_adapters:
             logger.warning(f"  - {name} ({output_type}: 0)")

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -299,6 +299,7 @@ def process_adapters(
     completed_adapters = list(
         checkpoint_manager.completed_adapters if checkpoint_manager else []
     )
+    empty_output_adapters: list[tuple[str, str]] = []
     total_start = time.time()
 
     for adapter_name in adapters_dict:
@@ -350,6 +351,9 @@ def process_adapters(
             if write_nodes:
                 nodes = adapter.get_nodes()
                 freq, props = writer.write_nodes(nodes, path_prefix=outdir)
+                if not freq:
+                    logger.warning(f"Adapter '{adapter_name}' produced 0 nodes.")
+                    empty_output_adapters.append((adapter_name, "nodes"))
                 for node_label, node_count in freq.items():
                     nodes_count[node_label] += node_count
                     if dataset_name is not None:
@@ -360,6 +364,9 @@ def process_adapters(
             if write_edges:
                 edges = adapter.get_edges()
                 freq = writer.write_edges(edges, path_prefix=outdir)
+                if not freq:
+                    logger.warning(f"Adapter '{adapter_name}' produced 0 edges.")
+                    empty_output_adapters.append((adapter_name, "edges"))
                 for edge_label_key, edge_count in freq.items():
                     edges_count[edge_label_key] += edge_count
 
@@ -408,6 +415,12 @@ def process_adapters(
             )
             logger.info(f"Checkpoint updated after adapter: {adapter_name}")
 
+    if empty_output_adapters:
+        logger.warning(
+            f"{len(empty_output_adapters)} adapter(s) produced empty output:"
+        )
+        for name, output_type in empty_output_adapters:
+            logger.warning(f"  - {name} ({output_type}: 0)")
     logger.info(f"All adapters completed in {_fmt_elapsed(time.time() - total_start)}")
     return nodes_count, nodes_props, edges_count, datasets_dict
 


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [x] New processor / Processor fix
- [ ] Schema change
- [ ] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [ ] Bug fix / Refactor

---

## Summary

- Adapters that return 0 nodes or 0 edges now log an immediate `WARNING`
  instead of silently passing.
- A grouped end-of-run summary lists every such adapter with its output
  type (`nodes` or `edges`), making misconfigured or broken adapters
  easy to spot in logs.

## Changes

`create_knowledge_graph.py` — `process_adapters()` only:
- Added `empty_output_adapters` accumulator before the adapter loop.
- After `write_nodes`: warn + record if `freq` is empty.
- After `write_edges`: warn + record if `freq` is empty.
- After the loop: log a grouped warning summary if any adapters fired.

---

## Checklist

### General
- [x] PR targets `main` and branch is up to date
- [x] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
- [x] No credentials, tokens, or real patient data committed

### New adapter
- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently

### Schema changes
- [ ] New labels are validated against BioCypher / Biolink expectations
- [ ] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
- [ ] Breaking label, schema, or adapter-arg changes are called out below

### Testing
- [x] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
- [ ] Ran additional focused checks relevant to the change
- [ ] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
- [ ] Spot-checked output node / edge labels and counts where relevant


