### PR TITLE
feat: convenient Neo4j deployment and loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,9 @@ cython_debug/
 #VSCode
 .vscode/
 
+# Neo4j env (contains credentials and host-specific paths — use docker/neo4j.env.example as template)
+docker/neo4j.env
+
 #project specific
 metta_out/
 metta_out_*/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: help setup check-uv run run-interactive run-sample run-direct test clean distclean
+.PHONY: help setup check-uv run run-interactive run-sample run-direct test clean distclean \
+        neo4j-up neo4j-down neo4j-logs neo4j-status neo4j-load
+
+# Path to the Neo4j env file; override with: make neo4j-up NEO4J_ENV_FILE=my.env
+NEO4J_ENV_FILE ?= docker/neo4j.env
 
 # Default target
 help:
@@ -11,11 +15,19 @@ help:
 	@echo "  make clean          - Clean temporary files"
 	@echo "  make distclean      - Full clean including virtual environment"
 	@echo ""
+	@echo "Neo4j deployment (configure via $(NEO4J_ENV_FILE)):"
+	@echo "  make neo4j-up       - Start Neo4j Docker container"
+	@echo "  make neo4j-down     - Stop and remove Neo4j Docker container"
+	@echo "  make neo4j-logs     - Stream Neo4j container logs"
+	@echo "  make neo4j-status   - Show Neo4j container status"
+	@echo "  make neo4j-load     - Load data into Neo4j (reads settings from NEO4J_ENV_FILE)"
+	@echo ""
 	@echo "Usage examples:"
 	@echo "  make run            - Interactive mode (recommended)"
 	@echo "  make run-interactive - Same as 'make run'"
-	@echo "  make run-sample                         - Run with sample data (default: metta writer)"
-	@echo "  make run-sample WRITER_TYPE=prolog       - Run with sample data using prolog writer"
+	@echo "  make run-sample                    - Run with sample data (default: metta writer)"
+	@echo "  make run-sample WRITER_TYPE=prolog - Run with sample data using prolog writer"
+	@echo "  make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env"
 
 # Check if UV is installed, install via pip if not
 check-uv:
@@ -181,6 +193,35 @@ run-sample: check-uv
 		$$WRITE_PROPERTIES_FLAG \
 		$$ADD_PROVENANCE_FLAG
 	@echo "✅ Sample run completed! Check the ./output directory for results."
+# ─── Neo4j deployment targets ────────────────────────────────────────────────
+
+neo4j-up: ## Start Neo4j Docker container (reads docker/neo4j.env)
+	docker compose --env-file $(NEO4J_ENV_FILE) -f docker/docker-compose.neo4j.yml up -d
+	@echo "✅ Neo4j starting — check status with: make neo4j-status"
+
+neo4j-down: ## Stop and remove Neo4j Docker container
+	docker compose --env-file $(NEO4J_ENV_FILE) -f docker/docker-compose.neo4j.yml down
+	@echo "✅ Neo4j stopped"
+
+neo4j-logs: ## Stream Neo4j container logs
+	docker compose --env-file $(NEO4J_ENV_FILE) -f docker/docker-compose.neo4j.yml logs -f neo4j
+
+neo4j-status: ## Show Neo4j container status
+	docker compose --env-file $(NEO4J_ENV_FILE) -f docker/docker-compose.neo4j.yml ps
+
+neo4j-load: check-uv ## Load data into Neo4j (reads connection settings from NEO4J_ENV_FILE)
+	@set -a; . $(NEO4J_ENV_FILE); set +a; \
+	export PATH="$$HOME/.local/bin:$$PATH"; \
+	uv run python kg-service/neo4j_loader.py \
+		--output-dir "$$NEO4J_OUTPUT_DIR" \
+		--archive-dir "$$NEO4J_ARCHIVE_DIR" \
+		--uri "$$NEO4J_URI" \
+		--username "$$NEO4J_USERNAME" \
+		--password "$$NEO4J_PASSWORD" \
+		--import-batch-size "$${NEO4J_IMPORT_BATCH_SIZE:-50000}"
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
 # Run tests
 test: check-uv
 	@export PATH="$$HOME/.local/bin:$$PATH"; uv run pytest -v

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help setup check-uv run run-interactive run-sample run-direct test clean distclean \
-        neo4j-up neo4j-down neo4j-logs neo4j-status neo4j-load
+        neo4j-up neo4j-down neo4j-logs neo4j-status neo4j-load neo4j-load-direct
 
 # Path to the Neo4j env file; override with: make neo4j-up NEO4J_ENV_FILE=my.env
 NEO4J_ENV_FILE ?= docker/neo4j.env
@@ -16,11 +16,12 @@ help:
 	@echo "  make distclean      - Full clean including virtual environment"
 	@echo ""
 	@echo "Neo4j deployment (configure via $(NEO4J_ENV_FILE)):"
-	@echo "  make neo4j-up       - Start Neo4j Docker container"
-	@echo "  make neo4j-down     - Stop and remove Neo4j Docker container"
-	@echo "  make neo4j-logs     - Stream Neo4j container logs"
-	@echo "  make neo4j-status   - Show Neo4j container status"
-	@echo "  make neo4j-load     - Load data into Neo4j (reads settings from NEO4J_ENV_FILE)"
+	@echo "  make neo4j-up           - Start Neo4j Docker container"
+	@echo "  make neo4j-down         - Stop and remove Neo4j Docker container"
+	@echo "  make neo4j-logs         - Stream Neo4j container logs"
+	@echo "  make neo4j-status       - Show Neo4j container status"
+	@echo "  make neo4j-load         - Load data with version tracking (incremental)"
+	@echo "  make neo4j-load-direct  - Load ALL data directly, skipping version check"
 	@echo ""
 	@echo "Usage examples:"
 	@echo "  make run            - Interactive mode (recommended)"
@@ -209,7 +210,7 @@ neo4j-logs: ## Stream Neo4j container logs
 neo4j-status: ## Show Neo4j container status
 	docker compose --env-file $(NEO4J_ENV_FILE) -f docker/docker-compose.neo4j.yml ps
 
-neo4j-load: check-uv ## Load data into Neo4j (reads connection settings from NEO4J_ENV_FILE)
+neo4j-load: check-uv ## Load data with version tracking (incremental — only reloads changed datasets)
 	@set -a; . $(NEO4J_ENV_FILE); set +a; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python kg-service/neo4j_loader.py \
@@ -219,6 +220,12 @@ neo4j-load: check-uv ## Load data into Neo4j (reads connection settings from NEO
 		--username "$$NEO4J_USERNAME" \
 		--password "$$NEO4J_PASSWORD" \
 		--import-batch-size "$${NEO4J_IMPORT_BATCH_SIZE:-50000}"
+
+neo4j-load-direct: check-uv ## Load ALL data directly, skipping version check
+	@set -a; . $(NEO4J_ENV_FILE); set +a; \
+	export PATH="$$HOME/.local/bin:$$PATH"; \
+	uv run python scripts/neo4j_loader.py \
+		--env-file $(NEO4J_ENV_FILE)
 
 # ─── Tests ───────────────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -211,15 +211,9 @@ neo4j-status: ## Show Neo4j container status
 	docker compose --env-file $(NEO4J_ENV_FILE) -f docker/docker-compose.neo4j.yml ps
 
 neo4j-load: check-uv ## Load data with version tracking (incremental — only reloads changed datasets)
-	@set -a; . $(NEO4J_ENV_FILE); set +a; \
-	export PATH="$$HOME/.local/bin:$$PATH"; \
+	@export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python kg-service/neo4j_loader.py \
-		--output-dir "$$NEO4J_OUTPUT_DIR" \
-		--archive-dir "$$NEO4J_ARCHIVE_DIR" \
-		--uri "$$NEO4J_URI" \
-		--username "$$NEO4J_USERNAME" \
-		--password "$$NEO4J_PASSWORD" \
-		--import-batch-size "$${NEO4J_IMPORT_BATCH_SIZE:-50000}"
+		--env-file $(NEO4J_ENV_FILE)
 
 neo4j-load-direct: check-uv ## Load ALL data directly, skipping version check
 	@set -a; . $(NEO4J_ENV_FILE); set +a; \

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ The project template is structured as follows:
 ├── docker
 │   ├── biocypher_entrypoint_patch.sh
 │   ├── create_table.sh
-│   └── import.sh
+│   ├── import.sh
+│   ├── neo4j.env                  # Neo4j config (image, ports, paths, memory)
+│   └── docker-compose.neo4j.yml   # Parameterized Neo4j compose file
 ├── docker-compose.yml
 ├── docker-variables.env
 │
@@ -145,8 +147,10 @@ The project template is structured as follows:
 │ # Scripts
 ├── scripts
 │   ├── metta_space_import.py
-│   ├── neo4j_loader.py
 │   └── ...
+├── kg-service
+│   ├── neo4j_loader.py            # Load CSV/Cypher output into Neo4j
+│   └── version_manager.py
 │
 ├── config
 │   ├── adapters_config_sample.yaml
@@ -179,26 +183,56 @@ The project supports multiple output formats for the knowledge graph:
 2. **Prolog Writer (`prolog_writer.py`)**: Generates knowledge graph data in the Prolog format.
 3. **Neo4j CSV Writer (`neo4j_csv_writer.py`)**: Generates CSV files containing nodes and edges of the knowledge graph, along with Cypher queries to load the data into a Neo4j database.
 
-### Neo4j Loader
-To load the generated knowledge graph into a Neo4j database, use the `neo4j_loader.py` script:
+### Neo4j Deployment & Loading
+
+Configure everything in `docker/neo4j.env` (image, ports, auth, data paths, memory), then use the Makefile targets:
 
 ```bash
-python scripts/neo4j_loader.py --output-dir <path_to_output_directory>
+# Start Neo4j Docker container
+make neo4j-up
+
+# Load data (reads connection settings from docker/neo4j.env)
+make neo4j-load
+
+# Other lifecycle commands
+make neo4j-status
+make neo4j-logs
+make neo4j-down
+
+# Override the env file
+make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env
 ```
 
-#### Neo4j Loader Options
-- `--output-dir`: **Required**. Path to the directory containing the generated Cypher query files.
-- `--uri`: Optional. Neo4j database URI (default: `bolt://localhost:7687`)
-- `--username`: Optional. Neo4j username (default: `neo4j`)
+To run the loader directly:
 
-When you run the script, you'll be prompted to enter your Neo4j database password securely.
+```bash
+# Using an env file (recommended)
+python kg-service/neo4j_loader.py --env-file docker/neo4j.env
+
+# Or pass each argument explicitly
+python kg-service/neo4j_loader.py \
+  --output-dir <path_to_neo4j_output> \
+  --archive-dir <path_to_archive_dir> \
+  --uri bolt://localhost:7887 \
+  --username neo4j \
+  --password <password>
+```
+
+#### Loader options
+| Flag | Env var | Description |
+|---|---|---|
+| `--env-file` | — | Load all settings from a `neo4j.env` file |
+| `--output-dir` | `NEO4J_OUTPUT_DIR` | Directory with generated CSV + Cypher files |
+| `--archive-dir` | `NEO4J_ARCHIVE_DIR` | Archive directory for version management |
+| `--uri` | `NEO4J_URI` | Neo4j bolt URI |
+| `--username` | `NEO4J_USERNAME` | Neo4j username (default: `neo4j`) |
+| `--password` | `NEO4J_PASSWORD` | Neo4j password |
+| `--import-batch-size` | `NEO4J_IMPORT_BATCH_SIZE` | APOC batch size (default: `50000`) |
+| `--import-dir` | — | Absolute path prefix for `file:///` URLs (non-Docker use only) |
 
 **Notes:**
-- Ensure your Neo4j database is running before executing the loader.
-- The script will automatically find and process all Cypher query files (node and edge files) in the specified output directory.
-- It supports processing multiple directories containing Cypher files.
-- The loader creates constraints and loads data in a single session.
-- Logging is provided to help you track the loading process.
+- The loader detects changed files via hash comparison and only reloads what changed.
+- Edges use `CREATE` (not `MERGE`) — the loader surgically deletes changed edges before reloading, so the existence check is unnecessary and very slow on large files.
 
 ## ⬇ Downloading data
 The `downloader` directory contains code for downloading data from various sources.

--- a/README.md
+++ b/README.md
@@ -148,8 +148,11 @@ The project template is structured as follows:
 ├── scripts
 │   ├── metta_space_import.py
 │   └── ...
+├── scripts
+│   ├── neo4j_loader.py            # Direct loader — no versioning (make neo4j-load-direct)
+│   └── ...
 ├── kg-service
-│   ├── neo4j_loader.py            # Load CSV/Cypher output into Neo4j
+│   ├── neo4j_loader.py            # Versioned/incremental loader (make neo4j-load)
 │   └── version_manager.py
 │
 ├── config
@@ -191,7 +194,10 @@ Configure everything in `docker/neo4j.env` (image, ports, auth, data paths, memo
 # Start Neo4j Docker container
 make neo4j-up
 
-# Load data (reads connection settings from docker/neo4j.env)
+# Load ALL data directly — no version checking (use for first run or fresh container)
+make neo4j-load-direct
+
+# Load incrementally — only reloads datasets whose files have changed
 make neo4j-load
 
 # Other lifecycle commands
@@ -203,13 +209,16 @@ make neo4j-down
 make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env
 ```
 
-To run the loader directly:
+To run the loaders directly:
 
 ```bash
-# Using an env file (recommended)
+# Direct load (no versioning) — using an env file
+python scripts/neo4j_loader.py --env-file docker/neo4j.env
+
+# Versioned/incremental load — using an env file
 python kg-service/neo4j_loader.py --env-file docker/neo4j.env
 
-# Or pass each argument explicitly
+# Versioned load — explicit args
 python kg-service/neo4j_loader.py \
   --output-dir <path_to_neo4j_output> \
   --archive-dir <path_to_archive_dir> \

--- a/README.md
+++ b/README.md
@@ -146,10 +146,8 @@ The project template is structured as follows:
 │ 
 │ # Scripts
 ├── scripts
-│   ├── metta_space_import.py
-│   └── ...
-├── scripts
 │   ├── neo4j_loader.py            # Direct loader — no versioning (make neo4j-load-direct)
+│   ├── metta_space_import.py
 │   └── ...
 ├── kg-service
 │   ├── neo4j_loader.py            # Versioned/incremental loader (make neo4j-load)

--- a/biocypher_metta/neo4j_csv_writer.py
+++ b/biocypher_metta/neo4j_csv_writer.py
@@ -350,13 +350,13 @@ class Neo4jCSVWriter(BaseWriter):
         return edge_freq
 
     def write_node_cypher(self, label, csv_path, cypher_path):
-        absolute_path = csv_path.resolve().as_posix()
-    
+        relative_path = csv_path.relative_to(self.output_path).as_posix()
+
         cypher_query = f"""
 CREATE CONSTRAINT IF NOT EXISTS FOR (n:{label}) REQUIRE n.id IS UNIQUE;
 
 CALL apoc.periodic.iterate(
-    "LOAD CSV WITH HEADERS FROM 'file:///{absolute_path}' AS row FIELDTERMINATOR '{self.csv_delimiter}' RETURN row",
+    "LOAD CSV WITH HEADERS FROM 'file:///{relative_path}' AS row FIELDTERMINATOR '{self.csv_delimiter}' RETURN row",
     "MERGE (n:{label} {{id: row.id}})
     SET n += apoc.map.removeKeys(row, ['id'])",
     {{batchSize:1000, parallel:true, concurrency:4}}
@@ -368,11 +368,11 @@ RETURN batches, total;
             f.write(cypher_query)
 
     def write_edge_cypher(self, edge_label, source_type, target_type, csv_path, cypher_path):
-        absolute_path = csv_path.resolve().as_posix()
-    
+        relative_path = csv_path.relative_to(self.output_path).as_posix()
+
         cypher_query = f"""
 CALL apoc.periodic.iterate(
-    "LOAD CSV WITH HEADERS FROM 'file:///{absolute_path}' AS row FIELDTERMINATOR '{self.csv_delimiter}' RETURN row",
+    "LOAD CSV WITH HEADERS FROM 'file:///{relative_path}' AS row FIELDTERMINATOR '{self.csv_delimiter}' RETURN row",
     "MATCH (source:{source_type} {{id: row.source_id}})
     MATCH (target:{target_type} {{id: row.target_id}})
     MERGE (source)-[r:{edge_label}]->(target)

--- a/biocypher_metta/neo4j_csv_writer.py
+++ b/biocypher_metta/neo4j_csv_writer.py
@@ -375,7 +375,7 @@ CALL apoc.periodic.iterate(
     "LOAD CSV WITH HEADERS FROM 'file:///{relative_path}' AS row FIELDTERMINATOR '{self.csv_delimiter}' RETURN row",
     "MATCH (source:{source_type} {{id: row.source_id}})
     MATCH (target:{target_type} {{id: row.target_id}})
-    MERGE (source)-[r:{edge_label}]->(target)
+    CREATE (source)-[r:{edge_label}]->(target)
     SET r += apoc.map.removeKeys(row, ['source_id', 'target_id', 'label', 'source_type', 'target_type'])",
     {{batchSize:1000}}
 )

--- a/docker/docker-compose.neo4j.yml
+++ b/docker/docker-compose.neo4j.yml
@@ -1,0 +1,51 @@
+version: "3.9"
+
+# Load defaults from docker/neo4j.env via:
+#   docker compose --env-file docker/neo4j.env -f docker/docker-compose.neo4j.yml up -d
+# Or use the Makefile targets:
+#   make neo4j-up / neo4j-down / neo4j-load / neo4j-logs / neo4j-status
+
+services:
+  neo4j:
+    image: ${NEO4J_IMAGE:-neo4j:5.21}
+    container_name: ${NEO4J_CONTAINER:-neo4j_bio_atomspace}
+    restart: always
+    ports:
+      - "${NEO4J_HTTP_PORT:-7674}:7474"
+      - "${NEO4J_BOLT_PORT:-7887}:7687"
+
+    environment:
+      NEO4J_AUTH: "${NEO4J_AUTH:-neo4j/neo4j}"
+
+      # APOC plugin
+      NEO4JLABS_PLUGINS: '["apoc"]'
+      NEO4J_apoc_export_file_enabled: "true"
+      NEO4J_apoc_import_file_enabled: "true"
+      # Allow APOC LOAD CSV to resolve file:///relative.csv against /import
+      # (rather than the internal Neo4j home path)
+      NEO4J_apoc_import_file_use__neo4j__config: "false"
+
+      # Procedure permissions
+      NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
+      NEO4J_dbms_security_procedures_allowlist: "apoc.*"
+
+      # Map /import as the LOAD CSV root
+      NEO4J_dbms_directories_import: "/import"
+
+      # Memory tuning
+      NEO4J_dbms_memory_pagecache_size: "${NEO4J_PAGECACHE:-4G}"
+      NEO4J_dbms_memory_heap_initial__size: "${NEO4J_HEAP_INIT:-2G}"
+      NEO4J_dbms_memory_heap_max__size: "${NEO4J_HEAP_MAX:-4G}"
+
+    volumes:
+      # Neo4j output dir is mounted read-only as the LOAD CSV import root
+      - ${NEO4J_OUTPUT_DIR}:/import:ro
+      # Persistent storage
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+      - neo4j_plugins:/plugins
+
+volumes:
+  neo4j_data:
+  neo4j_logs:
+  neo4j_plugins:

--- a/docker/neo4j.env
+++ b/docker/neo4j.env
@@ -1,0 +1,29 @@
+# ─── Neo4j image & container ────────────────────────────────────────────────
+NEO4J_IMAGE=neo4j:5.21
+NEO4J_CONTAINER=neo4j_bio_atomspace
+
+# ─── Ports (host side) ──────────────────────────────────────────────────────
+NEO4J_HTTP_PORT=7674
+NEO4J_BOLT_PORT=7887
+
+# ─── Auth ───────────────────────────────────────────────────────────────────
+# Format: username/password
+NEO4J_AUTH=neo4j/password123
+
+# ─── Data paths (host filesystem) ───────────────────────────────────────────
+# Path to the neo4j output directory (mounted as /import inside the container)
+NEO4J_OUTPUT_DIR=/mnt/hdd_1/biocypher-kg/output/hsa/neo4j_out_v6
+# Archive directory for version management
+NEO4J_ARCHIVE_DIR=/mnt/hdd_1/biocypher-kg/output/hsa/biocypher-archives
+
+# ─── Memory tuning ──────────────────────────────────────────────────────────
+NEO4J_PAGECACHE=4G
+NEO4J_HEAP_INIT=2G
+NEO4J_HEAP_MAX=4G
+
+# ─── Loader connection settings ─────────────────────────────────────────────
+# URI must use the BOLT port mapped above
+NEO4J_URI=bolt://localhost:7887
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=password123
+NEO4J_IMPORT_BATCH_SIZE=50000

--- a/docker/neo4j.env.example
+++ b/docker/neo4j.env.example
@@ -1,3 +1,6 @@
+# Copy this file to docker/neo4j.env and fill in your values.
+# docker/neo4j.env is gitignored to avoid committing credentials/host paths.
+
 # ─── Neo4j image & container ────────────────────────────────────────────────
 NEO4J_IMAGE=neo4j:5.21
 NEO4J_CONTAINER=neo4j_bio_atomspace
@@ -8,13 +11,13 @@ NEO4J_BOLT_PORT=7887
 
 # ─── Auth ───────────────────────────────────────────────────────────────────
 # Format: username/password
-NEO4J_AUTH=neo4j/password123
+NEO4J_AUTH=neo4j/your_password_here
 
 # ─── Data paths (host filesystem) ───────────────────────────────────────────
 # Path to the neo4j output directory (mounted as /import inside the container)
-NEO4J_OUTPUT_DIR=/mnt/hdd_1/biocypher-kg/output/hsa/neo4j_out_v6
+NEO4J_OUTPUT_DIR=/path/to/your/neo4j_output
 # Archive directory for version management
-NEO4J_ARCHIVE_DIR=/mnt/hdd_1/biocypher-kg/output/hsa/biocypher-archives
+NEO4J_ARCHIVE_DIR=/path/to/your/biocypher-archives
 
 # ─── Memory tuning ──────────────────────────────────────────────────────────
 NEO4J_PAGECACHE=4G
@@ -25,5 +28,5 @@ NEO4J_HEAP_MAX=4G
 # URI must use the BOLT port mapped above
 NEO4J_URI=bolt://localhost:7887
 NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=password123
+NEO4J_PASSWORD=your_password_here
 NEO4J_IMPORT_BATCH_SIZE=50000

--- a/kg-service/neo4j_loader.py
+++ b/kg-service/neo4j_loader.py
@@ -591,15 +591,18 @@ class Neo4jLoader:
 
 def _load_env_file(path: str) -> dict:
     """Parse a simple KEY=VALUE env file, ignoring comments and blanks."""
-    env = {}
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#') or '=' not in line:
-                continue
-            key, _, value = line.partition('=')
-            env[key.strip()] = value.strip()
-    return env
+    try:
+        env = {}
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, _, value = line.partition('=')
+                env[key.strip()] = value.strip()
+        return env
+    except OSError as e:
+        raise SystemExit(f"error: cannot read env file '{path}': {e}")
 
 
 def main():
@@ -641,19 +644,23 @@ def main():
         env = _load_env_file(args.env_file)
         logger.info(f"Loaded config from {args.env_file}")
 
-    def resolve(cli_val, env_key, default=None, required=False):
-        val = cli_val or env.get(env_key) or default
-        if required and not val:
-            parser.error(f"--{env_key.lower().replace('_', '-')} is required "
-                         f"(or set {env_key} in --env-file)")
+    def resolve(cli_val, env_key, flag, default=None, required=False):
+        if cli_val is not None:
+            val = cli_val
+        elif env_key in env:
+            val = env[env_key]
+        else:
+            val = default
+        if required and (val is None or val == ""):
+            parser.error(f"{flag} is required (or set {env_key} in --env-file)")
         return val
 
-    output_dir  = resolve(args.output_dir,  "NEO4J_OUTPUT_DIR",  required=True)
-    archive_dir = resolve(args.archive_dir, "NEO4J_ARCHIVE_DIR", required=True)
-    uri         = resolve(args.uri,         "NEO4J_URI",         required=True)
-    username    = resolve(args.username,    "NEO4J_USERNAME",    default="neo4j")
-    password    = resolve(args.password,    "NEO4J_PASSWORD",    required=True)
-    batch_size  = int(resolve(args.import_batch_size, "NEO4J_IMPORT_BATCH_SIZE", default=50000))
+    output_dir  = resolve(args.output_dir,         "NEO4J_OUTPUT_DIR",         "--output-dir",         required=True)
+    archive_dir = resolve(args.archive_dir,         "NEO4J_ARCHIVE_DIR",        "--archive-dir",        required=True)
+    uri         = resolve(args.uri,                 "NEO4J_URI",                "--uri",                required=True)
+    username    = resolve(args.username,            "NEO4J_USERNAME",           "--username",           default="neo4j")
+    password    = resolve(args.password,            "NEO4J_PASSWORD",           "--password",           required=True)
+    batch_size  = int(resolve(args.import_batch_size, "NEO4J_IMPORT_BATCH_SIZE", "--import-batch-size", default=50000))
 
     loader = Neo4jLoader(
         uri,

--- a/kg-service/neo4j_loader.py
+++ b/kg-service/neo4j_loader.py
@@ -291,12 +291,6 @@ class Neo4jLoader:
                 content
             )
 
-            # USE CREATE INSTEAD OF MERGE FOR EDGE FILES
-            # Edges are always surgically deleted before reloading, so MERGE's
-            # expensive existence check is unnecessary and causes Java heap OOM
-            # on large files (e.g. gtex eqtl: 67M rows). CREATE is correct here.
-            if cypher_file.name.startswith("edges_"):
-                content = re.sub(r'\bMERGE\s*\((\w+)\)-\[', r'CREATE (\1)-[', content)
 
             queries = []
             current_query = []

--- a/kg-service/neo4j_loader.py
+++ b/kg-service/neo4j_loader.py
@@ -14,11 +14,15 @@ logger = logging.getLogger(__name__)
 
 class Neo4jLoader:
     def __init__(self, uri, username, password, output_dir, archive_dir,
-                 import_batch_size: int = 50000):
+                 import_batch_size: int = 50000, import_dir: str = None):
         self.driver = GraphDatabase.driver(uri, auth=(username, password))
         self.output_dir = Path(output_dir)
         self.archive_dir = Path(archive_dir)
         self.import_batch_size = import_batch_size
+        # Optional: absolute path prefix injected into file:/// URLs.
+        # Use when Neo4j's import dir is NOT configured to the output dir
+        # (e.g. non-Docker Neo4j). Leave None for Docker (where /import is mounted).
+        self.import_dir = import_dir.rstrip('/') if import_dir else None
         
         self.version_manager = VersionManager(
             archive_dir=archive_dir,      
@@ -259,11 +263,18 @@ class Neo4jLoader:
             with open(cypher_file, 'r') as f:
                 content = f.read()
 
-            # FIX PATHS
-            content = content.replace(
-                f'file:///{str(self.output_dir)}/',
-                'file:///'
-            )
+            # BACKWARD COMPAT: old-style cypher files embed the absolute host path
+            # (file:////absolute/path/to/output/subdir/file.csv). Strip it down to a
+            # relative path so the same logic below applies to both old and new files.
+            old_prefix = f'file:///{str(self.output_dir)}/'
+            if old_prefix in content:
+                content = content.replace(old_prefix, 'file:///')
+
+            # INJECT IMPORT DIR: for non-Docker Neo4j where the import dir is not
+            # configured to the output dir, prepend the absolute path so Neo4j can
+            # resolve the file. Leave as-is for Docker (file:///relative → /import/relative).
+            if self.import_dir:
+                content = content.replace('file:///', f'file:///{self.import_dir}/')
 
             # BOOST BATCH SIZE: dynamically replace whatever small batchSize was baked
             # into the .cypher file with the configured import_batch_size.
@@ -584,41 +595,80 @@ class Neo4jLoader:
         return len(failed_files) == 0
 
 
+def _load_env_file(path: str) -> dict:
+    """Parse a simple KEY=VALUE env file, ignoring comments and blanks."""
+    env = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            env[key.strip()] = value.strip()
+    return env
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Load BioCypher data to Neo4j with version management"
     )
-    parser.add_argument("--output-dir", required=True,
-                        help="BioCypher output directory")
-    parser.add_argument("--archive-dir", 
-                        default="/mnt/hdd_1/biocypher-kg/output/human/biocypher-archives",
-                        help="Archive directory")
-    parser.add_argument("--uri", 
-                        default="bolt://localhost:27688",
-                        help="Neo4j URI")
-    parser.add_argument("--username", 
-                        default="neo4j",
-                        help="Neo4j username")
-    parser.add_argument("--password", 
-                        required=True,
-                        help="Neo4j password")
+    parser.add_argument("--env-file",
+                        default=None,
+                        help="Path to a neo4j.env file. Values are used as defaults "
+                             "and can be overridden by explicit CLI flags.")
+    parser.add_argument("--output-dir",
+                        help="BioCypher output directory (env: NEO4J_OUTPUT_DIR)")
+    parser.add_argument("--archive-dir",
+                        help="Archive directory for version management (env: NEO4J_ARCHIVE_DIR)")
+    parser.add_argument("--uri",
+                        help="Neo4j bolt URI, e.g. bolt://localhost:7887 (env: NEO4J_URI)")
+    parser.add_argument("--username",
+                        help="Neo4j username (env: NEO4J_USERNAME, default: neo4j)")
+    parser.add_argument("--password",
+                        help="Neo4j password (env: NEO4J_PASSWORD)")
     parser.add_argument("--build-id",
                         default=f"build-{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}",
                         help="Build ID")
     parser.add_argument("--import-batch-size",
                         type=int,
-                        default=50000,
-                        help="APOC batchSize for LOAD CSV and metadata operations (default: 50000). "
+                        help="APOC batchSize for LOAD CSV and metadata operations "
+                             "(env: NEO4J_IMPORT_BATCH_SIZE, default: 50000). "
                              "Increase for faster loading on high-memory servers.")
+    parser.add_argument("--import-dir",
+                        default=None,
+                        help="Absolute host path to inject into file:/// URLs. "
+                             "Use for non-Docker Neo4j where the import dir is not "
+                             "configured to the output dir. Omit when running via Docker.")
     args = parser.parse_args()
 
+    # Merge env-file values: CLI flags take precedence over env-file
+    env = {}
+    if args.env_file:
+        env = _load_env_file(args.env_file)
+        logger.info(f"Loaded config from {args.env_file}")
+
+    def resolve(cli_val, env_key, default=None, required=False):
+        val = cli_val or env.get(env_key) or default
+        if required and not val:
+            parser.error(f"--{env_key.lower().replace('_', '-')} is required "
+                         f"(or set {env_key} in --env-file)")
+        return val
+
+    output_dir  = resolve(args.output_dir,  "NEO4J_OUTPUT_DIR",  required=True)
+    archive_dir = resolve(args.archive_dir, "NEO4J_ARCHIVE_DIR", required=True)
+    uri         = resolve(args.uri,         "NEO4J_URI",         required=True)
+    username    = resolve(args.username,    "NEO4J_USERNAME",    default="neo4j")
+    password    = resolve(args.password,    "NEO4J_PASSWORD",    required=True)
+    batch_size  = int(resolve(args.import_batch_size, "NEO4J_IMPORT_BATCH_SIZE", default=50000))
+
     loader = Neo4jLoader(
-        args.uri,
-        args.username,
-        args.password,
-        args.output_dir,
-        args.archive_dir,
-        import_batch_size=args.import_batch_size
+        uri,
+        username,
+        password,
+        output_dir,
+        archive_dir,
+        import_batch_size=batch_size,
+        import_dir=args.import_dir,
     )
 
     try:
@@ -630,6 +680,7 @@ def main():
 
     finally:
         loader.close()
+
 
 
 if __name__ == "__main__":

--- a/kg-service/neo4j_loader.py
+++ b/kg-service/neo4j_loader.py
@@ -291,6 +291,12 @@ class Neo4jLoader:
                 content
             )
 
+            # USE CREATE INSTEAD OF MERGE FOR EDGE FILES
+            # Edges are always surgically deleted before reloading, so MERGE's
+            # expensive existence check is unnecessary and causes Java heap OOM
+            # on large files (e.g. gtex eqtl: 67M rows). CREATE is correct here.
+            if cypher_file.name.startswith("edges_"):
+                content = re.sub(r'\bMERGE\s*\((\w+)\)-\[', r'CREATE (\1)-[', content)
 
             queries = []
             current_query = []

--- a/kg-service/version_manager.py
+++ b/kg-service/version_manager.py
@@ -371,8 +371,12 @@ class VersionManager:
         changed_files = []
         for dataset in changed_datasets:
             folder = self.output_dir / dataset
-            for csv_file in sorted(folder.rglob("*.csv")):
-                changed_files.append(str(csv_file.relative_to(self.output_dir)))
+            if dataset == "root":
+                for csv_file in sorted(self.output_dir.glob("*.csv")):
+                    changed_files.append(str(csv_file.relative_to(self.output_dir)))
+            else:
+                for csv_file in sorted(folder.rglob("*.csv")):
+                    changed_files.append(str(csv_file.relative_to(self.output_dir)))
 
         # Return tuple format expected by neo4j_loader.py
         return (new_atomspace_version, new_dataset_versions, changed_datasets, changed_files)
@@ -467,7 +471,7 @@ if __name__ == "__main__":
         result = vm.check_and_version(args.output_dir)
 
         if result[0] is not None:
-            new_version, dataset_versions, changed = result
+            new_version, dataset_versions, changed, _changed_files = result
             print("\n" + "="*60)
             print("VERSION CHECK RESULT:")
             print("="*60)

--- a/kg-service/version_manager.py
+++ b/kg-service/version_manager.py
@@ -318,7 +318,7 @@ class VersionManager:
         current_hashes = self.hash_all_datasets()
         if not current_hashes:
             logger.error("No CSV files found!")
-            return (None, None, None)
+            return (None, None, None, None)
 
         # Step 2: Get stored hashes
         stored_hashes = self.get_stored_hashes()
@@ -348,7 +348,7 @@ class VersionManager:
         # Step 5: No changes?
         if not changed_datasets:
             logger.info("✅ No changes detected - nothing to load!")
-            return (None, None, None)
+            return (None, None, None, None)
 
         # Step 6: Discover sources
         logger.info("Discovering source names from CSV files...")
@@ -366,8 +366,16 @@ class VersionManager:
 
         logger.info(f"AtomSpace version: {current_atomspace_version or 'None'} → {new_atomspace_version}")
 
+        # Build per-file list for changed datasets (relative paths like "gaf/edges_foo.csv")
+        # neo4j_loader uses these for per-relationship surgical deletes and file-level loading.
+        changed_files = []
+        for dataset in changed_datasets:
+            folder = self.output_dir / dataset
+            for csv_file in sorted(folder.rglob("*.csv")):
+                changed_files.append(str(csv_file.relative_to(self.output_dir)))
+
         # Return tuple format expected by neo4j_loader.py
-        return (new_atomspace_version, new_dataset_versions, changed_datasets)
+        return (new_atomspace_version, new_dataset_versions, changed_datasets, changed_files)
 
     def finalize_version(self, output_dir, atomspace_version, dataset_versions, 
                          changed_datasets, build_id):

--- a/scripts/neo4j_loader.py
+++ b/scripts/neo4j_loader.py
@@ -109,15 +109,18 @@ class Neo4jLoader:
         }
 
 def _load_env_file(path):
-    env = {}
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#') or '=' not in line:
-                continue
-            k, _, v = line.partition('=')
-            env[k.strip()] = v.strip()
-    return env
+    try:
+        env = {}
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                k, _, v = line.partition('=')
+                env[k.strip()] = v.strip()
+        return env
+    except OSError as e:
+        raise SystemExit(f"error: cannot read env file '{path}': {e}")
 
 
 def get_neo4j_credentials():

--- a/scripts/neo4j_loader.py
+++ b/scripts/neo4j_loader.py
@@ -108,28 +108,53 @@ class Neo4jLoader:
             'edges': sorted(directory.glob("edges_*.cypher"))
         }
 
+def _load_env_file(path):
+    env = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            k, _, v = line.partition('=')
+            env[k.strip()] = v.strip()
+    return env
+
+
 def get_neo4j_credentials():
     parser = argparse.ArgumentParser(description='Load data into Neo4j database')
-    parser.add_argument('--output-dir', required=True, help='Path to the output directory')
-    parser.add_argument('--uri', default="bolt://localhost:7687", help='Neo4j URI (default: bolt://localhost:7687)')
-    parser.add_argument('--username', default="neo4j", help='Neo4j username (default: neo4j)')
-    
+    parser.add_argument('--output-dir', help='Path to the output directory')
+    parser.add_argument('--uri', default="bolt://localhost:7687", help='Neo4j URI')
+    parser.add_argument('--username', default="neo4j", help='Neo4j username')
+    parser.add_argument('--password', default=None, help='Neo4j password (falls back to interactive prompt)')
+    parser.add_argument('--env-file', default=None, help='Path to neo4j.env to load connection settings from')
+
+    # Pre-parse to detect --env-file, then set argparse defaults from it
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument('--env-file', default=None)
+    pre_args, _ = pre.parse_known_args()
+    if pre_args.env_file:
+        env = _load_env_file(pre_args.env_file)
+        parser.set_defaults(
+            uri=env.get('NEO4J_URI', 'bolt://localhost:7687'),
+            username=env.get('NEO4J_USERNAME', 'neo4j'),
+            password=env.get('NEO4J_PASSWORD'),
+            output_dir=env.get('NEO4J_OUTPUT_DIR'),
+        )
+
     args = parser.parse_args()
-    
-    max_attempts = 3
-    for attempt in range(max_attempts):
-        password = getpass.getpass('Enter Neo4j password: ')
-        loader = Neo4jLoader(args.uri, args.username, password)
-        
-        if loader.connect():
-            loader.close()  # Close the test connection
-            return args.uri, args.username, password, args.output_dir
-        
-        if attempt < max_attempts - 1:
-            logger.error(f"Authentication failed. {max_attempts - attempt - 1} attempts remaining.")
-    
-    logger.error("Maximum authentication attempts reached. Exiting.")
-    sys.exit(1)
+
+    if not args.output_dir:
+        parser.error('--output-dir is required (or set NEO4J_OUTPUT_DIR in --env-file)')
+
+    password = args.password or getpass.getpass('Enter Neo4j password: ')
+
+    loader = Neo4jLoader(args.uri, args.username, password)
+    if not loader.connect():
+        logger.error("Failed to connect to Neo4j.")
+        sys.exit(1)
+    loader.close()
+
+    return args.uri, args.username, password, args.output_dir
 
 def process_output_directory(output_dir):
     output_path = Path(output_dir)


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [x] New processor / Processor fix
- [ ] Schema change
- [ ] Adapters config change
- [x] Writer fix / update
- [ ] CI / workflow change
- [x] Bug fix / Refactor

---

## Summary

- **Writer fix**: `neo4j_csv_writer.py` now writes `file:///relative/path.csv` in generated cypher files (relative to output root) instead of baking in the absolute host path — making them portable across environments and Docker without any workaround
- **Config file**: `docker/neo4j.env` is the single source of truth for Neo4j image, ports, auth, data paths, and memory — edit once, all tools pick it up
- **Docker compose**: `docker/docker-compose.neo4j.yml` is fully parameterized; mounts `$NEO4J_OUTPUT_DIR` as `/import` and configures APOC to resolve relative cypher paths correctly
- **Loader improvements**: `neo4j_loader.py` gains `--env-file` (load all settings from `.env`), `--import-dir` (non-Docker path injection), removes hardcoded host paths from defaults, and keeps backward compat for old absolute-path cypher files
- **Makefile targets**: `make neo4j-up/down/logs/status/load` — full Neo4j lifecycle from one place
- **`make neo4j-load-direct`**: new Makefile target that loads all datasets immediately via `scripts/neo4j_loader.py` — no hashing, no versioning, no surgical delete. Use this for first runs or fresh containers. `make neo4j-load` remains the incremental option that only reloads what changed.
- **`scripts/neo4j_loader.py`**: added `--env-file` and `--password` args so it can be called non-interactively from Make (previously blocked on `getpass` prompt).
- **Edge `MERGE` → `CREATE`**: the writer now emits `CREATE` for edges directly instead of `MERGE`. Edges are always surgically deleted before reloading so the existence check was pure overhead — and caused heap OOM on large files (e.g. GTEx eQTL, 67M rows). The runtime regex patch in the loader is removed since the writer is now correct.
- Bug fixes **Version manager 3→4 tuple mismatch**: `version_manager.check_and_version()` was returning a 3-tuple but `neo4j_loader.load_all()` unpacked 4 values — every run crashed with `ValueError: not enough values to unpack` immediately after the dataset hashing step. Fixed by having the version manager enumerate per-file CSV paths from changed dataset folders and return them as the 4th element (`changed_files`).

## Usage

```bash
# 1. Edit docker/neo4j.env for your environment
# 2. Start Neo4j
make neo4j-up

# 3. Load data
make neo4j-load   # with versioning

make neo4j-load-direct    # direct load to an instance without versioning 

# 4. Monitor
make neo4j-status
make neo4j-logs

# Override env file per invocation
make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env
```

---

## Checklist

### General
- [x] PR targets `main` and branch is up to date
- [x] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
- [x] No credentials, tokens, or real patient data committed

### New adapter
- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently

### Schema changes
- [ ] New labels are validated against BioCypher / Biolink expectations
- [ ] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
- [ ] Breaking label, schema, or adapter-arg changes are called out below

### Testing
- [x] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
- [x] Ran additional focused checks relevant to the change
- [ ] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
- [ ] Spot-checked output node / edge labels and counts where relevant


