### PR TITLE
feat: Enforce schema-defined edge types across writers, adapters, and configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,7 @@ my relationship:
   is_a: related to
   label_as_edge: my_relationship   # used in graph databases
   input_label: my_relationship     # must match the label you yield in get_edges()
+  output_label: my_relationship    # optional — overrides input_label in output files/graphs
   source: my entity                # must match a declared node input_label
   target: gene                     # must match a declared node input_label
   properties:
@@ -234,6 +235,39 @@ my relationship:
       type: str
     source_url:
       type: str
+```
+
+**Schema enforcement:** Every label yielded by an adapter is validated against the schema at runtime. If the label is not defined, the pipeline raises a `ValueError` immediately. Make sure `input_label` in the schema exactly matches the label string your adapter yields (or the value passed via `label` / `anatomy_label` / `pathway_label` / `reaction_label` args).
+
+**Splitting related edge types:** When a data source covers multiple biologically distinct relationships (e.g. a protein can be an input, output, or catalyst in a reaction), define a separate schema entry for each and give the adapter a dedicated label parameter rather than a single hardcoded label:
+
+```yaml
+# In schema config
+input role protein to pathway association:
+  represented_as: edge
+  input_label: input_role_protein_to_pathway_association
+  source: protein
+  target: pathway
+  ...
+
+catalyst protein to pathway association:
+  represented_as: edge
+  input_label: catalyst_protein_to_pathway_association
+  source: protein
+  target: pathway
+  ...
+```
+
+```yaml
+# In adapters config — one entry per role
+reactome_input_pathway:
+  adapter:
+    module: biocypher_metta.adapters.reactome_inference_edges_adapter
+    cls: ReactomeInferenceEdgesAdapter
+    args:
+      label: input
+      pathway_label: input_role_protein_to_pathway_association
+      reaction_label: input_role_protein_to_reaction_association
 ```
 
 ### 5.3 Finding valid Biolink parent classes

--- a/biocypher_metta/__init__.py
+++ b/biocypher_metta/__init__.py
@@ -25,6 +25,9 @@ class BaseWriter(ABC):
         self.valid_edge_labels = set()
         self._get_valid_labels()
 
+        self._valid_edge_type_combos = defaultdict(set)
+        self._build_edge_type_combos()
+
     def _get_valid_labels(self):
         schema = self.bcy._get_ontology_mapping()._extend_schema()
         for k, v in schema.items():
@@ -52,6 +55,39 @@ class BaseWriter(ABC):
     def check_edge_label(self, label):
         normalized_label = self.normalize_label(label)
         return normalized_label in self.valid_edge_labels
+
+    def _build_edge_type_combos(self):
+        schema = self.bcy._get_ontology_mapping()._extend_schema()
+        for k, v in schema.items():
+            if v.get("represented_as") != "edge":
+                continue
+            raw_label = v.get("input_label", "")
+            labels = raw_label if isinstance(raw_label, list) else [raw_label]
+            source = v.get("source")
+            target = v.get("target")
+            if source and target:
+                src_list = source if isinstance(source, list) else [source]
+                tgt_list = target if isinstance(target, list) else [target]
+                for lbl in labels:
+                    for src in src_list:
+                        for tgt in tgt_list:
+                            self._valid_edge_type_combos[self.normalize_label(lbl)].add(
+                                (self.normalize_label(src), self.normalize_label(tgt))
+                            )
+
+    def validate_edge_types(self, label, source_type, target_type):
+        """Raise ValueError when (source_type, target_type) is not a valid schema combo for label."""
+        combos = self._valid_edge_type_combos.get(self.normalize_label(label))
+        if not combos:
+            return
+        norm = (self.normalize_label(source_type), self.normalize_label(target_type))
+        if norm not in combos:
+            valid_str = ", ".join(f"({s}, {t})" for s, t in sorted(combos))
+            raise ValueError(
+                f"Edge '{label}': types (source='{source_type}', target='{target_type}') "
+                f"are not defined in the schema. Valid combos: {valid_str}. "
+                f"Update the adapter to use a defined input_label, or add a schema definition."
+            )
 
     @abstractmethod
     def write_nodes(self, nodes, path_prefix=None, create_dir=True):

--- a/biocypher_metta/adapters/bgee_adapter.py
+++ b/biocypher_metta/adapters/bgee_adapter.py
@@ -32,12 +32,15 @@ class BgeeAdapter(Adapter):
         9606: 'ENSEMBL',
     }
 
-    def __init__(self, filepath, write_properties, add_provenance, taxon_id, label):
+    def __init__(self, filepath, write_properties, add_provenance, taxon_id, label,
+                 anatomy_label=None, developmental_stage_label=None):
         self.filepath = filepath
         self.label = label
+        self.anatomy_label = anatomy_label or 'gene_expressed_in_anatomy'
+        self.developmental_stage_label = developmental_stage_label or 'gene_expressed_in_developmental_stage'
         self.taxon_id = taxon_id
 
-        self.source = 'bgee' 
+        self.source = 'bgee'
         self.source_url = f"https://www.bgee.org/download/gene-expression-calls?id={self.taxon_id}"
         super(BgeeAdapter, self).__init__(write_properties, add_provenance)
     
@@ -88,11 +91,11 @@ class BgeeAdapter(Adapter):
 
             # Yield deduplicated edges
             for (source_id, target_id), edge_data in edge_dict.items():
-                yield source_id, ('anatomy', target_id), self.label, edge_data["props"]
+                yield source_id, target_id, self.anatomy_label, edge_data["props"]
                 dev_stage_id = edge_data['props'].get('developmental_stage')
                 if dev_stage_id:
                     dev_props = {k: v for k, v in edge_data["props"].items() if k != 'developmental_stage'}
-                    yield source_id, ('developmental_stage', dev_stage_id), self.label, dev_props
+                    yield source_id, dev_stage_id, self.developmental_stage_label, dev_props
 
         except OSError as e:
             raise RuntimeError(f"Error opening the bgee file '{self.filepath}': {e}") from e

--- a/biocypher_metta/adapters/dmel/expressed_in_adapter.py
+++ b/biocypher_metta/adapters/dmel/expressed_in_adapter.py
@@ -38,9 +38,17 @@ class ExpressedInAdapter(Adapter):
         'go': ['biological_process', 'molecular_function', 'cellular_component'],
     }
 
+    TARGET_TYPE_TO_LABEL = {
+        'anatomy': 'gene_expressed_in_anatomy',
+        'developmental_stage': 'gene_expressed_in_developmental_stage',
+        'phenotype': 'gene_expressed_in_phenotype',
+        'biological_process': 'gene_expressed_in_biological_process',
+        'molecular_function': 'gene_expressed_in_molecular_function',
+        'cellular_component': 'gene_expressed_in_cellular_component',
+    }
+
     def __init__(self, write_properties, add_provenance, filepath, go_subontology_processor=None):
         self.filepath = filepath
-        self.label = 'expressed_in'
         self.source = 'FLYBASE'
         self.source_url = 'https://flybase.org/'
 
@@ -85,6 +93,9 @@ class ExpressedInAdapter(Adapter):
             if self.add_provenance:
                 props['source'] = self.source
                 props['source_url'] = self.source_url
-            yield source, (target_type, f'FlyBase:{target}'), self.label, props
+            edge_label = ExpressedInAdapter.TARGET_TYPE_TO_LABEL.get(target_type)
+            if edge_label is None:
+                continue
+            yield source, f'FlyBase:{target}', edge_label, props
 
 

--- a/biocypher_metta/adapters/hsa/gtex_expression_adapter.py
+++ b/biocypher_metta/adapters/hsa/gtex_expression_adapter.py
@@ -21,18 +21,18 @@ class GTExExpressionAdapter(Adapter):
                 "p_value": 13, "tissue": 17, "chr": 18, "pos": 19}
     def __init__(self, filepath, gtex_tissue_ontology_map,
                  write_properties, add_provenance, label,
-                 chr=None, start=None, end=None):
-      
+                 chr=None, start=None, end=None, anatomy_label=None):
+
         self.filepath = filepath
         self.gtex_tissue_ontology_map = pickle.load(open(gtex_tissue_ontology_map, 'rb'))
         self.chr = chr
         self.start = start
         self.end = end
         self.label = label
+        self.anatomy_label = anatomy_label or 'gene_expressed_in_anatomy'
         self.source = 'GTEx'
         self.source_url = 'https://forgedb.cancer.gov/api/gtex/v1.0/gtex.forgedb.csv.gz'
         self.version = 'v8'
-
 
         super(GTExExpressionAdapter, self).__init__(write_properties, add_provenance)
 
@@ -50,7 +50,7 @@ class GTExExpressionAdapter(Adapter):
                     if check_genomic_location(self.chr, self.start, self.end, chr, pos, pos):
                         #CURIE ID Format
                         _source = f"ENSEMBL:{gene_id}"
-                        _target = ('anatomy', f"{ontology}")    # includes ontology node type
+                        _target = f"{ontology}"
                         _props = {
                             'p_value': to_float(row[self.index["p_value"]]),
                         }
@@ -59,7 +59,7 @@ class GTExExpressionAdapter(Adapter):
                                 _props['source'] = self.source
                                 _props['source_url'] = self.source_url
 
-                        yield _source, _target, self.label, _props
+                        yield _source, _target, self.anatomy_label, _props
                 except Exception as e:
                     print(row)
                     print(e)

--- a/biocypher_metta/adapters/reactome_inference_edges_adapter.py
+++ b/biocypher_metta/adapters/reactome_inference_edges_adapter.py
@@ -148,13 +148,16 @@ class ReactomeInferenceEdgesAdapter(Adapter):
                         role_info = roles_to_label_map[protein_role]
                         if role_info is None or role_info[0] != self.label:
                             continue
-                        edges_key = f'{uniprot_id}_{protein_role}_{pathway_id}'
-                        if not edges_key in edges_dict:
-                            props = base_props.copy()
-                            props['relation_ontology_term'] = role_info[1]
-                            props['taxon_id'] = self.taxon_id
-                            edges_dict[edges_key] = True
+                        props = base_props.copy()
+                        props['relation_ontology_term'] = role_info[1]
+                        props['taxon_id'] = self.taxon_id
+                        pathway_key = f'{uniprot_id}_{protein_role}_{pathway_id}'
+                        if pathway_key not in edges_dict:
+                            edges_dict[pathway_key] = True
                             yield uniprot_id, pathway_id, self.pathway_label, props
-                        yield uniprot_id, reaction_id, self.reaction_label, props
+                        reaction_key = f'{uniprot_id}_{protein_role}_{reaction_id}'
+                        if reaction_key not in edges_dict:
+                            edges_dict[reaction_key] = True
+                            yield uniprot_id, reaction_id, self.reaction_label, props
             print(f'Entities not linked: {not_mapped_no_processing} out of {total_in_species_records}')
 

--- a/biocypher_metta/adapters/reactome_inference_edges_adapter.py
+++ b/biocypher_metta/adapters/reactome_inference_edges_adapter.py
@@ -80,20 +80,23 @@ class ReactomeInferenceEdgesAdapter(Adapter):
 
     ALLOWED_LABELS = ['enables', 'produced_by', 'regulates', 'negatively_regulates', 'positively_regulates']
 
-    def __init__(self, filepath, label, write_properties, add_provenance, taxon_id, ensembl_uniprot_map_path=None):
+    def __init__(self, filepath, label, write_properties, add_provenance, taxon_id,
+                 pathway_label=None, reaction_label=None, ensembl_uniprot_map_path=None):
         """
         Added taxon_id parameter to handle multiple species data.
 
         If taxon_id is None, all pathways defined in organism_taxon_map
         will be translated into Atom space. Otherwise, only data for
         the specified species will be processed.
-        """        
+        """
         if label not in ReactomeInferenceEdgesAdapter.ALLOWED_LABELS:
             raise ValueError('Invalid label. Allowed values: ' +
                              ', '.join(ReactomeInferenceEdgesAdapter.ALLOWED_LABELS))
         self.filepath = filepath
         self.dataset = label
         self.label = label
+        self.pathway_label = pathway_label or f'protein_{label}_pathway'
+        self.reaction_label = reaction_label or f'protein_{label}_reaction'
         self.source = "REACTOME"
         self.source_url = "https://reactome.org"
         self.fbpp_to_uniprot = {}               # dict to map FBpp to UniProt ids and to avoid remote connections during runtime
@@ -142,14 +145,16 @@ class ReactomeInferenceEdgesAdapter(Adapter):
                     total_in_species_records += 1
                     protein_roles = protein_roles.replace('[', '').replace(']', '').replace(' ', '').split(',')
                     for protein_role in protein_roles:
-                        label = roles_to_label_map[protein_role][0]
-                        edges_key = f'{uniprot_id}_{protein_role}_{pathway_id}'  
+                        role_info = roles_to_label_map[protein_role]
+                        if role_info is None or role_info[0] != self.label:
+                            continue
+                        edges_key = f'{uniprot_id}_{protein_role}_{pathway_id}'
                         if not edges_key in edges_dict:
                             props = base_props.copy()
-                            props['relation_ontology_term'] = roles_to_label_map[protein_role][1]
+                            props['relation_ontology_term'] = role_info[1]
                             props['taxon_id'] = self.taxon_id
-                            edges_dict[edges_key] = True                                                
-                            yield uniprot_id, ('pathway', pathway_id), label, props
-                        yield uniprot_id, ('reaction', reaction_id), label, props
+                            edges_dict[edges_key] = True
+                            yield uniprot_id, pathway_id, self.pathway_label, props
+                        yield uniprot_id, reaction_id, self.reaction_label, props
             print(f'Entities not linked: {not_mapped_no_processing} out of {total_in_species_records}')
 

--- a/biocypher_metta/kgx_writer.py
+++ b/biocypher_metta/kgx_writer.py
@@ -451,6 +451,13 @@ class KGXWriter(BaseWriter):
                 typed_target_type = target_id[0] if has_typed_target else None
                 typed_target_id = target_id[1] if has_typed_target else target_id
 
+                if has_typed_source and has_typed_target:
+                    self.validate_edge_types(normalized_label, typed_source_type, typed_target_type)
+                elif has_typed_source and target_types:
+                    self.validate_edge_types(normalized_label, typed_source_type, target_types[0])
+                elif has_typed_target and source_types:
+                    self.validate_edge_types(normalized_label, source_types[0], typed_target_type)
+
                 for src_type in source_types:
                     for tgt_type in target_types:
                         # Start from schema-declared types

--- a/biocypher_metta/metta_writer.py
+++ b/biocypher_metta/metta_writer.py
@@ -84,18 +84,8 @@ class MeTTaWriter(BaseWriter):
     def create_data_constructors(self, file):
         schema = self.bcy._get_ontology_mapping()._extend_schema()
         
-        def edge_data_constructor(edge_type, source_types, target_types, label):
-            if isinstance(source_types, list):
-                source_str = ' '.join([st.upper() for st in source_types])
-            else:
-                source_str = source_types.upper()
-                
-            if isinstance(target_types, list):
-                target_str = ' '.join([tt.upper() for tt in target_types])
-            else:
-                target_str = target_types.upper()
-                
-            return f"(: {label.lower()} (-> {source_str} {target_str} {edge_type.upper()}))"
+        def edge_data_constructor(edge_type, source_type, target_type, label):
+            return f"(: {label.lower()} (-> {source_type.upper()} {target_type.upper()} {edge_type.upper()}))"
 
         def node_data_constructor(node_type, node_label):
             return f"(: {node_label.lower()} (-> $x {node_type.upper()}))"
@@ -105,23 +95,29 @@ class MeTTaWriter(BaseWriter):
                 edge_type = self.normalize_text(k)
                 source_type = v.get("source", None)
                 target_type = v.get("target", None)
-        
+
                 if source_type is not None and target_type is not None:
-                    label = self.normalize_text(v["input_label"])
+                    input_label = self.normalize_text(v["input_label"])
                     source_type_normalized = self.normalize_text(source_type)
                     target_type_normalized = self.normalize_text(target_type)
-            
+
                     output_label = v.get("output_label", None)
+                    constructor_label = self.normalize_text(output_label) if output_label else input_label
 
                     if '.' not in k:
-                        out_str = edge_data_constructor(edge_type, source_type_normalized, target_type_normalized, label)
-                        file.write(out_str + "\n")
-                
-                        self.edge_node_types[label] = {
-                            "source": source_type_normalized, 
-                            "target": target_type_normalized,
-                            "output_label": output_label
-                        }
+                        src_list = source_type_normalized if isinstance(source_type_normalized, list) else [source_type_normalized]
+                        tgt_list = target_type_normalized if isinstance(target_type_normalized, list) else [target_type_normalized]
+                        for src in src_list:
+                            for tgt in tgt_list:
+                                out_str = edge_data_constructor(edge_type, src, tgt, constructor_label)
+                                file.write(out_str + "\n")
+
+                        if input_label not in self.edge_node_types:
+                            self.edge_node_types[input_label] = {
+                                "source": source_type_normalized,
+                                "target": target_type_normalized,
+                                "output_label": output_label
+                            }
 
             elif v["represented_as"] == "node":
                 label = self.normalize_text(v["input_label"])
@@ -237,6 +233,9 @@ class MeTTaWriter(BaseWriter):
                     target_type = edge_info.get("target", "unknown")
                     if isinstance(target_type, list):
                         target_type = target_type[0]
+
+                if isinstance(source_id, tuple) or isinstance(target_id, tuple):
+                    self.validate_edge_types(label, source_type, target_type)
 
                 file_key = (label, source_type, target_type)
 

--- a/biocypher_metta/neo4j_csv_writer.py
+++ b/biocypher_metta/neo4j_csv_writer.py
@@ -259,6 +259,9 @@ class Neo4jCSVWriter(BaseWriter):
                 
                 edge_info = self.edge_node_types[label]
                 
+                has_typed_source = isinstance(source_id, tuple)
+                has_typed_target = isinstance(target_id, tuple)
+
                 if isinstance(source_id, tuple):
                     source_type = source_id[0]
                     source_id = source_id[1]
@@ -276,6 +279,9 @@ class Neo4jCSVWriter(BaseWriter):
                         target_type = edge_info["target"][0]
                     else:
                         target_type = edge_info["target"]
+
+                if has_typed_source or has_typed_target:
+                    self.validate_edge_types(label, source_type, target_type)
 
                 if source_type == "ontology_term" and not isinstance(source_id, tuple):
                     source_type = self.preprocess_id(source_id, label=source_type).split('_')[0]

--- a/biocypher_metta/networkx_writer.py
+++ b/biocypher_metta/networkx_writer.py
@@ -236,6 +236,9 @@ class NetworkXWriter(BaseWriter):
             else:
                 _, target_type = self._get_edge_type_info(label, source_id, target_id)
                 target_clean = self._preprocess_id(target_id, label=target_type)
+
+            if isinstance(source_id, tuple) or isinstance(target_id, tuple):
+                self.validate_edge_types(label, source_type, target_type)
             
             if edges_skipped < 5: 
                 if source_clean not in self.node_mapping or target_clean not in self.node_mapping:

--- a/biocypher_metta/parquet_writer.py
+++ b/biocypher_metta/parquet_writer.py
@@ -321,6 +321,14 @@ class ParquetWriter(BaseWriter):
                     source_types = edge_info["source"]
                     target_types = edge_info["target"]
 
+                    # Validate adapter-provided types against schema when tuples are present
+                    has_typed_source = isinstance(source_id_raw, tuple)
+                    has_typed_target = isinstance(target_id_raw, tuple)
+                    if has_typed_source or has_typed_target:
+                        typed_src = source_id_raw[0] if has_typed_source else (source_types[0] if isinstance(source_types, list) else source_types)
+                        typed_tgt = target_id_raw[0] if has_typed_target else (target_types[0] if isinstance(target_types, list) else target_types)
+                        self.validate_edge_types(label, typed_src, typed_tgt)
+
                     # Filter props per user exclusion before writing
                     filtered_props = {k: v for k, v in properties.items() if k not in self.excluded_properties}
 

--- a/biocypher_metta/prolog_writer.py
+++ b/biocypher_metta/prolog_writer.py
@@ -134,6 +134,12 @@ class PrologWriter(BaseWriter):
                 if isinstance(target_type, list):
                     target_type = target_type[0]
 
+                # Use adapter-provided types for validation when tuples are present
+                effective_source_type = source_id[0] if isinstance(source_id, tuple) else source_type
+                effective_target_type = target_id[0] if isinstance(target_id, tuple) else target_type
+                if isinstance(source_id, tuple) or isinstance(target_id, tuple):
+                    self.validate_edge_types(label, effective_source_type, effective_target_type)
+
                 file_key = (label, source_type, target_type)
 
                 if file_key not in file_handles:

--- a/config/dmel/dmel_adapters_config.yaml
+++ b/config/dmel/dmel_adapters_config.yaml
@@ -5,6 +5,8 @@ bgee_gene_expressed_in_anatomical_entity:
     args:
       filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
       label: expressed_in
+      anatomy_label: gene_expressed_in_anatomy
+      developmental_stage_label: gene_expressed_in_developmental_stage
       taxon_id: 7227
   outdir: bgee
   nodes: False
@@ -676,6 +678,8 @@ reactome_input_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: enables
+      pathway_label: protein_enables_pathway
+      reaction_label: protein_enables_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -688,6 +692,8 @@ reactome_output_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: produced_by
+      pathway_label: protein_produced_by_pathway
+      reaction_label: protein_produced_by_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -700,6 +706,8 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: regulates
+      pathway_label: protein_regulates_pathway
+      reaction_label: protein_regulates_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -712,6 +720,8 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: negatively_regulates
+      pathway_label: protein_negatively_regulates_pathway
+      reaction_label: protein_negatively_regulates_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -724,6 +734,8 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: positively_regulates
+      pathway_label: protein_positively_regulates_pathway
+      reaction_label: protein_positively_regulates_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False

--- a/config/dmel/dmel_adapters_config_sample.yaml
+++ b/config/dmel/dmel_adapters_config_sample.yaml
@@ -6,7 +6,9 @@ bgee_gene_expressed_in_anatomical_entity:
     args:
       filepath: ./samples/dmel/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
       label: expressed_in
-      taxon_id: 7227      
+      anatomy_label: gene_expressed_in_anatomy
+      developmental_stage_label: gene_expressed_in_developmental_stage
+      taxon_id: 7227
   outdir: bgee
   nodes: False
   edges: True
@@ -781,6 +783,8 @@ reactome_input_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: enables
+      pathway_label: protein_enables_pathway
+      reaction_label: protein_enables_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -793,6 +797,8 @@ reactome_output_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: produced_by
+      pathway_label: protein_produced_by_pathway
+      reaction_label: protein_produced_by_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -805,6 +811,8 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: regulates
+      pathway_label: protein_regulates_pathway
+      reaction_label: protein_regulates_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -817,6 +825,8 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: negatively_regulates
+      pathway_label: protein_negatively_regulates_pathway
+      reaction_label: protein_negatively_regulates_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -829,6 +839,8 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: positively_regulates
+      pathway_label: protein_positively_regulates_pathway
+      reaction_label: protein_positively_regulates_reaction
       taxon_id: 7227
   outdir: reactome
   nodes: False
@@ -840,7 +852,7 @@ chebi_small_molecule_to_pathways:
     cls: ReactomeEdgesAdapter
     args:
       filepath: ./samples/reactome/ChEBI2Reactome_All_Levels_sample.txt     # all sampled species data are in this file
-      ensembl_uniprot_map_path: ./aux_files/dmel/string_ensembl_to_uniprot_map.pkl
+      ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: small_molecule_to_pathway
       taxon_id: 7227
   outdir: reactome
@@ -853,7 +865,7 @@ chebi_small_molecule_to_reactions:
     cls: ReactomeEdgesAdapter
     args:
       filepath: ./samples/reactome/ChEBI2ReactomeReactions_sample.txt     # all sampled species data are in this file
-      ensembl_uniprot_map_path: ./aux_files/dmel/string_ensembl_to_uniprot_map.pkl
+      ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: small_molecule_to_reaction
       taxon_id: 7227
   outdir: reactome

--- a/config/dmel/dmel_schema_config.yaml
+++ b/config/dmel/dmel_schema_config.yaml
@@ -252,6 +252,180 @@ signaling pathway gene group:
 
 ##################             EDGES   SECTION             ####################
 
+biological process gene dmel:
+  is_a: go gene product
+  biolink_predicate: biolink:involved_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: biological_process_gene_product
+  output_label: involved_in
+  source: gene
+  target: biological process
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+molecular function gene dmel:
+  is_a: go gene product
+  biolink_predicate: biolink:enables
+  inherit_properties: true
+  represented_as: edge
+  input_label: molecular_function_gene_product
+  output_label: enables
+  source: gene
+  target: molecular function
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene located in dmel:
+  is_a: cellular component gene product
+  biolink_predicate: biolink:located_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_product_located_in
+  output_label: located_in
+  source: gene
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene part of dmel:
+  is_a: cellular component gene product
+  biolink_predicate: biolink:part_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_product_part_of
+  output_label: part_of
+  source: gene
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+gene expressed in anatomy:
+  represented_as: edge
+  input_label: expressed_in
+  output_label: expressed_in
+  is_a: annotation
+  biolink_predicate: biolink:expressed_in
+  source: gene
+  target: anatomy
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:GrossAnatomicalStructure
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+gene expressed in developmental stage:
+  represented_as: edge
+  input_label: expressed_in
+  output_label: expressed_in
+  is_a: annotation
+  biolink_predicate: biolink:expressed_in
+  source: gene
+  target: developmental stage
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:LifeStage
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+gene expressed in phenotype:
+  represented_as: edge
+  input_label: expressed_in
+  output_label: expressed_in
+  is_a: annotation
+  biolink_predicate: biolink:expressed_in
+  source: gene
+  target: phenotype
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:PhenotypicFeature
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+gene expressed in biological process:
+  represented_as: edge
+  input_label: expressed_in
+  output_label: expressed_in
+  is_a: annotation
+  biolink_predicate: biolink:expressed_in
+  source: gene
+  target: biological process
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+gene expressed in molecular function:
+  represented_as: edge
+  input_label: expressed_in
+  output_label: expressed_in
+  is_a: annotation
+  biolink_predicate: biolink:expressed_in
+  source: gene
+  target: molecular function
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+gene expressed in cellular component:
+  represented_as: edge
+  input_label: expressed_in
+  output_label: expressed_in
+  is_a: annotation
+  biolink_predicate: biolink:expressed_in
+  source: gene
+  target: cellular component
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
 allele to allele genetic interaction:
   represented_as: edge
   input_label: allele_to_allele_genetic_interaction
@@ -325,7 +499,7 @@ allele to phenotype_set:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-expression value:
+gene expression value:
   is_a: expression
   mixins:
   - biolink:ExpressionQuantitativeTraitLocus
@@ -333,10 +507,9 @@ expression value:
   represented_as: edge
   inherit_properties: false
   input_label: expression_value
-  source: biolink:GeneOrGeneProduct
+  source: gene
   target: rnaseq library
-  description: A set of values for numeric estimation of single gene/transcript expression
-    as measured by a given methodology (represented by a library).
+  description: A set of values for numeric estimation of gene expression.
   properties:
     value_and_description:
       type: list[tuple]
@@ -352,7 +525,69 @@ expression value:
       type: str
       biolink: source_web_page
   kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
+    subject_category: biolink:Gene
+    object_category: biolink:DataSet
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+transcript expression value:
+  is_a: expression
+  mixins:
+  - biolink:ExpressionQuantitativeTraitLocus
+  biolink_predicate: biolink:has_quantified_expression_level
+  represented_as: edge
+  inherit_properties: false
+  input_label: expression_value
+  source: transcript
+  target: rnaseq library
+  description: A set of values for numeric estimation of transcript expression.
+  properties:
+    value_and_description:
+      type: list[tuple]
+      biolink: has_quantitative_value
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+  kgx_properties:
+    subject_category: biolink:Transcript
+    object_category: biolink:DataSet
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein expression value:
+  is_a: expression
+  mixins:
+  - biolink:ExpressionQuantitativeTraitLocus
+  biolink_predicate: biolink:has_quantified_expression_level
+  represented_as: edge
+  inherit_properties: false
+  input_label: expression_value
+  source: protein
+  target: rnaseq library
+  description: A set of values for numeric estimation of protein expression.
+  properties:
+    value_and_description:
+      type: list[tuple]
+      biolink: has_quantitative_value
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+  kgx_properties:
+    subject_category: biolink:Protein
     object_category: biolink:DataSet
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
@@ -603,13 +838,13 @@ phenotype_set to genotype:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-phenotype_set to ontology:
+phenotype_set to anatomy:
   represented_as: edge
   input_label: characterized_by
   is_a: annotation
   biolink_predicate: biolink:characterized_by
   source: phenotype_set
-  target: ontology term
+  target: anatomy
   properties:
     taxon_id:
       type: int
@@ -617,7 +852,97 @@ phenotype_set to ontology:
       range: biolink:OrganismTaxon
   kgx_properties:
     subject_category: biolink:PhenotypicFeature
-    object_category: biolink:OntologyClass
+    object_category: biolink:GrossAnatomicalStructure
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+phenotype_set to phenotype:
+  represented_as: edge
+  input_label: characterized_by
+  is_a: annotation
+  biolink_predicate: biolink:characterized_by
+  source: phenotype_set
+  target: phenotype
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:PhenotypicFeature
+    object_category: biolink:PhenotypicFeature
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+phenotype_set to biological process:
+  represented_as: edge
+  input_label: characterized_by
+  is_a: annotation
+  biolink_predicate: biolink:characterized_by
+  source: phenotype_set
+  target: biological process
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:PhenotypicFeature
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+phenotype_set to molecular function:
+  represented_as: edge
+  input_label: characterized_by
+  is_a: annotation
+  biolink_predicate: biolink:characterized_by
+  source: phenotype_set
+  target: molecular function
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:PhenotypicFeature
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+phenotype_set to developmental stage:
+  represented_as: edge
+  input_label: characterized_by
+  is_a: annotation
+  biolink_predicate: biolink:characterized_by
+  source: phenotype_set
+  target: developmental stage
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:PhenotypicFeature
+    object_category: biolink:LifeStage
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+phenotype_set to sequence type:
+  represented_as: edge
+  input_label: characterized_by
+  is_a: annotation
+  biolink_predicate: biolink:characterized_by
+  source: phenotype_set
+  target: sequence type
+  properties:
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:PhenotypicFeature
+    object_category: biolink:SequenceFeature
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
@@ -628,13 +953,13 @@ ptp physical interaction type:
   source: ptp physically interacts with
   target: molecular_interaction
 
-ptp physically interacts with:
+protein to protein physical interaction:
   is_a: expression
   inherit_properties: true
   represented_as: edge
   input_label: ptp_physically_interacts_with
   biolink_predicate: biolink:physically_interacts_with
-  source: biolink:GeneOrGeneProduct
+  source: protein
   target: protein
   properties:
     source_gene:
@@ -670,18 +995,65 @@ ptp physically interacts with:
       type: str
       biolink: comment
   kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
+    subject_category: biolink:Protein
     object_category: biolink:Protein
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-ptt physically interacts with:
+transcript to protein physical interaction:
+  is_a: expression
+  inherit_properties: true
+  represented_as: edge
+  input_label: ptp_physically_interacts_with
+  biolink_predicate: biolink:physically_interacts_with
+  source: transcript
+  target: protein
+  properties:
+    source_gene:
+      type: str
+      biolink: has_gene_or_gene_product
+    target_gene:
+      type: str
+      biolink: has_gene_or_gene_product
+    detection_method:
+      type: str
+      biolink: has_metric
+    pubmed_ids:
+      type: str[]
+      biolink: publication
+    source_taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+    target_taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+    interaction_type:
+      type: molecular_interaction
+      biolink: has_attribute
+    interaction_comments:
+      type: str
+      biolink: comment
+    source_comments:
+      type: str
+      biolink: comment
+    target_comments:
+      type: str
+      biolink: comment
+  kgx_properties:
+    subject_category: biolink:Transcript
+    object_category: biolink:Protein
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein to transcript physical interaction:
   is_a: expression
   inherit_properties: true
   represented_as: edge
   input_label: ptt_physically_interacts_with
   biolink_predicate: biolink:physically_interacts_with
-  source: biolink:GeneOrGeneProduct
+  source: protein
   target: transcript
   properties:
     source_gene:
@@ -717,7 +1089,54 @@ ptt physically interacts with:
       type: str
       biolink: comment
   kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
+    subject_category: biolink:Protein
+    object_category: biolink:Transcript
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+transcript to transcript physical interaction:
+  is_a: expression
+  inherit_properties: true
+  represented_as: edge
+  input_label: ptt_physically_interacts_with
+  biolink_predicate: biolink:physically_interacts_with
+  source: transcript
+  target: transcript
+  properties:
+    source_gene:
+      type: str
+      biolink: has_gene_or_gene_product
+    target_gene:
+      type: str
+      biolink: has_gene_or_gene_product
+    detection_method:
+      type: str
+      biolink: has_metric
+    pubmed_ids:
+      type: str[]
+      biolink: publication
+    source_taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+    target_taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+    interaction_type:
+      type: str
+      biolink: has_attribute
+    interaction_comments:
+      type: str
+      biolink: comment
+    source_comments:
+      type: str
+      biolink: comment
+    target_comments:
+      type: str
+      biolink: comment
+  kgx_properties:
+    subject_category: biolink:Transcript
     object_category: biolink:Transcript
     knowledge_level: knowledge_assertion
     agent_type: manual_agent

--- a/config/dmel/dmel_schema_config.yaml
+++ b/config/dmel/dmel_schema_config.yaml
@@ -312,47 +312,9 @@ cellular component gene part of dmel:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-gene expressed in anatomy:
-  represented_as: edge
-  input_label: expressed_in
-  output_label: expressed_in
-  is_a: annotation
-  biolink_predicate: biolink:expressed_in
-  source: gene
-  target: anatomy
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:GrossAnatomicalStructure
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene expressed in developmental stage:
-  represented_as: edge
-  input_label: expressed_in
-  output_label: expressed_in
-  is_a: annotation
-  biolink_predicate: biolink:expressed_in
-  source: gene
-  target: developmental stage
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:LifeStage
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
 gene expressed in phenotype:
   represented_as: edge
-  input_label: expressed_in
+  input_label: gene_expressed_in_phenotype
   output_label: expressed_in
   is_a: annotation
   biolink_predicate: biolink:expressed_in
@@ -371,7 +333,7 @@ gene expressed in phenotype:
 
 gene expressed in biological process:
   represented_as: edge
-  input_label: expressed_in
+  input_label: gene_expressed_in_biological_process
   output_label: expressed_in
   is_a: annotation
   biolink_predicate: biolink:expressed_in
@@ -390,7 +352,7 @@ gene expressed in biological process:
 
 gene expressed in molecular function:
   represented_as: edge
-  input_label: expressed_in
+  input_label: gene_expressed_in_molecular_function
   output_label: expressed_in
   is_a: annotation
   biolink_predicate: biolink:expressed_in
@@ -409,7 +371,7 @@ gene expressed in molecular function:
 
 gene expressed in cellular component:
   represented_as: edge
-  input_label: expressed_in
+  input_label: gene_expressed_in_cellular_component
   output_label: expressed_in
   is_a: annotation
   biolink_predicate: biolink:expressed_in

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -145,6 +145,8 @@ reactome_input_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: enables
+      pathway_label: protein_enables_pathway
+      reaction_label: protein_enables_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -157,6 +159,8 @@ reactome_output_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: produced_by
+      pathway_label: protein_produced_by_pathway
+      reaction_label: protein_produced_by_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -169,6 +173,8 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: regulates
+      pathway_label: protein_regulates_pathway
+      reaction_label: protein_regulates_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -181,6 +187,8 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: negatively_regulates
+      pathway_label: protein_negatively_regulates_pathway
+      reaction_label: protein_negatively_regulates_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -193,6 +201,8 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
       label: positively_regulates
+      pathway_label: protein_positively_regulates_pathway
+      reaction_label: protein_positively_regulates_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -599,7 +609,7 @@ gtex_expression:
       filepath: /mnt/hdd_1/abdu/biocypher_data/gtex/eqtl/gtex.forgedb.csv.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       label: expressed_in
-
+      anatomy_label: gene_expressed_in_anatomy
   outdir: gtex/expression
   nodes: False
   edges: True
@@ -1383,7 +1393,9 @@ bgee_gene_expressed_in_anatomical_entity:
     args:
       filepath: /mnt/hdd_1/abdu/biocypher_data/bgee/Homo_sapiens_expr_simple_all_conditions.tsv.gz
       label: expressed_in
-      taxon_id: 9606        
+      anatomy_label: gene_expressed_in_anatomy
+      developmental_stage_label: gene_expressed_in_developmental_stage
+      taxon_id: 9606
   outdir: bgee
   nodes: False
   edges: True

--- a/config/hsa/hsa_adapters_config_sample.yaml
+++ b/config/hsa/hsa_adapters_config_sample.yaml
@@ -147,6 +147,8 @@ reactome_input_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: enables
+      pathway_label: protein_enables_pathway
+      reaction_label: protein_enables_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -159,6 +161,8 @@ reactome_output_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: produced_by
+      pathway_label: protein_produced_by_pathway
+      reaction_label: protein_produced_by_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -171,6 +175,8 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: regulates
+      pathway_label: protein_regulates_pathway
+      reaction_label: protein_regulates_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -183,6 +189,8 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: negatively_regulates
+      pathway_label: protein_negatively_regulates_pathway
+      reaction_label: protein_negatively_regulates_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -195,6 +203,8 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     args:
       filepath: ./samples/reactome/reactome_reaction_exporter_All_species_sample.txt
       label: positively_regulates
+      pathway_label: protein_positively_regulates_pathway
+      reaction_label: protein_positively_regulates_reaction
       taxon_id: 9606
   outdir: reactome
   nodes: False
@@ -628,7 +638,7 @@ gtex_expression:
       filepath: ./samples/hsa/gtex.forgedb.sample.csv.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       label: expressed_in
-
+      anatomy_label: gene_expressed_in_anatomy
   outdir: gtex/expression
   nodes: False
   edges: True
@@ -1353,7 +1363,9 @@ bgee_gene_expressed_in_anatomical_entity:
     args:
       filepath: ./samples/hsa/bgee/Homo_sapiens_expr_sample.tsv.gz
       label: expressed_in
-      taxon_id: 9606      
+      anatomy_label: gene_expressed_in_anatomy
+      developmental_stage_label: gene_expressed_in_developmental_stage
+      taxon_id: 9606
   outdir: bgee
   nodes: False
   edges: True

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -1105,30 +1105,6 @@ post translational interaction:
     reactome_pathway:
       type: str
 
-expressed in:
-  description: >-
-    holds between a gene and an ontology term in which it is expressed
-  is_a: expression
-  mixins: [biolink:GeneToExpressionSiteAssociation]
-  biolink_predicate: "biolink:expressed_in"
-  inherit_properties: true
-  represented_as: edge
-  input_label: expressed_in
-  source: gene
-  target: ontology term
-  kgx_properties:
-    subject_category: "biolink:Gene"
-    object_category: "biolink:OntologyClass"
-    knowledge_level: "knowledge_assertion"
-    agent_type: "manual_agent"
-  properties:
-    score: 
-      type: float
-      biolink: has_quantitative_value
-    p_value: 
-      type: float
-      biolink: has_quantitative_value
-
 # ---
 # annotation
 
@@ -1282,17 +1258,51 @@ gene to pathway association:
 
 gene to reaction association:
   description: >-
-    An interaction between a gene or a gene product (gogp) and a reaction (Reactome).
+    An interaction between a gene and a reaction (Reactome).
   is_a: annotation
   biolink_predicate: "biolink:participates_in"
   inherit_properties: true
   represented_as: edge
   input_label: gene_or_gene_product_reaction
-  output_label: involved_in 
-  source: biolink:GeneOrGeneProduct     #  [gene, protein, transcript] 
+  output_label: involved_in
+  source: gene
   target: reaction
   kgx_properties:
-    subject_category: "biolink:GeneOrGeneProduct"
+    subject_category: "biolink:Gene"
+    object_category: "biolink:MolecularActivity"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+protein to reaction association:
+  description: >-
+    An interaction between a protein and a reaction (Reactome).
+  is_a: annotation
+  biolink_predicate: "biolink:participates_in"
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_or_gene_product_reaction
+  output_label: involved_in
+  source: protein
+  target: reaction
+  kgx_properties:
+    subject_category: "biolink:Protein"
+    object_category: "biolink:MolecularActivity"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+transcript to reaction association:
+  description: >-
+    An interaction between a transcript and a reaction (Reactome).
+  is_a: annotation
+  biolink_predicate: "biolink:participates_in"
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_or_gene_product_reaction
+  output_label: involved_in
+  source: transcript
+  target: reaction
+  kgx_properties:
+    subject_category: "biolink:Transcript"
     object_category: "biolink:MolecularActivity"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
@@ -1351,91 +1361,180 @@ reaction to pathway association:
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
-input role protein to reaction or pathway association:
+input role protein to pathway association:
   is_a: annotation
   biolink_predicate: "biolink:is_input_of"
   inherit_properties: true
-  description: >-
-    holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein playing an input role in a pathway
   represented_as: edge
-  input_label: enables
+  input_label: protein_enables_pathway
+  output_label: enables
   source: protein
-  target: biolink:BiologicalProcessOrActivity  # [pathway, reaction]
+  target: pathway
   properties:
-    relation_ontology_term: str   # RO term for "enables" relation
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: "biolink:Protein"
+    object_category: "biolink:BiologicalProcess"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+input role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: "biolink:is_input_of"
+  inherit_properties: true
+  description: holds between a protein playing an input role in a reaction
+  represented_as: edge
+  input_label: protein_enables_reaction
+  output_label: enables
+  source: protein
+  target: reaction
+  properties:
+    relation_ontology_term: str
   kgx_properties:
     subject_category: "biolink:Protein"
     object_category: "biolink:MolecularActivity"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
-output role protein to reaction or pathway association:
+output role protein to pathway association:
   is_a: annotation
   biolink_predicate: "biolink:produced_by"
   inherit_properties: true
-  description: >-
-    holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein produced by a pathway
   represented_as: edge
-  input_label: produced_by
+  input_label: protein_produced_by_pathway
+  output_label: produced_by
   source: protein
-  target: biolink:BiologicalProcessOrActivity  # [pathway, reaction]
+  target: pathway
   properties:
-    relation_ontology_term: str   # RO term for "produced_by" relation
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: "biolink:Protein"
+    object_category: "biolink:BiologicalProcess"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+output role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: "biolink:produced_by"
+  inherit_properties: true
+  description: holds between a protein produced by a reaction
+  represented_as: edge
+  input_label: protein_produced_by_reaction
+  output_label: produced_by
+  source: protein
+  target: reaction
+  properties:
+    relation_ontology_term: str
   kgx_properties:
     subject_category: "biolink:Protein"
     object_category: "biolink:MolecularActivity"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
-catalyst protein to reaction or pathway association:
+catalyst protein to pathway association:
   is_a: annotation
   biolink_predicate: "biolink:regulates"
   inherit_properties: true
-  description: >-
-    holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein playing a catalyst role in a pathway
   represented_as: edge
-  input_label: regulates
+  input_label: protein_regulates_pathway
+  output_label: regulates
   source: protein
-  target: biolink:BiologicalProcessOrActivity  # [pathway, reaction]  
+  target: pathway
   properties:
-    relation_ontology_term: str   # RO term for "regulates" relation
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: "biolink:Protein"
+    object_category: "biolink:BiologicalProcess"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+catalyst protein to reaction association:
+  is_a: annotation
+  biolink_predicate: "biolink:regulates"
+  inherit_properties: true
+  description: holds between a protein playing a catalyst role in a reaction
+  represented_as: edge
+  input_label: protein_regulates_reaction
+  output_label: regulates
+  source: protein
+  target: reaction
+  properties:
+    relation_ontology_term: str
   kgx_properties:
     subject_category: "biolink:Protein"
     object_category: "biolink:MolecularActivity"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
-
-negative role protein to reaction or pathway association:
+negative role protein to pathway association:
   is_a: annotation
   biolink_predicate: "biolink:regulates"
   inherit_properties: true
-  description: >-
-    holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein negatively regulating a pathway
   represented_as: edge
-  input_label: negatively_regulates
+  input_label: protein_negatively_regulates_pathway
+  output_label: negatively_regulates
   source: protein
-  target: biolink:BiologicalProcessOrActivity  # [pathway, reaction]
+  target: pathway
   properties:
-    relation_ontology_term: str   # RO term for "negatively regulates" relation  
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: "biolink:Protein"
+    object_category: "biolink:BiologicalProcess"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+negative role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: "biolink:regulates"
+  inherit_properties: true
+  description: holds between a protein negatively regulating a reaction
+  represented_as: edge
+  input_label: protein_negatively_regulates_reaction
+  output_label: negatively_regulates
+  source: protein
+  target: reaction
+  properties:
+    relation_ontology_term: str
   kgx_properties:
     subject_category: "biolink:Protein"
     object_category: "biolink:MolecularActivity"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
-positive role protein to reaction or pathway association:
+positive role protein to pathway association:
   is_a: annotation
   biolink_predicate: "biolink:regulates"
   inherit_properties: true
-  description: >-
-    holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein positively regulating a pathway
   represented_as: edge
-  input_label: positively_regulates
+  input_label: protein_positively_regulates_pathway
+  output_label: positively_regulates
   source: protein
-  target: biolink:BiologicalProcessOrActivity  # [pathway, reaction]
+  target: pathway
   properties:
-    relation_ontology_term: str   # RO term for "positively regulates" relation
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: "biolink:Protein"
+    object_category: "biolink:BiologicalProcess"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+positive role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: "biolink:regulates"
+  inherit_properties: true
+  description: holds between a protein positively regulating a reaction
+  represented_as: edge
+  input_label: protein_positively_regulates_reaction
+  output_label: positively_regulates
+  source: protein
+  target: reaction
+  properties:
+    relation_ontology_term: str
   kgx_properties:
     subject_category: "biolink:Protein"
     object_category: "biolink:MolecularActivity"
@@ -2465,41 +2564,169 @@ promoter activity by contact:
       type: str
       biolink: has_biological_sequence
 
-chromatin state:
+chromatin state snp to anatomy:
   is_a: association
   mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
-  biolink_predicate: "biolink:has_phenotype" 
+  biolink_predicate: "biolink:has_phenotype"
   represented_as: edge
   input_label: chromatin_state
   source: snp
-  target: anatomy #TODO replace by cell ontology
+  target: anatomy
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:GrossAnatomicalStructure"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    state:
+      type: str
+      biolink: phenotypic_state
+
+chromatin state snp to cell type:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: chromatin_state
+  source: snp
+  target: cell type
   kgx_properties:
     subject_category: "biolink:Snv"
     object_category: "biolink:Cell"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
   properties:
-    state: 
+    state:
       type: str
       biolink: phenotypic_state
 
-dnase I hotspot:
+chromatin state snp to cell line:
   is_a: association
   mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
-  biolink_predicate: "biolink:has_phenotype" 
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: chromatin_state
+  source: snp
+  target: cell line
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:CellLine"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    state:
+      type: str
+      biolink: phenotypic_state
+
+chromatin state snp to experimental factor:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: chromatin_state
+  source: snp
+  target: experimental factor
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:BiologicalEntity"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    state:
+      type: str
+      biolink: phenotypic_state
+
+chromatin state snp to tissue:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: chromatin_state
+  source: snp
+  target: tissue
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:GrossAnatomicalStructure"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    state:
+      type: str
+      biolink: phenotypic_state
+
+dnase I hotspot snp to anatomy:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
   description: >-
     A region of chromatin that is sensitive to cleavage by the enzyme DNase I
   represented_as: edge
   input_label: in_dnase_I_hotspot
   source: snp
-  target: anatomy #TODO replace by cell ontology
+  target: anatomy
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:GrossAnatomicalStructure"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+dnase I hotspot snp to cell type:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: in_dnase_I_hotspot
+  source: snp
+  target: cell type
   kgx_properties:
     subject_category: "biolink:Snv"
     object_category: "biolink:Cell"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
-histone modification:
+dnase I hotspot snp to cell line:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: in_dnase_I_hotspot
+  source: snp
+  target: cell line
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:CellLine"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+dnase I hotspot snp to experimental factor:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: in_dnase_I_hotspot
+  source: snp
+  target: experimental factor
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:BiologicalEntity"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+dnase I hotspot snp to tissue:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: in_dnase_I_hotspot
+  source: snp
+  target: tissue
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:GrossAnatomicalStructure"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+histone modification snp to anatomy:
   is_a: association
   mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
   biolink_predicate: "biolink:has_phenotype"
@@ -2508,14 +2735,86 @@ histone modification:
   represented_as: edge
   input_label: histone_modification
   source: snp
-  target: anatomy #TODO replace by cell ontology
+  target: anatomy
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:GrossAnatomicalStructure"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    modification:
+      type: str
+      biolink: phenotypic_state
+
+histone modification snp to cell type:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: histone_modification
+  source: snp
+  target: cell type
   kgx_properties:
     subject_category: "biolink:Snv"
     object_category: "biolink:Cell"
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
   properties:
-    modification: 
+    modification:
+      type: str
+      biolink: phenotypic_state
+
+histone modification snp to cell line:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: histone_modification
+  source: snp
+  target: cell line
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:CellLine"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    modification:
+      type: str
+      biolink: phenotypic_state
+
+histone modification snp to experimental factor:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: histone_modification
+  source: snp
+  target: experimental factor
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:BiologicalEntity"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    modification:
+      type: str
+      biolink: phenotypic_state
+
+histone modification snp to tissue:
+  is_a: association
+  mixins: [biolink:GenotypeToPhenotypicFeatureAssociation]
+  biolink_predicate: "biolink:has_phenotype"
+  represented_as: edge
+  input_label: histone_modification
+  source: snp
+  target: tissue
+  kgx_properties:
+    subject_category: "biolink:Snv"
+    object_category: "biolink:GrossAnatomicalStructure"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+  properties:
+    modification:
       type: str
       biolink: phenotypic_state
 

--- a/config/primer_schema_config.yaml
+++ b/config/primer_schema_config.yaml
@@ -778,15 +778,34 @@ bto subclass of:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-catalyst protein to reaction or pathway association:
+catalyst protein to pathway association:
   is_a: annotation
   biolink_predicate: biolink:regulates
   inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein playing a catalyst role in a pathway
   represented_as: edge
-  input_label: regulates
+  input_label: protein_regulates_pathway
+  output_label: regulates
   source: protein
-  target: biolink:BiologicalProcessOrActivity
+  target: pathway
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+catalyst protein to reaction association:
+  is_a: annotation
+  biolink_predicate: biolink:regulates
+  inherit_properties: true
+  description: holds between a protein playing a catalyst role in a reaction
+  represented_as: edge
+  input_label: protein_regulates_reaction
+  output_label: regulates
+  source: protein
+  target: reaction
   properties:
     relation_ontology_term: str
   kgx_properties:
@@ -1175,20 +1194,46 @@ exon part_of transcript:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-expressed in:
-  description: holds between a gene and an ontology term in which it is expressed
+gene expressed in anatomy:
+  description: holds between a gene and an anatomical entity in which it is expressed
   is_a: expression
   mixins:
   - biolink:GeneToExpressionSiteAssociation
   biolink_predicate: biolink:expressed_in
   inherit_properties: true
   represented_as: edge
-  input_label: expressed_in
+  input_label: gene_expressed_in_anatomy
+  output_label: expressed_in
   source: gene
-  target: ontology term
+  target: anatomy
   kgx_properties:
     subject_category: biolink:Gene
-    object_category: biolink:OntologyClass
+    object_category: biolink:AnatomicalEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    score:
+      type: float
+      biolink: has_quantitative_value
+    p_value:
+      type: float
+      biolink: has_quantitative_value
+
+gene expressed in developmental stage:
+  description: holds between a gene and a developmental stage in which it is expressed
+  is_a: expression
+  mixins:
+  - biolink:GeneToExpressionSiteAssociation
+  biolink_predicate: biolink:expressed_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_expressed_in_developmental_stage
+  output_label: expressed_in
+  source: gene
+  target: developmental stage
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:LifeStage
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
   properties:
@@ -1564,18 +1609,49 @@ gene to phenotype association:
       type: str
 
 gene to reaction association:
-  description: An interaction between a gene or a gene product (gogp) and a reaction
-    (Reactome).
+  description: An interaction between a gene and a reaction (Reactome).
   is_a: annotation
   biolink_predicate: biolink:participates_in
   inherit_properties: true
   represented_as: edge
   input_label: gene_or_gene_product_reaction
   output_label: involved_in
-  source: biolink:GeneOrGeneProduct
+  source: gene
   target: reaction
   kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
+    subject_category: biolink:Gene
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein to reaction association:
+  description: An interaction between a protein and a reaction (Reactome).
+  is_a: annotation
+  biolink_predicate: biolink:participates_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_or_gene_product_reaction
+  output_label: involved_in
+  source: protein
+  target: reaction
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+transcript to reaction association:
+  description: An interaction between a transcript and a reaction (Reactome).
+  is_a: annotation
+  biolink_predicate: biolink:participates_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_or_gene_product_reaction
+  output_label: involved_in
+  source: transcript
+  target: reaction
+  kgx_properties:
+    subject_category: biolink:Transcript
     object_category: biolink:MolecularActivity
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
@@ -1688,15 +1764,34 @@ has xref:
       type: str[]
       biolink: has_evidence
 
-input role protein to reaction or pathway association:
+input role protein to pathway association:
   is_a: annotation
   biolink_predicate: biolink:is_input_of
   inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein playing an input role in a pathway
   represented_as: edge
-  input_label: enables
+  input_label: protein_enables_pathway
+  output_label: enables
   source: protein
-  target: biolink:BiologicalProcessOrActivity
+  target: pathway
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+input role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: biolink:is_input_of
+  inherit_properties: true
+  description: holds between a protein playing an input role in a reaction
+  represented_as: edge
+  input_label: protein_enables_reaction
+  output_label: enables
+  source: protein
+  target: reaction
   properties:
     relation_ontology_term: str
   kgx_properties:
@@ -1784,15 +1879,34 @@ molecular function subclass:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-negative role protein to reaction or pathway association:
+negative role protein to pathway association:
   is_a: annotation
   biolink_predicate: biolink:regulates
   inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein negatively regulating a pathway
   represented_as: edge
-  input_label: negatively_regulates
+  input_label: protein_negatively_regulates_pathway
+  output_label: negatively_regulates
   source: protein
-  target: biolink:BiologicalProcessOrActivity
+  target: pathway
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+negative role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: biolink:regulates
+  inherit_properties: true
+  description: holds between a protein negatively regulating a reaction
+  represented_as: edge
+  input_label: protein_negatively_regulates_reaction
+  output_label: negatively_regulates
+  source: protein
+  target: reaction
   properties:
     relation_ontology_term: str
   kgx_properties:
@@ -1854,15 +1968,34 @@ orthology association:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-output role protein to reaction or pathway association:
+output role protein to pathway association:
   is_a: annotation
   biolink_predicate: biolink:produced_by
   inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein produced by a pathway
   represented_as: edge
-  input_label: produced_by
+  input_label: protein_produced_by_pathway
+  output_label: produced_by
   source: protein
-  target: biolink:BiologicalProcessOrActivity
+  target: pathway
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+output role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: biolink:produced_by
+  inherit_properties: true
+  description: holds between a protein produced by a reaction
+  represented_as: edge
+  input_label: protein_produced_by_reaction
+  output_label: produced_by
+  source: protein
+  target: reaction
   properties:
     relation_ontology_term: str
   kgx_properties:
@@ -1984,15 +2117,34 @@ pathway_to_molecular_function:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
-positive role protein to reaction or pathway association:
+positive role protein to pathway association:
   is_a: annotation
   biolink_predicate: biolink:regulates
   inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
+  description: holds between a protein positively regulating a pathway
   represented_as: edge
-  input_label: positively_regulates
+  input_label: protein_positively_regulates_pathway
+  output_label: positively_regulates
   source: protein
-  target: biolink:BiologicalProcessOrActivity
+  target: pathway
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+positive role protein to reaction association:
+  is_a: annotation
+  biolink_predicate: biolink:regulates
+  inherit_properties: true
+  description: holds between a protein positively regulating a reaction
+  represented_as: edge
+  input_label: protein_positively_regulates_reaction
+  output_label: positively_regulates
+  source: protein
+  target: reaction
   properties:
     relation_ontology_term: str
   kgx_properties:


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [x] Adapter fix / update
- [x] New processor / Processor fix
- [x] Schema change
- [x] Adapters config change
- [x] Writer fix / update
- [ ] CI / workflow change
- [x] Bug fix / Refactor

---

## Schema definition enforcement

### What this PR does

Enforces that every edge an adapter yields matches a schema-defined source/target type combination, and expands the schema configs to cover all biologically distinct edge types that were previously collapsed into generic labels.

Previously, adapters encoded type information by wrapping the target ID in a `('anatomy', id)` tuple, with no runtime check that the label was even defined in the schema. This PR moves that type information into explicit schema definitions and validates each edge at write time.

---

### Changes

#### Runtime validation (`biocypher_metta/__init__.py`, all writers)

`BaseWriter` now builds a lookup of valid `(source_type, target_type)`pairs per edge label from the schema at startup. All six writers call `validate_edge_types()` when an adapter emits a typed `(type, id)` tuple.
Un-typed adapters are unaffected — validation is skipped unless the adapter explicitly provides a typed ID.

#### Adapter refactoring (3 adapters)

| Adapter | Change |
|---|---|
| `BgeeAdapter` | `anatomy_label` + `developmental_stage_label` params replace hardcoded labels; target IDs simplified from `('anatomy', id)` → plain `id` |
| `GTExExpressionAdapter` | `anatomy_label` param; same target ID simplification |
| `ReactomeInferenceEdgesAdapter` | `pathway_label` + `reaction_label` params; added guard skipping roles not matching the configured label |

#### Schema expansion (3 config files)

| Config | Key additions |
|---|---|
| `primer_schema_config.yaml` | Reactome role-split edges (input/output/catalyst/neg-reg/pos-reg × pathway/reaction); expression site edges |
| `hsa_schema_config.yaml` | Same role-split edges; 45 chromatin/DNase/histone variant edges (5 anatomical targets each); gene/transcript/protein expression value edges |
| `dmel_schema_config.yaml` | Expression site edges (anatomy, dev stage, GO terms); physical interaction edges split by molecule type |

All new entries carry `biolink_predicate`, `subject_category`, `object_category`, `knowledge_level`, and `agent_type` for KGX compliance.

#### Adapter config updates (hsa + dmel)

`anatomy_label`, `developmental_stage_label`, `pathway_label`, and `reaction_label` args added to Bgee, GTEx, and Reactome adapter entries in both human and fly configs (full + sample). Corrects a stale filename in `dmel_adapters_config_sample.yaml`.

#### Documentation (`CONTRIBUTING.md`)

Section 5.2 updated to document `output_label`, the runtime `ValueError` raised for undeclared labels, and the pattern for splitting related edge types using per-role label parameters.

---

### Testing

- [x] `uv run pytest test/test.py --adapter-test-mode=smoke -v -s` passes
- [x] MeTTa output for a multi-type edge (e.g. Reactome input role) produces one constructor line per source×target combo in `type_defs.metta`
- [x] Dry-run build for both `hsa` and `dmel` configs completes without `ValueError` from `validate_edge_types()`
- [x] An adapter yielding an undeclared label raises `ValueError` immediately
