### PR TITLE
fix: downloader import, parquet writer visibility, and README accuracy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help setup check-uv run run-interactive run-sample run-direct check-paths test clean distclean \
+.PHONY: help setup check-uv run run-interactive run-sample run-direct check-paths \
+        download download-direct \
+        test clean distclean \
         neo4j-up neo4j-down neo4j-logs neo4j-status neo4j-load neo4j-load-direct
 
 # Path to the Neo4j env file; override with: make neo4j-up NEO4J_ENV_FILE=my.env
@@ -12,6 +14,8 @@ help:
 	@echo "  make run-sample     - Run with sample configuration and data"
 	@echo "  make run-direct     - Run with explicit parameters (non-interactive)"
 	@echo "  make check-paths    - Validate file paths in an adapters config (no adapters run)"
+	@echo "  make download       - Download data sources (interactive)"
+	@echo "  make download-direct - Download data sources with explicit parameters"
 	@echo "  make test           - Run tests"
 	@echo "  make clean          - Clean temporary files"
 	@echo "  make distclean      - Full clean including virtual environment"
@@ -34,6 +38,9 @@ help:
 	@echo "  make run-sample     SKIP_PREFLIGHT=yes   - Same, for sample runs"
 	@echo "  make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env"
 	@echo "  make run-sample INCLUDE_TAXON_ID=no   - Run without taxon_id in output (single-species KG)"
+	@echo "  make download                          - Interactive download (recommended)"
+	@echo "  make download-direct OUTPUT_DIR=./input SOURCE=uniprot  - Download a single source"
+	@echo "  make download-direct OUTPUT_DIR=./input CONFIG_FILE=./config/dmel/dmel_data_source_config.yaml"
 
 # Check if UV is installed, install via pip if not
 check-uv:
@@ -283,6 +290,50 @@ neo4j-load-direct: check-uv ## Load ALL data directly, skipping version check
 	export PATH="$$HOME/.local/bin:$$PATH"; \
 	uv run python scripts/neo4j_loader.py \
 		--env-file $(NEO4J_ENV_FILE)
+
+# ─── Data download ───────────────────────────────────────────────────────────
+
+# Interactive download
+download: check-uv
+	@echo "\n📥 Starting interactive data download..."
+	@echo "Press ENTER to use the default value [in square brackets]...\n"
+	@read -p "📁 Enter output directory [./input]: " OUTPUT_DIR; \
+	OUTPUT_DIR=$${OUTPUT_DIR:-./input}; \
+	echo "Using output directory: $$OUTPUT_DIR"; \
+	echo ""; \
+	read -p "⚙️  Enter config file path [./config/hsa/hsa_data_source_config.yaml]: " CONFIG_FILE; \
+	CONFIG_FILE=$${CONFIG_FILE:-./config/hsa/hsa_data_source_config.yaml}; \
+	echo "Using config file: $$CONFIG_FILE"; \
+	echo ""; \
+	read -p "🔬 Enter source name to download (leave blank to download all): " SOURCE; \
+	if [ -n "$$SOURCE" ]; then \
+		SOURCE_FLAG="--source $$SOURCE"; \
+		echo "Downloading source: $$SOURCE"; \
+	else \
+		SOURCE_FLAG=""; \
+		echo "Downloading all sources"; \
+	fi; \
+	echo ""; \
+	echo "📥 Starting download..."; \
+	export PATH="$$HOME/.local/bin:$$PATH"; \
+	uv run python biocypher_dataset_downloader/download_data.py \
+		--output-dir "$$OUTPUT_DIR" \
+		--config-file "$$CONFIG_FILE" \
+		$$SOURCE_FLAG && \
+	echo "✅ Download completed! Check $$OUTPUT_DIR for results."
+
+# Direct download with explicit parameters
+download-direct: check-uv
+	@if [ -z "$(OUTPUT_DIR)" ]; then \
+		echo "❌ Error: OUTPUT_DIR is required"; \
+		echo "Usage: make download-direct OUTPUT_DIR=./input [CONFIG_FILE=./config/hsa/hsa_data_source_config.yaml] [SOURCE=<source_name>]"; \
+		exit 1; \
+	fi
+	@export PATH="$$HOME/.local/bin:$$PATH"; \
+	uv run python biocypher_dataset_downloader/download_data.py \
+		--output-dir $(OUTPUT_DIR) \
+		--config-file $(if $(CONFIG_FILE),$(CONFIG_FILE),./config/hsa/hsa_data_source_config.yaml) \
+		$(if $(SOURCE),--source $(SOURCE),)
 
 # ─── Tests ───────────────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -295,8 +295,8 @@ neo4j-load-direct: check-uv ## Load ALL data directly, skipping version check
 
 # Interactive download
 download: check-uv
-	@echo "\n📥 Starting interactive data download..."
-	@echo "Press ENTER to use the default value [in square brackets]...\n"
+	@printf '\n%s\n' "📥 Starting interactive data download..."
+	@printf '%s\n\n' "Press ENTER to use the default value [in square brackets]..."
 	@read -p "📁 Enter output directory [./input]: " OUTPUT_DIR; \
 	OUTPUT_DIR=$${OUTPUT_DIR:-./input}; \
 	echo "Using output directory: $$OUTPUT_DIR"; \
@@ -316,7 +316,7 @@ download: check-uv
 	echo ""; \
 	echo "📥 Starting download..."; \
 	export PATH="$$HOME/.local/bin:$$PATH"; \
-	uv run python biocypher_dataset_downloader/download_data.py \
+	uv run python -m biocypher_dataset_downloader.download_data \
 		--output-dir "$$OUTPUT_DIR" \
 		--config-file "$$CONFIG_FILE" \
 		$$SOURCE_FLAG && \
@@ -330,10 +330,10 @@ download-direct: check-uv
 		exit 1; \
 	fi
 	@export PATH="$$HOME/.local/bin:$$PATH"; \
-	uv run python biocypher_dataset_downloader/download_data.py \
-		--output-dir $(OUTPUT_DIR) \
-		--config-file $(if $(CONFIG_FILE),$(CONFIG_FILE),./config/hsa/hsa_data_source_config.yaml) \
-		$(if $(SOURCE),--source $(SOURCE),)
+	uv run python -m biocypher_dataset_downloader.download_data \
+		--output-dir "$(OUTPUT_DIR)" \
+		--config-file "$(if $(CONFIG_FILE),$(CONFIG_FILE),./config/hsa/hsa_data_source_config.yaml)" \
+		$(if $(SOURCE),--source "$(SOURCE)",)
 
 # ─── Tests ───────────────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ run-interactive: check-uv
 		echo "dbSNP variant: not set (sample mode)"; \
 	fi; \
 	echo ""; \
-	read -p "📝 Enter writer type (metta/prolog/neo4j) [metta]: " WRITER_TYPE; \
+	read -p "📝 Enter writer type (metta/prolog/neo4j/parquet/networkx/KGX) [metta]: " WRITER_TYPE; \
 	WRITER_TYPE=$${WRITER_TYPE:-metta}; \
 	echo "Using writer type: $$WRITER_TYPE"; \
 	echo ""; \

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ When you run `make run`, you'll see:
 
 📁 Enter output directory [./output]: 
 ⚙️  Enter adapters config path [./config/adapters_config_sample.yaml]: 
-🧬 Enter dbSNP RSIDs path [./aux_files/sample_dbsnp_rsids.pkl]: 
-📍 Enter dbSNP positions path [./aux_files/sample_dbsnp_pos.pkl]: 
-📝 Enter writer type (metta/prolog/neo4j) [metta]: 
+🗂️  Enter dbSNP cache root [./aux_files/hsa/sample_dbsnp]: 
+🧬 Enter dbSNP variant (common/full/leave blank for sample) []: 
+📝 Enter writer type (metta/prolog/neo4j/parquet/networkx/KGX) [metta]: 
 📋 Write properties? (yes/no) [no]: 
 🔗 Add provenance? (yes/no) [no]: 
 🧬 Include taxon_id in output? (yes/no) [yes]: 
@@ -295,15 +295,54 @@ python kg-service/neo4j_loader.py \
 - Edges use `CREATE` (not `MERGE`) — the loader surgically deletes changed edges before reloading, so the existence check is unnecessary and very slow on large files.
 
 ## ⬇ Downloading data
-The `downloader` directory contains code for downloading data from various sources.
+The `biocypher_dataset_downloader` directory contains code for downloading data from various sources.
 The `download.yaml` file contains the configuration for the data sources.
 
 To download the data, run the `download_data.py` script with the following command:
 ```{bash}
-python downloader/download_data.py --output_dir <output_directory>
+python biocypher_dataset_downloader/download_data.py --output_dir <output_directory>
 ```
 
 To download data from a specific source, run the script with the following command:
 ```{bash}
-python downloader/download_data.py --output_dir <output_directory> --source <source_name>
+python biocypher_dataset_downloader/download_data.py --output_dir <output_directory> --source <source_name>
+```
+
+## 🧬 dbSNP Cache
+
+The pipeline requires a pre-built dbSNP cache for human (`hsa`) runs. Sample runs use the bundled cache at `aux_files/hsa/sample_dbsnp` automatically.
+
+### Bizon server (pre-built cache available)
+
+If you have access to the Bizon server, the cache is already available — no build step needed:
+```
+dbSNP cache root: /mnt/hdd_1/biocypher-kg/input/hsa/dbsnp/rsids_map/
+dbSNP variant:    common
+```
+
+Pass these when prompted by `make run`, or set them directly:
+```bash
+uv run python create_knowledge_graph.py \
+  --dbsnp-cache-root /mnt/hdd_1/biocypher-kg/input/hsa/dbsnp/rsids_map/ \
+  --dbsnp-variant common \
+  ...
+```
+
+### Building the cache from scratch
+
+Use `scripts/update_dbsnp.py` to generate the cache locally:
+```bash
+# Common variants only (~1–2 GB, recommended)
+python scripts/update_dbsnp.py --cache-dir <root>/common --common-only
+
+# All variants (~35–50 GB)
+python scripts/update_dbsnp.py --cache-dir <root>/full
+```
+
+Then either pass `--dbsnp-cache-root <root>` on the command line, or set `dbsnp_cache_root` in `config/species_config.yaml`:
+```yaml
+hsa:
+  full:
+    dbsnp_cache_root: /path/to/dbsnp/cache
+    dbsnp_variant: common   # or "full"
 ```

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ When you run `make run`, you'll see:
 🚀 Starting interactive knowledge graph creation...
 
 📁 Enter output directory [./output]: 
-⚙️  Enter adapters config path [./config/adapters_config_sample.yaml]: 
+⚙️  Enter adapters config path [./config/hsa/hsa_adapters_config_sample.yaml]: 
+📊 Enter schema config path [./config/hsa/hsa_schema_config.yaml]: 
 🗂️  Enter dbSNP cache root [./aux_files/hsa/sample_dbsnp]: 
 🧬 Enter dbSNP variant (common/full/leave blank for sample) []: 
 📝 Enter writer type (metta/prolog/neo4j/parquet/networkx/KGX) [metta]: 
-📋 Write properties? (yes/no) [no]: 
+🔌 Enter adapters to include [all]: 
+📋 Write properties? (yes/no) [yes]: 
 🔗 Add provenance? (yes/no) [no]: 
 🧬 Include taxon_id in output? (yes/no) [yes]: 
+🚦 Skip pre-flight path validation? (yes/no) [no]: 
 ```
 
 ### Available Make Commands

--- a/README.md
+++ b/README.md
@@ -56,16 +56,18 @@ When you run `make run`, you'll see:
 
 ### Available Make Commands
 ```bash
-make help           # Show all commands
-make setup          # Install UV and dependencies
-make run            # Interactive mode (recommended)
+make help            # Show all commands
+make setup           # Install UV and dependencies
+make run             # Interactive mode (recommended)
 make run-interactive # Same as make run
-make run-direct     # Direct mode with parameters
-make run-sample     # Run with sample data
-make check-paths    # Validate file paths in an adapters config (no adapters run)
-make test           # Run tests
-make clean          # Clean temporary files
-make distclean      # Full clean
+make run-direct      # Direct mode with parameters
+make run-sample      # Run with sample data
+make check-paths     # Validate file paths in an adapters config (no adapters run)
+make download        # Download data sources (interactive)
+make download-direct # Download data sources with explicit parameters
+make test            # Run tests
+make clean           # Clean temporary files
+make distclean       # Full clean
 ```
 
 ### Pre-flight File Path Validation
@@ -296,16 +298,37 @@ python kg-service/neo4j_loader.py \
 
 ## ⬇ Downloading data
 The `biocypher_dataset_downloader` directory contains code for downloading data from various sources.
-The `download.yaml` file contains the configuration for the data sources.
+Data source URLs and metadata are configured in the species-specific config files under `config/` (e.g. `config/hsa/hsa_data_source_config.yaml`).
 
-To download the data, run the `download_data.py` script with the following command:
-```{bash}
-python biocypher_dataset_downloader/download_data.py --output_dir <output_directory>
+### Interactive (recommended)
+
+```bash
+make download
 ```
 
-To download data from a specific source, run the script with the following command:
-```{bash}
-python biocypher_dataset_downloader/download_data.py --output_dir <output_directory> --source <source_name>
+You will be prompted for the output directory, config file path, and an optional source name (leave blank to download everything).
+
+### Direct mode
+
+```bash
+# Download all sources for human
+make download-direct OUTPUT_DIR=./input
+
+# Download a single source
+make download-direct OUTPUT_DIR=./input SOURCE=uniprot
+
+# Download all sources for Drosophila
+make download-direct OUTPUT_DIR=./input CONFIG_FILE=./config/dmel/dmel_data_source_config.yaml
+```
+
+### Without Make
+
+```bash
+# Download all sources
+python biocypher_dataset_downloader/download_data.py --output-dir <output_directory>
+
+# Download a specific source
+python biocypher_dataset_downloader/download_data.py --output-dir <output_directory> --source <source_name>
 ```
 
 ## 🧬 dbSNP Cache

--- a/README.md
+++ b/README.md
@@ -325,10 +325,10 @@ make download-direct OUTPUT_DIR=./input CONFIG_FILE=./config/dmel/dmel_data_sour
 
 ```bash
 # Download all sources
-python biocypher_dataset_downloader/download_data.py --output-dir <output_directory>
+python -m biocypher_dataset_downloader.download_data --output-dir <output_directory>
 
 # Download a specific source
-python biocypher_dataset_downloader/download_data.py --output-dir <output_directory> --source <source_name>
+python -m biocypher_dataset_downloader.download_data --output-dir <output_directory> --source <source_name>
 ```
 
 ## 🧬 dbSNP Cache
@@ -365,7 +365,7 @@ python scripts/update_dbsnp.py --cache-dir <root>/full
 Then either pass `--dbsnp-cache-root <root>` on the command line, or set `dbsnp_cache_root` in `config/species_config.yaml`:
 ```yaml
 hsa:
-  full:
+  full:                          # dataset type (sample vs full run)
     dbsnp_cache_root: /path/to/dbsnp/cache
-    dbsnp_variant: common   # or "full"
+    dbsnp_variant: common        # SNP variant subset: "common" (~1-2 GB) or "full" (~35-50 GB)
 ```

--- a/biocypher_dataset_downloader/download_data.py
+++ b/biocypher_dataset_downloader/download_data.py
@@ -1,12 +1,7 @@
-import sys
-import os
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 import typer
 from pathlib import Path
 from typing_extensions import Annotated
-from biocypher_dataset_downloader import DownloadManager
+from .download_manager import DownloadManager
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -15,7 +10,7 @@ app = typer.Typer()
 @app.command()
 def download_data(
     output_dir: Annotated[Path, typer.Option(exists=False, file_okay=False, dir_okay=True)],
-    config_file: str = "config/data_source_config.yaml",
+    config_file: str = "config/hsa/hsa_data_source_config.yaml",
     source: str = None
 ):
     """Download data sources"""

--- a/biocypher_dataset_downloader/download_data.py
+++ b/biocypher_dataset_downloader/download_data.py
@@ -1,7 +1,7 @@
 import typer
 from pathlib import Path
 from typing_extensions import Annotated
-from downloader import DownloadManager
+from biocypher_dataset_downloader import DownloadManager
 import logging
 
 logging.basicConfig(level=logging.INFO)

--- a/biocypher_dataset_downloader/download_data.py
+++ b/biocypher_dataset_downloader/download_data.py
@@ -1,3 +1,8 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import typer
 from pathlib import Path
 from typing_extensions import Annotated

--- a/biocypher_dataset_downloader/download_data.py
+++ b/biocypher_dataset_downloader/download_data.py
@@ -1,7 +1,7 @@
 import typer
 from pathlib import Path
 from typing_extensions import Annotated
-from .download_manager import DownloadManager
+from biocypher_dataset_downloader.download_manager import DownloadManager
 import logging
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [x] New processor / Processor fix
- [ ] Schema change
- [ ] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [x] Bug fix / Refactor
- [x] README

---

## Summary

- **Broken downloader import** (`biocypher_dataset_downloader/download_data.py`):
  The script imported `from downloader import DownloadManager` after the package was renamed, causing a `ModuleNotFoundError` on every invocation. Fixed to use the correct package name.

- **`make download` and `make download-direct` targets** (`Makefile`):
  Added two new targets for downloading data sources, following the same interactive/direct pattern as the `run` commands. `make download` prompts for output directory, config file, and an optional source name. `make download-direct` accepts `OUTPUT_DIR=`, `CONFIG_FILE=`, and `SOURCE=` as parameters.

- **Parquet writer hidden from `make run`** (`Makefile`):
  The interactive prompt only listed `metta/prolog/neo4j`. Parquet (and networkx, KGX) are fully implemented and wired into `create_knowledge_graph.py` but were invisible to users going through the interactive flow. Prompt updated to list all six writers.

- **Stale README** (`README.md`):
  - The downloader section referenced the old `downloader/` path in both prose and code examples; updated to `biocypher_dataset_downloader/`.
  - The interactive-mode example showed `.pkl` dbSNP paths that no longer exist; updated to the current `--dbsnp-cache-root` / `--dbsnp-variant` interface.
  - Expanded the Downloading data section with `make download` / `make download-direct` usage and added the new targets to the Available Make Commands table.
  - Added a new **dbSNP Cache** section covering the pre-built cache on the Bizon server (`/mnt/hdd_1/biocypher-kg/input/hsa/dbsnp/rsids_map/`, variant `common`), and how to build it from scratch with `scripts/update_dbsnp.py`.

## Test plan

- [x] `python biocypher_dataset_downloader/download_data.py --help` prints usage without error
- [x] `make download` prompts correctly and calls the downloader script
- [x] `make download-direct OUTPUT_DIR=./input SOURCE=uniprot` runs without error
- [x] `make run` writer-type prompt lists all six options
- [x] README downloader commands copy-paste correctly
- [x] README interactive-mode example matches actual `make run` prompts
- [x] README dbSNP Cache section paths are accurate against the Bizon server
