### PR TITLE
Fix: Use helper function for cCRE adapter IDs

### DIFF
--- a/biocypher_metta/adapters/candidate_cis_regulatory_enhancer_adapter.py
+++ b/biocypher_metta/adapters/candidate_cis_regulatory_enhancer_adapter.py
@@ -31,6 +31,7 @@ class EnhancercCREAdapter(Adapter):
         super(EnhancercCREAdapter, self).__init__(write_properties, add_provenance)
 
     def get_nodes(self):
+        from biocypher_metta.adapters.helpers import build_regulatory_region_id
         try:
             if self.filepath.endswith('.gz'):
                 file = gzip.open(self.filepath, 'rt')
@@ -72,7 +73,7 @@ class EnhancercCREAdapter(Adapter):
                         props['source'] = self.source
                         props['source_url'] = self.source_url
 
-                element_id = f"ENCODE_SCREEN:{chrom}_{start}_{end}"
+                element_id = f"ENCODE_SCREEN:{build_regulatory_region_id(chrom, start, end)}"
                 yield element_id, self.label, props
             
             file.close()                
@@ -84,6 +85,7 @@ class EnhancercCREAdapter(Adapter):
             raise
     
     def get_edges(self):
+        from biocypher_metta.adapters.helpers import build_regulatory_region_id
         try:
             if self.filepath.endswith('.gz'):
                 file = gzip.open(self.filepath, 'rt')
@@ -141,7 +143,7 @@ class EnhancercCREAdapter(Adapter):
                     props['source'] = self.source
                     props['source_url'] = self.source_url
 
-                element_id = f"ENCODE_SCREEN:{chrom}_{start}_{end}"
+                element_id = f"ENCODE_SCREEN:{build_regulatory_region_id(chrom, start, end)}"
                 yield element_id, gene_id, self.label, props
             
             file.close()

--- a/biocypher_metta/adapters/candidate_cis_regulatory_promoter_adapter.py
+++ b/biocypher_metta/adapters/candidate_cis_regulatory_promoter_adapter.py
@@ -68,6 +68,7 @@ class PromotercCREAdapter(Adapter):
         return ontology_id if ontology_id else tissue_name
     
     def _preload_data(self):
+        from biocypher_metta.adapters.helpers import build_regulatory_region_id
         try:
             if self.filepath.endswith('.gz'):
                 file = gzip.open(self.filepath, 'rt')
@@ -125,7 +126,7 @@ class PromotercCREAdapter(Adapter):
                     except (ValueError, IndexError):
                         distance = "NA"
                 
-                element_id = f"ENCODE_SCREEN:{chrom}_{start}_{end}"
+                element_id = f"ENCODE_SCREEN:{build_regulatory_region_id(chrom, start, end)}"
                 self.accession_to_promoter[accession] = {
                     'chrom': chrom,
                     'start': start,


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [x] Adapter fix / update
- [ ] New processor / Processor fix
- [ ] Schema change
- [ ] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [x] Bug fix / Refactor

---

## Summary

Refactor the cCRE adapters to use the `build_regulatory_region_id` helper function instead of manually constructing regulatory region IDs.

**Changes**
- **EnhancercCREAdapter**: Updated both `get_nodes()` and `get_edges()` methods to use `build_regulatory_region_id()` for generating `element_id`
- **PromotercCREAdapter**: Updated `_preload_data()` method to use the helper function instead of inline ID construction
