### PR TITLE
Adding HspDv and OMIM ontologies (hsa) #270

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to .env and fill in your actual values.
+# The .env file is gitignored and must never be committed.
+
+# ── BioPortal ────────────────────────────────────────────────────────────────
+# Required for downloading OMIM and Disease ontologies via the BioPortal API.
+# Register for a free API key at: https://bioportal.bioontology.org/account
+BIOPORTAL_API_KEY=your_bioportal_api_key_here
+
+# ── LLM / AI providers ───────────────────────────────────────────────────────
+# OPENAI_API_KEY=your_openai_api_key_here
+
+AI_PROVIDER=groq
+GROQ_API_KEY=your_groq_api_key_here
+GROQ_MODEL=llama-3.3-70b-versatile
+GROQ_API_KEY_ADAPTER_GEN=your_groq_api_key_here
+
+GEMINI_API_KEY=your_gemini_api_key_here
+
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_MODEL=openai/gpt-4o-mini

--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,6 @@
 # Copy this file to .env and fill in your actual values.
 # The .env file is gitignored and must never be committed.
 
-# ── BioPortal ────────────────────────────────────────────────────────────────
-# Required for downloading OMIM and Disease ontologies via the BioPortal API.
+# Required for downloading Disease ontologies via the BioPortal API.
 # Register for a free API key at: https://bioportal.bioontology.org/account
 BIOPORTAL_API_KEY=your_bioportal_api_key_here
-
-# ── LLM / AI providers ───────────────────────────────────────────────────────
-# OPENAI_API_KEY=your_openai_api_key_here
-
-AI_PROVIDER=groq
-GROQ_API_KEY=your_groq_api_key_here
-GROQ_MODEL=llama-3.3-70b-versatile
-GROQ_API_KEY_ADAPTER_GEN=your_groq_api_key_here
-
-GEMINI_API_KEY=your_gemini_api_key_here
-
-OPENROUTER_API_KEY=your_openrouter_api_key_here
-OPENROUTER_MODEL=openai/gpt-4o-mini

--- a/biocypher_metta/adapters/disease_ontology_adapter.py
+++ b/biocypher_metta/adapters/disease_ontology_adapter.py
@@ -1,14 +1,24 @@
 
+import os
 from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
 
 class DiseaseOntologyAdapter(OntologyAdapter):
-    ONTOLOGIES = {
-        # 'do': 'https://purl.obolibrary.org/obo/do.owl' 
-        # Sometimes the above link doesn't respond. This is an alternative:
-        'do': 'https://data.bioontology.org/ontologies/DOID/submissions/654/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb'        
-    }
+    @classmethod
+    def _get_ontologies(cls):
+        api_key = os.getenv('BIOPORTAL_API_KEY')
+        if not api_key:
+            raise EnvironmentError(
+                "BIOPORTAL_API_KEY environment variable is not set. "
+                "Please add it to your .env file to download the Disease Ontology."
+            )
+        return {
+            # 'do': 'https://purl.obolibrary.org/obo/do.owl'
+            # Sometimes the above link doesn't respond. This is an alternative:
+            'do': f'https://data.bioontology.org/ontologies/DOID/submissions/654/download?apikey={api_key}'
+        }
     
     def __init__(self, write_properties, add_provenance, ontology, type, label='disease', dry_run=False, add_description=False, cache_dir=None):
+        self.ONTOLOGIES = self._get_ontologies()
         super(DiseaseOntologyAdapter, self).__init__(write_properties, add_provenance, ontology, type, label, dry_run, add_description, cache_dir)
     
     def get_ontology_source(self):

--- a/biocypher_metta/adapters/hsapdv_ontology_adapter.py
+++ b/biocypher_metta/adapters/hsapdv_ontology_adapter.py
@@ -1,0 +1,21 @@
+from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
+
+class HsapDvOntologyAdapter(OntologyAdapter):
+    ONTOLOGIES = {
+        'hsapdv': 'http://purl.obolibrary.org/obo/hsapdv.owl'
+    }
+
+    def __init__(self, write_properties, add_provenance, ontology, type, label='developmental_stage', dry_run=False, add_description=False, cache_dir=None):
+        super().__init__(write_properties, add_provenance, ontology, type, label, dry_run, add_description, cache_dir)
+
+    def get_ontology_source(self):
+        """
+        Returns the source and source URL for HsapDv.
+        """
+        return 'HsapDv', 'http://purl.obolibrary.org/obo/hsapdv.owl'
+
+    def get_uri_prefixes(self):
+        """Define URI prefixes for HsapDv."""
+        return {
+            'primary': 'http://purl.obolibrary.org/obo/HsapDv_'
+        }

--- a/biocypher_metta/adapters/molecular_interactions_ontology_adapter.py
+++ b/biocypher_metta/adapters/molecular_interactions_ontology_adapter.py
@@ -1,5 +1,5 @@
 # https://purl.obolibrary.org/obo/mi.owl
-# https://data.bioontology.org/ontologies/MI/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb&download_format=rdf
+# Alternative (requires BIOPORTAL_API_KEY): https://data.bioontology.org/ontologies/MI/download?apikey=<BIOPORTAL_API_KEY>&download_format=rdf
 
 from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
 

--- a/biocypher_metta/adapters/omim_ontology_adapter.py
+++ b/biocypher_metta/adapters/omim_ontology_adapter.py
@@ -1,0 +1,31 @@
+from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
+
+class OMIMOntologyAdapter(OntologyAdapter):
+    ONTOLOGIES = {
+        'omim': 'https://data.bioontology.org/ontologies/OMIM/submissions/29/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb'
+    }
+
+    def __init__(self, write_properties, add_provenance, ontology, type, label='disease', dry_run=False, add_description=False, cache_dir=None):
+        super().__init__(write_properties, add_provenance, ontology, type, label, dry_run, add_description, cache_dir)
+
+    def get_ontology_source(self):
+        """
+        Returns the source and source URL for OMIM.
+        """
+        return 'OMIM', 'https://bioportal.bioontology.org/ontologies/OMIM'
+
+    def get_uri_prefixes(self):
+        """Define URI prefixes for OMIM."""
+        return {
+            'primary': 'http://purl.bioontology.org/ontology/OMIM/'
+        }
+
+    @classmethod
+    def to_key(cls, node_uri):
+        key = super().to_key(node_uri)
+        if key is not None and key.isdigit():
+            return f"OMIM:{key}"
+        # handle case where to_key already prefixed it with number_
+        if key is not None and key.startswith('number_'):
+            return f"OMIM:{key[7:]}"
+        return key

--- a/biocypher_metta/adapters/omim_ontology_adapter.py
+++ b/biocypher_metta/adapters/omim_ontology_adapter.py
@@ -1,11 +1,21 @@
+import os
 from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
 
 class OMIMOntologyAdapter(OntologyAdapter):
-    ONTOLOGIES = {
-        'omim': 'https://data.bioontology.org/ontologies/OMIM/submissions/29/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb'
-    }
+    @classmethod
+    def _get_ontologies(cls):
+        api_key = os.getenv('BIOPORTAL_API_KEY')
+        if not api_key:
+            raise EnvironmentError(
+                "BIOPORTAL_API_KEY environment variable is not set. "
+                "Please add it to your .env file to download the OMIM ontology."
+            )
+        return {
+            'omim': f'https://data.bioontology.org/ontologies/OMIM/submissions/29/download?apikey={api_key}'
+        }
 
     def __init__(self, write_properties, add_provenance, ontology, type, label='disease', dry_run=False, add_description=False, cache_dir=None):
+        self.ONTOLOGIES = self._get_ontologies()
         super().__init__(write_properties, add_provenance, ontology, type, label, dry_run, add_description, cache_dir)
 
     def get_ontology_source(self):

--- a/biocypher_metta/adapters/omim_ontology_adapter.py
+++ b/biocypher_metta/adapters/omim_ontology_adapter.py
@@ -1,33 +1,25 @@
-import os
+
 from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
 
 class OMIMOntologyAdapter(OntologyAdapter):
-    @classmethod
-    def _get_ontologies(cls):
-        api_key = os.getenv('BIOPORTAL_API_KEY')
-        if not api_key:
-            raise EnvironmentError(
-                "BIOPORTAL_API_KEY environment variable is not set. "
-                "Please add it to your .env file to download the OMIM ontology."
-            )
-        return {
-            'omim': f'https://data.bioontology.org/ontologies/OMIM/submissions/29/download?apikey={api_key}'
-        }
+
+    ONTOLOGIES = {
+        'omim': 'http://purl.obolibrary.org/obo/mondo/sources/omim.owl'
+    }
 
     def __init__(self, write_properties, add_provenance, ontology, type, label='disease', dry_run=False, add_description=False, cache_dir=None):
-        self.ONTOLOGIES = self._get_ontologies()
         super().__init__(write_properties, add_provenance, ontology, type, label, dry_run, add_description, cache_dir)
 
     def get_ontology_source(self):
         """
-        Returns the source and source URL for OMIM.
+        Return the ontology name and the URL of the OWL source.
         """
-        return 'OMIM', 'https://bioportal.bioontology.org/ontologies/OMIM'
+        return 'OMIM', 'http://purl.obolibrary.org/obo/mondo/sources/omim.owl'
 
     def get_uri_prefixes(self):
         """Define URI prefixes for OMIM."""
         return {
-            'primary': 'http://purl.bioontology.org/ontology/OMIM/'
+            'primary': 'https://omim.org/'
         }
 
     @classmethod
@@ -38,4 +30,6 @@ class OMIMOntologyAdapter(OntologyAdapter):
         # handle case where to_key already prefixed it with number_
         if key is not None and key.startswith('number_'):
             return f"OMIM:{key[7:]}"
+        if key is not None and key.startswith('PS') and key[2:].isdigit():
+            return f"OMIM:{key}"
         return key

--- a/biocypher_metta/adapters/ontologies_adapter.py
+++ b/biocypher_metta/adapters/ontologies_adapter.py
@@ -47,6 +47,7 @@ class OntologyAdapter(Adapter):
         self.cache = {}
         self.ontology = ontology
         self.add_description = add_description
+        self.world = None
 
         # Set source and source_url based on the ontology
         self.source, self.source_url = self.get_ontology_source()
@@ -112,7 +113,8 @@ class OntologyAdapter(Adapter):
                     meta = json.load(f)
         
                 cached_date = dt.fromisoformat(meta['date'])
-                cache_expired = dt.now() - cached_date > timedelta(days=self.cache_expiration_days)
+                now = dt.now(cached_date.tzinfo) if cached_date.tzinfo else dt.now()
+                cache_expired = now - cached_date > timedelta(days=self.cache_expiration_days)
         
                 remote_version = self._get_remote_version()
                 current_version = meta.get('version')
@@ -404,7 +406,8 @@ class OntologyAdapter(Adapter):
         if remote_version is None or current_version is None or current_version == "unknown":
             print("Version information is incomplete. Checking cache expiration.")
             cached_date = dt.fromisoformat(meta['date'])
-            if dt.now() - cached_date > timedelta(days=self.cache_expiration_days):
+            now = dt.now(cached_date.tzinfo) if cached_date.tzinfo else dt.now()
+            if now - cached_date > timedelta(days=self.cache_expiration_days):
                 print("Cache has expired. Updating data.")
                 return True
             else:

--- a/biocypher_metta/adapters/ontologies_adapter.py
+++ b/biocypher_metta/adapters/ontologies_adapter.py
@@ -461,12 +461,12 @@ class OntologyAdapter(Adapter):
         return self._is_new_version_available(meta)
     
     def is_deprecated(self, node):
-        node_key = OntologyAdapter.to_key(node)
+        node_key = self.to_key(node)
         deprecated_values = self.cache.get(node_key, {}).get('deprecated', [])
         return any(value for value in deprecated_values if value.lower() == 'true')
     
     def get_alternative_ids(self, node):
-        node_key = OntologyAdapter.to_key(node)
+        node_key = self.to_key(node)
         return self.cache.get(node_key, {}).get('alternative_ids', [])
     
     def _process_node_key(self, node):
@@ -583,13 +583,13 @@ class OntologyAdapter(Adapter):
 
                 # Skip deprecated nodes
                 if self.is_deprecated(from_node) or self.is_deprecated(to_node):
-                    print(f"Skipping edge with deprecated node: {OntologyAdapter.to_key(from_node)} -> {OntologyAdapter.to_key(to_node)}")
+                    print(f"Skipping edge with deprecated node: {self.to_key(from_node)} -> {self.to_key(to_node)}")
                     continue
 
                 if self.type == 'edge':
-                    from_node_key = OntologyAdapter.to_key(from_node)
-                    predicate_key = OntologyAdapter.to_key(predicate)
-                    to_node_key = OntologyAdapter.to_key(to_node)
+                    from_node_key = self.to_key(from_node)
+                    predicate_key = self.to_key(predicate)
+                    to_node_key = self.to_key(to_node)
 
                     if predicate == OntologyAdapter.DB_XREF:
                         if to_node.__class__ == rdflib.term.Literal:
@@ -724,7 +724,7 @@ class OntologyAdapter(Adapter):
     def cache_predicate(self, predicate, collection=None):
         triples = list(self.graph.subject_objects(predicate=predicate, unique=True))
         for s, o in triples:
-            s_key = OntologyAdapter.to_key(s)
+            s_key = self.to_key(s)
 
             if s_key not in self.cache:
                 self.cache[s_key] = {}
@@ -744,5 +744,5 @@ class OntologyAdapter(Adapter):
 
 
     def get_all_property_values_from_node(self, node, collection):
-        node_key = OntologyAdapter.to_key(node)
+        node_key = self.to_key(node)
         return self.cache.get(node_key, {}).get(collection, [])

--- a/biocypher_metta/adapters/ontologies_adapter.py
+++ b/biocypher_metta/adapters/ontologies_adapter.py
@@ -334,9 +334,12 @@ class OntologyAdapter(Adapter):
         print(f"Graph initialized with {len(self.graph)} triples for {self.ontology}")
 
     def __del__(self):
-        # Clean up the world instance when the adapter is destroyed
-        if self.world is not None:
-            self.world.close()
+        # Clean up the world instance when the adapter is destroyed.
+        # Use getattr to guard against partial initialisation (e.g. when
+        # __init__ raised before self.world was set by super().__init__).
+        world = getattr(self, 'world', None)
+        if world is not None:
+            world.close()
             self.world = None
 
     def _calculate_file_hash(self, file_path):

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -421,6 +421,64 @@ go_cellular_component_subclass_of:
   nodes: False
   edges: True
 
+hsapdv:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: node
+      label: developmental_stage
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: True
+  edges: False
+
+hsapdv_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: edge
+      label: hsapdv_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: False
+  edges: True
+
+omim:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: node
+      label: disease
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: True
+  edges: False
+
+omim_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: edge
+      label: omim_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: False
+  edges: True
+
 gaf_biological_process_gene_product:
   adapter:
     module: biocypher_metta.adapters.gaf_adapter

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -485,6 +485,64 @@ go_cellular_component_subclass_of:
   nodes: False
   edges: True
 
+hsapdv:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: node
+      label: developmental_stage
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: True
+  edges: False
+
+hsapdv_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: edge
+      label: hsapdv_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: False
+  edges: True
+
+omim:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: node
+      label: disease
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: True
+  edges: False
+
+omim_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: edge
+      label: omim_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: False
+  edges: True
+
 gaf_biological_process_gene_product:
   adapter:
     module: biocypher_metta.adapters.gaf_adapter

--- a/config/hsa/hsa_adapters_config_sample.yaml
+++ b/config/hsa/hsa_adapters_config_sample.yaml
@@ -2014,3 +2014,62 @@ alliance_gene_orthology:
   outdir: alliance/orthology
   nodes: False
   edges: True
+
+
+hsapdv:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: node
+      label: developmental_stage
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: True
+  edges: False
+
+hsapdv_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: edge
+      label: hsapdv_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: False
+  edges: True
+
+omim:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: node
+      label: disease
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: True
+  edges: False
+
+omim_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: edge
+      label: omim_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: False
+  edges: True

--- a/config/hsa/hsa_adapters_config_sample.yaml
+++ b/config/hsa/hsa_adapters_config_sample.yaml
@@ -1968,3 +1968,62 @@ alliance_gene_orthology:
   outdir: alliance/orthology
   nodes: False
   edges: True
+
+
+hsapdv:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: node
+      label: developmental_stage
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: True
+  edges: False
+
+hsapdv_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.hsapdv_ontology_adapter
+    cls: HsapDvOntologyAdapter
+    args:
+      ontology: 'hsapdv'
+      type: edge
+      label: hsapdv_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: hsapdv
+  nodes: False
+  edges: True
+
+omim:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: node
+      label: disease
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: True
+  edges: False
+
+omim_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.omim_ontology_adapter
+    cls: OMIMOntologyAdapter
+    args:
+      ontology: 'omim'
+      type: edge
+      label: omim_subclass_of
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: omim
+  nodes: False
+  edges: True

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -671,6 +671,36 @@ do subclass of:
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
+hsapdv subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: hsapdv_subclass_of
+  output_label: is_a
+  biolink_predicate: "biolink:subclass_of"
+  source: developmental stage
+  target: developmental stage
+  kgx_properties:
+    subject_category: "biolink:LifeStage"
+    object_category: "biolink:LifeStage"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
+omim subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: omim_subclass_of
+  output_label: is_a
+  biolink_predicate: "biolink:subclass_of"
+  source: disease
+  target: disease
+  kgx_properties:
+    subject_category: "biolink:Disease"
+    object_category: "biolink:Disease"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
 #chebi
 small molecule:
   is_a: ontology term

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -2,6 +2,15 @@
 Knowledge graph generation through BioCypher script
 """
 
+# Load environment variables from .env (if present) before anything else,
+# so secrets like BIOPORTAL_API_KEY are available to all adapters.
+try:
+    from dotenv import load_dotenv as _load_dotenv
+    _load_dotenv(override=False)  # don't override vars already set in the shell
+except ImportError:
+    pass  # python-dotenv is optional; set env vars manually if not installed
+
+
 import importlib
 import json
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dependencies = [
     "pytest==8.4.2",
     "pytest-cov==5.0.0",
     "python-dateutil==2.9.0.post0",
+    "python-dotenv>=1.0.0",
     "pytz==2025.2",
     "pyyaml==6.0.3",
     "questionary==2.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -148,6 +148,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-dateutil" },
+    { name = "python-dotenv" },
     { name = "pytz" },
     { name = "pyyaml" },
     { name = "questionary" },
@@ -246,6 +247,7 @@ requires-dist = [
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-cov", specifier = "==5.0.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pytz", specifier = "==2025.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "questionary", specifier = "==2.1.1" },
@@ -1438,6 +1440,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary

#270 

This PR integrates the **HsapDv** (Human Developmental Stage) and **OMIM** (Disease) ontologies into the BioCypher-KG pipeline.

Changes

- Adapters: Implemented **HsapDvOntologyAdapter** and **OMIMOntologyAdapter** (with custom **CURIE ID** mapping for OMIM).
- Config: Updated **hsa_schema_config.yaml** and adapter configs (full/sample) to support these new sources and their hierarchies.

Bug Fixes:

- Resolved TypeError in OntologyAdapter by ensuring datetime comparisons are timezone-aware.