### PR TITLE
feat: Add pipeline run summary, elapsed time tracking, and graph_info enhancements

### DIFF
--- a/biocypher_metta/processors/entrez_ensembl_processor.py
+++ b/biocypher_metta/processors/entrez_ensembl_processor.py
@@ -95,9 +95,9 @@ class EntrezEnsemblProcessor(BaseMappingProcessor):
                 if chunk:
                     f.write(chunk)
                     downloaded += len(chunk)
-                    mb_downloaded = downloaded // (1024 * 1024)
-                    if mb_downloaded > 0 and downloaded % (1024 * 1024) < chunk_size:
-                        logger.info(f"{self.name}: Downloaded {mb_downloaded} MB...")
+                    # mb_downloaded = downloaded // (1024 * 1024)
+                    # if mb_downloaded > 0 and downloaded % (1024 * 1024) < chunk_size:
+                    #     logger.info(f"{self.name}: Downloaded {mb_downloaded} MB...")
 
         logger.info(f"{self.name}: NCBI Gene Info downloaded successfully")
 
@@ -113,9 +113,9 @@ class EntrezEnsemblProcessor(BaseMappingProcessor):
                 if chunk:
                     f.write(chunk)
                     downloaded += len(chunk)
-                    mb_downloaded = downloaded // (1024 * 1024)
-                    if mb_downloaded > 0 and mb_downloaded % 10 == 0 and downloaded % (10 * 1024 * 1024) < chunk_size:
-                        logger.info(f"{self.name}: Downloaded {mb_downloaded} MB...")
+                    # mb_downloaded = downloaded // (1024 * 1024)
+                    # if mb_downloaded > 0 and mb_downloaded % 10 == 0 and downloaded % (10 * 1024 * 1024) < chunk_size:
+                    #     logger.info(f"{self.name}: Downloaded {mb_downloaded} MB...")
 
         logger.info(f"{self.name}: GENCODE annotations downloaded successfully ({downloaded // (1024 * 1024)} MB)")
 
@@ -140,8 +140,8 @@ class EntrezEnsemblProcessor(BaseMappingProcessor):
                     if line.startswith('#') or not line.strip():
                         continue
 
-                    if line_num % 10000 == 0:
-                        logger.info(f"{self.name}: Processed {line_num:,} lines from Gene Info...")
+                    # if line_num % 10000 == 0:
+                    #     logger.info(f"{self.name}: Processed {line_num:,} lines from Gene Info...")
 
                     fields = line.split('\t')
                     if len(fields) < 16:
@@ -201,8 +201,8 @@ class EntrezEnsemblProcessor(BaseMappingProcessor):
                     if line.startswith('#') or not line.strip():
                         continue
 
-                    if line_num % 100000 == 0:
-                        logger.info(f"{self.name}: Processed {line_num:,} lines from GENCODE...")
+                    # if line_num % 100000 == 0:
+                    #     logger.info(f"{self.name}: Processed {line_num:,} lines from GENCODE...")
 
                     fields = line.split('\t')
                     if len(fields) < 9:

--- a/checkpoint_manager.py
+++ b/checkpoint_manager.py
@@ -78,7 +78,8 @@ class CheckpointManager:
         "nodes_count": {...},
         "nodes_props":  {...},    # lists (serialised sets)
         "edges_count":  {...},
-        "datasets_dict": {...}
+        "datasets_dict": {...},
+        "elapsed_seconds": 0.0    # accumulated wall-clock time across all runs
     }
     """
 

--- a/checkpoint_manager.py
+++ b/checkpoint_manager.py
@@ -130,6 +130,7 @@ class CheckpointManager:
         edges_count: Counter,
         datasets_dict: dict,
         failed_adapter: Optional[str] = None,
+        elapsed_seconds: float = 0.0,
     ):
         """Atomically write the checkpoint file."""
         now = datetime.utcnow().isoformat()
@@ -143,6 +144,7 @@ class CheckpointManager:
             "nodes_props": _serialize(nodes_props),
             "edges_count": _serialize(edges_count),
             "datasets_dict": _serialize(datasets_dict),
+            "elapsed_seconds": elapsed_seconds,
         }
         # Write atomically via a temp file
         tmp = self.checkpoint_path.with_suffix(".tmp")
@@ -177,6 +179,12 @@ class CheckpointManager:
             _deserialize_edges_count(self._state.get("edges_count", {})),
             _deserialize_datasets_dict(self._state.get("datasets_dict", {})),
         )
+
+    def restore_elapsed(self) -> float:
+        """Return accumulated elapsed seconds from previous run(s)."""
+        if self._state is None:
+            return 0.0
+        return self._state.get("elapsed_seconds", 0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -904,7 +904,7 @@ def main(
                         resume=resume,
                     )
 
-                    nodes_count, nodes_props, edges_count, datasets_dict = process_adapters(
+                    nodes_count, nodes_props, edges_count, datasets_dict, adapter_times, empty_output_adapters, total_start = process_adapters(
                         sp_adapters_dict,
                         sp_dbsnp_rsids_dict,
                         sp_dbsnp_pos_dict,
@@ -939,9 +939,25 @@ def main(
 
                     delete_temp_schema(sp_schema_config)
 
-                    logger.info(f"Done with {sp}")
-                    logger.info(f"Total nodes processed for {sp}: {sum(nodes_count.values())}")
-                    logger.info(f"Total edges processed for {sp}: {sum(edges_count.values())}")
+                    logger.info("")
+                    logger.info("#" * 60)
+                    logger.info(f"  PIPELINE COMPLETE [{sp}]")
+                    logger.info(f"  Total time  : {_fmt_elapsed(time.time() - total_start)}")
+                    logger.info(f"  Total nodes : {sum(nodes_count.values()):,}")
+                    logger.info(f"  Total edges : {sum(edges_count.values()):,}")
+                    if adapter_times:
+                        top = sorted(adapter_times.items(), key=lambda x: x[1], reverse=True)[:5]
+                        logger.info("")
+                        logger.info("  Top slowest adapters:")
+                        for rank, (name, secs) in enumerate(top, 1):
+                            logger.info(f"    {rank}. {name}: {_fmt_elapsed(secs)}")
+                    if empty_output_adapters:
+                        logger.info("")
+                        logger.info(f"  Empty output ({len({n for n, _ in empty_output_adapters})} adapter(s)):")
+                        for name, output_type in empty_output_adapters:
+                            logger.info(f"    - {name} ({output_type}: 0)")
+                    logger.info("#" * 60)
+                    logger.info("")
 
                 logger.info("\n" + "=" * 60)
                 logger.info("All species processed successfully!")

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -4,6 +4,7 @@ Knowledge graph generation through BioCypher script
 
 import importlib
 import json
+import logging
 import os
 import tempfile
 import time
@@ -252,6 +253,19 @@ def _fmt_elapsed(seconds: float) -> str:
     return f"{int(hours)}h {int(minutes)}m {seconds:.1f}s"
 
 
+def _add_file_logger(output_dir: Path) -> logging.FileHandler:
+    log_path = output_dir / "kg_pipeline.log"
+    handler = logging.FileHandler(log_path, encoding="utf-8")
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter(
+        "%(asctime)s  %(levelname)s -- %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    ))
+    logger.addHandler(handler)
+    logger.info(f"Pipeline log: {log_path}")
+    return handler
+
+
 def _load_adapters_config(config_path: Path, context: str) -> dict:
     with open(config_path, "r") as fp:
         try:
@@ -489,8 +503,8 @@ def process_adapters(
         adapter_times[adapter_name] = adapter_elapsed
         completed_adapters.append(adapter_name)
         logger.info(
-            f"Adapter '{adapter_name}' completed in {_fmt_elapsed(adapter_elapsed)}"
-            f"  [total: {_fmt_elapsed(time.time() - total_start)}]"
+            f"Adapter '{adapter_name}' completed"
+            f"  [time taken: {_fmt_elapsed(adapter_elapsed)}]"
         )
         if checkpoint_manager is not None:
             checkpoint_manager.save(
@@ -827,6 +841,7 @@ def main(
 
     is_merged_schema = False
     temp_schema_to_cleanup = None
+    _log_handlers: list = []
 
     try:
         if species_mode:
@@ -850,6 +865,7 @@ def main(
                     logger.info(f"{'=' * 60}\n")
 
                     sp_output_dir.mkdir(parents=True, exist_ok=True)
+                    _log_handlers.append(_add_file_logger(sp_output_dir))
                     config = species_config[sp][dataset]
 
                     sp_adapters_config = Path(config["adapters_config"])
@@ -1082,6 +1098,7 @@ def main(
             logger.info(f"Filtered to {len(adapters_dict)}/{original_count} adapters")
 
         output_dir.mkdir(parents=True, exist_ok=True)
+        _log_handlers.append(_add_file_logger(output_dir))
         ckpt = _setup_checkpoint(
             output_dir,
             pipeline_id=f"{output_dir}::{adapters_config}",
@@ -1142,6 +1159,9 @@ def main(
         logger.info("#" * 60)
         logger.info("")
     finally:
+        for _h in _log_handlers:
+            logger.removeHandler(_h)
+            _h.close()
         if is_merged_schema and temp_schema_to_cleanup is not None:
             delete_temp_schema(temp_schema_to_cleanup)
 

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -158,11 +158,13 @@ def preprocess_schema(schema_config_path: Path):
     return edge_node_types
 
 
-def gather_graph_info(nodes_count, nodes_props, edges_count, schema_dict, output_dir):
+def gather_graph_info(nodes_count, nodes_props, edges_count, schema_dict, output_dir, kg_format: str = ""):
     graph_info = {
         "node_count": sum(nodes_count.values()),
         "edge_count": sum(edges_count.values()),
         "dataset_count": 0,
+        "last_updated_at": str(date.today()),
+        "kg_format": kg_format,
         "data_size": "",
         "top_entities": [{"name": node, "count": count} for node, count in nodes_count.items()],
         "top_connections": [],
@@ -214,7 +216,7 @@ def gather_graph_info(nodes_count, nodes_props, edges_count, schema_dict, output
 
     for node, props in nodes_props.items():
         graph_info["schema"]["nodes"].append(
-            {"data": {"name": node, "properties": list(props)}}
+            {"data": {"id": node, "properties": list(props)}}
         )
 
     for conn, pos_connections in possible_connections.items():
@@ -370,9 +372,11 @@ def process_adapters(
         checkpoint_manager.completed_adapters if checkpoint_manager else []
     )
     empty_output_adapters: list[tuple[str, str]] = []
-    total_start = time.time()
+    elapsed_offset = checkpoint_manager.restore_elapsed() if checkpoint_manager else 0.0
+    total_start = time.time() - elapsed_offset
     total_adapters = len(adapters_dict)
     current_adapter_idx = 0
+    adapter_times: dict[str, float] = {}
 
     for adapter_name in adapters_dict:
         current_adapter_idx += 1
@@ -384,7 +388,7 @@ def process_adapters(
         writer.clear_counts()
         logger.info("")
         logger.info("=" * 60)
-        logger.info(f"  >> [{current_adapter_idx}/{total_adapters}] Running adapter: {adapter_name}")
+        logger.info(f"  >> [{current_adapter_idx}/{total_adapters}] Running adapter: {adapter_name}  [total: {_fmt_elapsed(time.time() - total_start)}]")
         logger.info("=" * 60)
 
         adapter_config = adapters_dict[adapter_name]["adapter"]
@@ -474,15 +478,19 @@ def process_adapters(
                     edges_count=edges_count,
                     datasets_dict=datasets_dict,
                     failed_adapter=adapter_name,
+                    elapsed_seconds=time.time() - total_start,
                 )
                 logger.info(
                     f"Checkpoint saved. Re-run the pipeline to resume from adapter '{adapter_name}'."
                 )
             raise
 
+        adapter_elapsed = time.time() - adapter_start
+        adapter_times[adapter_name] = adapter_elapsed
         completed_adapters.append(adapter_name)
         logger.info(
-            f"Adapter '{adapter_name}' completed in {_fmt_elapsed(time.time() - adapter_start)}"
+            f"Adapter '{adapter_name}' completed in {_fmt_elapsed(adapter_elapsed)}"
+            f"  [total: {_fmt_elapsed(time.time() - total_start)}]"
         )
         if checkpoint_manager is not None:
             checkpoint_manager.save(
@@ -492,26 +500,20 @@ def process_adapters(
                 edges_count=edges_count,
                 datasets_dict=datasets_dict,
                 failed_adapter=None,
+                elapsed_seconds=time.time() - total_start,
             )
             # logger.info(f"Checkpoint updated after adapter: {adapter_name}")
 
-    if empty_output_adapters:
-        empty_adapter_count = len({name for name, _ in empty_output_adapters})
-        logger.warning(
-            f"{empty_adapter_count} adapter(s) produced empty output:"
-        )
-        for name, output_type in empty_output_adapters:
-            logger.warning(f"  - {name} ({output_type}: 0)")
     logger.info(f"All adapters completed in {_fmt_elapsed(time.time() - total_start)}")
-    return nodes_count, nodes_props, edges_count, datasets_dict
+    return nodes_count, nodes_props, edges_count, datasets_dict, adapter_times, empty_output_adapters, total_start
 
 
 def _write_graph_info(
-    nodes_count, nodes_props, edges_count, schema_dict, output_dir, datasets_dict
+    nodes_count, nodes_props, edges_count, schema_dict, output_dir, datasets_dict, kg_format: str = ""
 ):
     """Build and write graph_info.json."""
     graph_info = gather_graph_info(
-        nodes_count, nodes_props, edges_count, schema_dict, output_dir
+        nodes_count, nodes_props, edges_count, schema_dict, output_dir, kg_format=kg_format
     )
     for dataset_name in datasets_dict:
         datasets_dict[dataset_name]["nodes"] = list(datasets_dict[dataset_name]["nodes"])
@@ -929,6 +931,7 @@ def main(
                         schema_dict,
                         sp_output_dir,
                         datasets_dict,
+                        kg_format=writer_type,
                     )
 
                     if ckpt is not None:
@@ -1070,7 +1073,7 @@ def main(
             resume=resume,
         )
 
-        nodes_count, nodes_props, edges_count, datasets_dict = process_adapters(
+        nodes_count, nodes_props, edges_count, datasets_dict, adapter_times, empty_output_adapters, total_start = process_adapters(
             adapters_dict,
             dbsnp_rsids_dict,
             dbsnp_pos_dict,
@@ -1097,14 +1100,31 @@ def main(
             schema_dict,
             output_dir,
             datasets_dict,
+            kg_format=writer_type,
         )
 
         if ckpt is not None:
             ckpt.delete()
 
-        logger.info("Done")
-        logger.info(f"Total nodes processed: {sum(nodes_count.values())}")
-        logger.info(f"Total edges processed: {sum(edges_count.values())}")
+        logger.info("")
+        logger.info("#" * 60)
+        logger.info("  PIPELINE COMPLETE")
+        logger.info(f"  Total time  : {_fmt_elapsed(time.time() - total_start)}")
+        logger.info(f"  Total nodes : {sum(nodes_count.values()):,}")
+        logger.info(f"  Total edges : {sum(edges_count.values()):,}")
+        if adapter_times:
+            top = sorted(adapter_times.items(), key=lambda x: x[1], reverse=True)[:5]
+            logger.info("")
+            logger.info("  Top slowest adapters:")
+            for rank, (name, secs) in enumerate(top, 1):
+                logger.info(f"    {rank}. {name}: {_fmt_elapsed(secs)}")
+        if empty_output_adapters:
+            logger.info("")
+            logger.info(f"  Empty output ({len({n for n, _ in empty_output_adapters})} adapter(s)):")
+            for name, output_type in empty_output_adapters:
+                logger.info(f"    - {name} ({output_type}: 0)")
+        logger.info("#" * 60)
+        logger.info("")
     finally:
         if is_merged_schema and temp_schema_to_cleanup is not None:
             delete_temp_schema(temp_schema_to_cleanup)


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [ ] New processor / Processor fix
- [ ] Schema change
- [ ] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [x] Bug fix / Refactor

---

## Summary

- **Pipeline run summary**: Replaces the plain "Done / Total nodes / Total edges" log lines with a visually distinct `###` banner showing total time, node/edge counts, top 5 slowest adapters, and any adapters that produced empty output.

- **Elapsed time in adapter logs**: Every adapter header and completion line now shows `[total: Xh Ym Z.Zs]` — the accumulated wall-clock time since the pipeline started.

- **Checkpoint-aware elapsed time**: When resuming from a checkpoint, the elapsed timer continues from where it left off instead of resetting to zero. `CheckpointManager` now persists and restores `elapsed_seconds` across runs.

- **graph_info.json enhancements**: Added `last_updated_at` (date string) and `kg_format` (writer type: metta, neo4j, kgx, etc.) fields. Renamed `"name"` → `"id"` in schema node entries for consistency.

- **Quieter Entrez/ENSEMBL logs**: Commented out per-MB download progress and per-N-lines parsing progress in `EntrezEnsemblProcessor` — only start/finish/summary lines remain.

- **File Logger**: Pipeline logs are now saved to `kg_pipeline.log` inside the output directory, capturing every log line with timestamps for post-run inspection and debugging. The file handler is attached immediately after the output directory is created and flushed cleanly on exit, so the log is complete even if the run fails partway through.

## Log output (before → after)

**Before:**

```
INFO -- ============================================================
INFO --   >> [5/20] Running adapter: bgee_adapter
INFO -- ============================================================
...
INFO -- Adapter 'bgee_adapter' completed in 8m 22.1s
...
INFO -- Done
INFO -- Total nodes processed: 448798
INFO -- Total edges processed: 799715

```

**After:**

```
INFO -- ============================================================
INFO --   >> [5/20] Running adapter: bgee_adapter  [total: 1h 12m 4.3s]
INFO -- ============================================================
...
INFO -- Adapter 'bgee_adapter' completed   [time taken: 20m 26.4s]
...
INFO -- ############################################################
INFO --   PIPELINE COMPLETE
INFO --   Total time  : 2h 34m 10.0s
INFO --   Total nodes : 448,798
INFO --   Total edges : 799,715
INFO --
INFO --   Top slowest adapters:
INFO --     1. bgee_adapter: 45m 12.3s
INFO --     2. string_coexpression_adapter: 32m 4.1s
INFO --     3. gtex_expression_adapter: 18m 55.7s
INFO --     4. reactome_adapter: 9m 10.2s
INFO --     5. gencode_gene_adapter: 8m 22.1s
INFO --
INFO --   Empty output (2 adapter(s)):
INFO --     - uniprot_has_xref_cofactor (edges: 0)
INFO --     - uniprot_chebi_part_of_chebi (edges: 0)
INFO -- ############################################################
```

---

## Files changed
- `create_knowledge_graph.py` — elapsed time logging, pipeline summary banner, graph_info fields
- `checkpoint_manager.py` — persist/restore `elapsed_seconds` across interrupted runs
- `biocypher_metta/processors/entrez_ensembl_processor.py` — suppress verbose progress logs


---
## Checklist

### General
- [x] PR targets `main` and branch is up to date
- [x] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
- [x] No credentials, tokens, or real patient data committed

### New adapter
- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently

### Schema changes
- [ ] New labels are validated against BioCypher / Biolink expectations
- [ ] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
- [ ] Breaking label, schema, or adapter-arg changes are called out below

### Testing
- [x] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
- [ ] Ran additional focused checks relevant to the change
- [ ] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
- [ ] Spot-checked output node / edge labels and counts where relevant


