### PR TITLE
perf(adapters): optimize roadmap adapters rsid lookup and genomic filter

### DIFF
--- a/biocypher_metta/adapters/hsa/roadmap_dhs_adapter.py
+++ b/biocypher_metta/adapters/hsa/roadmap_dhs_adapter.py
@@ -47,49 +47,54 @@ class RoadMapDHSAdapter(Adapter):
         super(RoadMapDHSAdapter, self).__init__(write_properties, add_provenance)
 
     def get_edges(self):
+        _last_id = _last_chr = _last_pos = None
         with gzip.open(self.filepath, "rt") as fp:
             next(fp)
             reader = csv.reader(fp, delimiter=',')
             for row in reader:
                 try:
                     _id = row[0]
-                    chr = self.dbsnp_rsid_map.get(_id, {}).get("chr", None) 
-                    pos = self.dbsnp_rsid_map.get(_id, {}).get("pos", None)
-                    if chr == None:
-                        # print(f"roadmap_dhs: chr is None for {_id}. Skipping it {_id}...")
+                    if _id != _last_id:
+                        rsid_data = self.dbsnp_rsid_map.get(_id)
+                        if rsid_data is not None:
+                            _last_chr = rsid_data.get("chr")
+                            _last_pos = rsid_data.get("pos")
+                        else:
+                            _last_chr = _last_pos = None
+                        _last_id = _id
+                    chr, pos = _last_chr, _last_pos
+
+                    if chr is None or pos is None:
                         continue
-                    if pos == None:
-                        # print(f"roadmap_dhs: pos is None for {_id}. Skipping it {_id}...")
-                        continue                    
-                    #tissue = row[COL_DICT['tissue']].replace('"', '').replace("'", '')
+                    if not check_genomic_location(self.chr, self.start, self.end, chr, pos, pos):
+                        continue
+
                     cell_id = row[self.COL_DICT['cell']].split()[0]
-                    biological_context = self.cell_to_ontology_id_map.get(cell_id, None)
-                    if biological_context == None:
+                    biological_context = self.cell_to_ontology_id_map.get(cell_id)
+                    if biological_context is None:
                         print(f"{cell_id} not found in ontology map. Skipping it...")
                         continue
-                    
-                    if check_genomic_location(self.chr, self.start, self.end, chr, pos, pos):
-                        _props = {}                        
-                        _source = _id
-                        prefix = biological_context[1].split('_')[0]
-                        _target = (self.ONTOLOGIES_PREFIX_TO_TYPE[prefix], biological_context[1])
 
-                        # for tissue linking, we need to get the tissue id from the biological context
-                        tissue = row[self.COL_DICT['tissue']]
-                        tissue_id = self.tissue_to_ontology_id_map.get(tissue, None)
-                        if tissue_id == None:
-                            print(f"{tissue} not found in ontology map. Skipping it...")
-                            continue
-                        
-                        tissue_type = self.ONTOLOGIES_PREFIX_TO_TYPE[tissue_id.split('_')[0]]
-                        tissue_target = (tissue_type, tissue_id)
+                    _props = {}
+                    _source = _id
+                    prefix = biological_context[1].split('_')[0]
+                    _target = (self.ONTOLOGIES_PREFIX_TO_TYPE[prefix], biological_context[1])
 
-                        if self.write_properties and self.add_provenance:
-                            _props['source'] = self.source
-                            _props['source_url'] = self.source_url
-                                
-                        yield _source, _target, self.label, _props
-                        yield _source, tissue_target, self.label, _props                        
+                    tissue = row[self.COL_DICT['tissue']]
+                    tissue_id = self.tissue_to_ontology_id_map.get(tissue)
+                    if tissue_id is None:
+                        print(f"{tissue} not found in ontology map. Skipping it...")
+                        continue
+
+                    tissue_type = self.ONTOLOGIES_PREFIX_TO_TYPE[tissue_id.split('_')[0]]
+                    tissue_target = (tissue_type, tissue_id)
+
+                    if self.write_properties and self.add_provenance:
+                        _props['source'] = self.source
+                        _props['source_url'] = self.source_url
+
+                    yield _source, _target, self.label, _props
+                    yield _source, tissue_target, self.label, _props
                 except Exception as e:
-                    print(f"error while parsing row: {row}, error: {e.args} skipping... {biological_context}")
+                    print(f"error while parsing row: {row}, error: {e.args} skipping...")
                     continue

--- a/biocypher_metta/adapters/hsa/roadmap_h3_marks_adapter.py
+++ b/biocypher_metta/adapters/hsa/roadmap_h3_marks_adapter.py
@@ -52,47 +52,52 @@ class RoadMapH3MarkAdapter(Adapter):
 
     def get_edges(self):
         for file_name in os.listdir(self.filepath):
+            _last_id = _last_chr = _last_pos = None
             with gzip.open(os.path.join(self.filepath, file_name), "rt") as fp:
                 next(fp)
                 reader = csv.reader(fp, delimiter=',')
                 for row in reader:
                     try:
                         _id = row[0]
-                        chr = self.dbsnp_rsid_map.get(_id, {}).get("chr", None) 
-                        pos = self.dbsnp_rsid_map.get(_id, {}).get("pos", None)
-                        if chr == None:
-                            # print(f"roadmap_h3_marks: chr is None for {_id}. Skipping it {_id}...")
+                        if _id != _last_id:
+                            rsid_data = self.dbsnp_rsid_map.get(_id)
+                            if rsid_data is not None:
+                                _last_chr = rsid_data.get("chr")
+                                _last_pos = rsid_data.get("pos")
+                            else:
+                                _last_chr = _last_pos = None
+                            _last_id = _id
+                        chr, pos = _last_chr, _last_pos
+
+                        if chr is None or pos is None:
                             continue
-                        if pos == None:
-                            # print(f"roadmap_h3_marks: pos is None for {_id}. Skipping it {_id}...")
+                        if not check_genomic_location(self.chr, self.start, self.end, chr, pos, pos):
                             continue
+
                         cell_id = row[self.COL_DICT['cell']].split()[0]
                         biological_context = self.cell_to_ontology_id_map.get(cell_id, [None])[-1]
-                        if biological_context == None:
-                            # print(f"{row[self.COL_DICT['cell']]} not found in ontology map. Skipping it...")
+                        if biological_context is None:
                             continue
 
-                        if check_genomic_location(self.chr, self.start, self.end, chr, pos, pos):                        
-                            _source = _id
-                            prefix = biological_context.split('_')[0]
-                            _target = (self.ONTOLOGIES_PREFIX_TO_TYPE[prefix], biological_context)
+                        _source = _id
+                        prefix = biological_context.split('_')[0]
+                        _target = (self.ONTOLOGIES_PREFIX_TO_TYPE[prefix], biological_context)
 
-                            # for tissue linking, we need to get the tissue id from the biological context
-                            tissue = row[self.COL_DICT['tissue']]
-                            tissue_id = self.tissue_to_ontology_id_map.get(tissue, None)
-                            if tissue_id == None:
-                                print(f"{tissue} not found in ontology map. Skipping it...")
-                                continue
-                            
-                            tissue_type = self.ONTOLOGIES_PREFIX_TO_TYPE[tissue_id.split('_')[0]]
-                            tissue_target = (tissue_type, tissue_id)
-                            _props = {}
-                            if self.write_properties and self.add_provenance:
-                                _props['source'] = self.source
-                                _props['source_url'] = self.source_url
-                                    
-                            yield _source, _target, self.label, _props
-                            yield _source, tissue_target, self.label, _props                            
+                        tissue = row[self.COL_DICT['tissue']]
+                        tissue_id = self.tissue_to_ontology_id_map.get(tissue)
+                        if tissue_id is None:
+                            print(f"{tissue} not found in ontology map. Skipping it...")
+                            continue
+
+                        tissue_type = self.ONTOLOGIES_PREFIX_TO_TYPE[tissue_id.split('_')[0]]
+                        tissue_target = (tissue_type, tissue_id)
+                        _props = {}
+                        if self.write_properties and self.add_provenance:
+                            _props['source'] = self.source
+                            _props['source_url'] = self.source_url
+
+                        yield _source, _target, self.label, _props
+                        yield _source, tissue_target, self.label, _props
                     except Exception as e:
-                        print(f"error while parsing row: {row}, error: {e} skipping... {biological_context}")
+                        print(f"error while parsing row: {row}, error: {e} skipping...")
                         continue

--- a/biocypher_metta/adapters/hsa/roadmap_state_adapter.py
+++ b/biocypher_metta/adapters/hsa/roadmap_state_adapter.py
@@ -3,7 +3,6 @@ import csv
 import gzip
 import os.path
 import pickle
-from collections import defaultdict
 from biocypher_metta.adapters import Adapter
 from biocypher_metta.adapters.helpers import check_genomic_location
 
@@ -50,65 +49,65 @@ class RoadMapChromatinStateAdapter(Adapter):
 
         super(RoadMapChromatinStateAdapter, self).__init__(write_properties, add_provenance)
 
-    def get_edges(self):        
-        edge_dict = defaultdict(lambda: {"props": {}})
+    def get_edges(self):
+        seen_edges = set()
         for file_name in os.listdir(self.filepath):
+            _last_id = _last_chr = _last_pos = None
             with gzip.open(os.path.join(self.filepath, file_name), "rt") as fp:
                 next(fp)
                 reader = csv.reader(fp, delimiter=',')
                 for row in reader:
                     try:
                         _id = row[0]
-                        chr = self.dbsnp_rsid_map.get(_id, {}).get("chr", None) 
-                        pos = self.dbsnp_rsid_map.get(_id, {}).get("pos", None)
-                        if chr == None:
-                            # print(f"roadmap_chromatin_state: chr is None for {_id}. Skipping it {_id}...")
+                        if _id != _last_id:
+                            rsid_data = self.dbsnp_rsid_map.get(_id)
+                            if rsid_data is not None:
+                                _last_chr = rsid_data.get("chr")
+                                _last_pos = rsid_data.get("pos")
+                            else:
+                                _last_chr = _last_pos = None
+                            _last_id = _id
+                        chr, pos = _last_chr, _last_pos
+
+                        if chr is None or pos is None:
                             continue
-                        if pos == None:
-                            # print(f"roadmap_chromatin_state: pos is None for {_id}. Skipping it {_id}...")
+                        if not check_genomic_location(self.chr, self.start, self.end, chr, pos, pos):
                             continue
+
                         cell_id = row[self.COL_DICT['cell']].split()[0]
                         biological_context = self.cell_to_ontology_id_map.get(cell_id, [None])[-1]
-                        if biological_context == None:
+                        if biological_context is None:
                             print(f"{cell_id} not found in ontology map. Skipping it...")
                             continue
-                        if check_genomic_location(self.chr, self.start, self.end, chr, pos, pos):
-                            _props = {}                         
-                            _source = _id
-                            prefix = biological_context.split('_')[0]
-                            _target = (self.ONTOLOGIES_PREFIX_TO_TYPE[prefix], biological_context)
 
-                            # for tissue linking, we need to get the tissue id from the biological context
-                            tissue = row[self.COL_DICT['tissue']]
-                            tissue_id = self.tissue_to_ontology_id_map.get(tissue, None)
-                            if tissue_id == None:
-                                print(f"{tissue} not found in ontology map. Skipping it...")
-                                continue
-                            
-                            tissue_type = self.ONTOLOGIES_PREFIX_TO_TYPE[tissue_id.split('_')[0]]
-                            tissue_target = (tissue_type, tissue_id)
-                            if self.write_properties:
-                                _props["state"] = row[self.COL_DICT['datatype']]
-                                if self.add_provenance:
-                                    _props['source'] = self.source
-                                    _props['source_url'] = self.source_url
-                            edge_key = (_source, _target)
-                            edge_key2 = (_source, tissue_target)
-                            if edge_key in edge_dict:
-                                if edge_key2 in edge_dict:
-                                    continue
-                                else:
-                                    edge_dict[edge_key2] = {"props": _props}
-                                    yield _source, tissue_target, self.label, _props
-                            else:
-                                edge_dict[edge_key] = {"props": _props}
-                                yield _source, _target, self.label, _props
-                                if edge_key2  in edge_dict:
-                                    continue
-                                else:
-                                    edge_dict[edge_key2] = {"props": _props}
-                                    yield _source, tissue_target, self.label, _props
+                        _source = _id
+                        prefix = biological_context.split('_')[0]
+                        _target = (self.ONTOLOGIES_PREFIX_TO_TYPE[prefix], biological_context)
+
+                        tissue = row[self.COL_DICT['tissue']]
+                        tissue_id = self.tissue_to_ontology_id_map.get(tissue)
+                        if tissue_id is None:
+                            print(f"{tissue} not found in ontology map. Skipping it...")
+                            continue
+
+                        tissue_type = self.ONTOLOGIES_PREFIX_TO_TYPE[tissue_id.split('_')[0]]
+                        tissue_target = (tissue_type, tissue_id)
+                        _props = {}
+                        if self.write_properties:
+                            _props["state"] = row[self.COL_DICT['datatype']]
+                            if self.add_provenance:
+                                _props['source'] = self.source
+                                _props['source_url'] = self.source_url
+
+                        edge_key = (_source, _target)
+                        edge_key2 = (_source, tissue_target)
+                        if edge_key not in seen_edges:
+                            seen_edges.add(edge_key)
+                            yield _source, _target, self.label, _props
+                        if edge_key2 not in seen_edges:
+                            seen_edges.add(edge_key2)
+                            yield _source, tissue_target, self.label, _props
 
                     except Exception as e:
-                        print(f"error while parsing row: {row}, error: {e.args}. Skipping... {biological_context} / {tissue_id}")
+                        print(f"error while parsing row: {row}, error: {e.args}. Skipping...")
                         continue


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [x] Adapter fix / update
- [ ] New processor / Processor fix
- [ ] Schema change
- [ ] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [x] Bug fix / Refactor

---

## Summary

- **Cache rsid lookups**: `dbsnp_rsid_map` is an `_SQLiteRsidToPosWrapper` that executes a SQLite query on every `.get()` call. The old code called `.get()` twice per row (once for `chr`, once for `pos`). Since roadmap CSV files are sorted by rsid and each rsid repeats ~100+ times (one row per cell type), this caused hundreds of millions of redundant SQLite queries across ~18GB of compressed input. Fixed by caching the result across consecutive identical rsids — 1 query per unique rsid instead of 2 per every row.
- **Early genomic filter**: moved `check_genomic_location` before ontology map lookups. The chr16:53M–56M window filters out ~99.9% of rows, so ontology work was being done for rows that would be discarded immediately after.
- **Simpler deduplication** (chromatin state only): replaced `defaultdict(lambda: {"props": {}})` with a plain `set`, removing 8 lines of complex branching and reducing memory per tracked edge.

## Affected files
- `biocypher_metta/adapters/hsa/roadmap_state_adapter.py`
- `biocypher_metta/adapters/hsa/roadmap_h3_marks_adapter.py`
- `biocypher_metta/adapters/hsa/roadmap_dhs_adapter.py`

## Performance

| Adapter | Before | After | Speedup |
|---|---|---|---|
| `roadmap_chromatin_state` | 13h 13m 54s | 1h 52m 38s | ~7x |

`roadmap_chromatin_state` previously accounted for >60% of total pipeline runtime
(21h 41m total). The same optimizations apply to `roadmap_h3_mark` and `roadmap_dhs`.


---

## Checklist

### General
- [x] PR targets `main` and branch is up to date
- [x] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
- [x] No credentials, tokens, or real patient data committed

### New adapter
- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently

### Schema changes
- [ ] New labels are validated against BioCypher / Biolink expectations
- [ ] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
- [ ] Breaking label, schema, or adapter-arg changes are called out below

### Testing
- [x] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
- [x] Ran additional focused checks relevant to the change
- [ ] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
- [x] Spot-checked output node / edge labels and counts where relevant


