### PR TITLE
fix(config): consolidate HSA and dmel adapter input paths to species-specific canonical directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Example output when paths are missing:
 ERROR: Pre-flight check failed — 2 adapter(s) have missing file paths:
 
   [gencode_gene]
-    filepath: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz
+    filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz
 
   [bgee_gene_expressed_in_anatomical_entity]
-    filepath: /mnt/hdd_1/abdu/biocypher_data/bgee/Homo_sapiens_expr_simple_all_conditions.tsv.gz
+    filepath: /mnt/hdd_1/biocypher-kg/input/hsa/bgee/Homo_sapiens_expr_simple_all_conditions.tsv.gz
 
 Fix the paths above or run with --skip-preflight to bypass this check.
 ```

--- a/config/dmel/dmel_adapters_config.yaml
+++ b/config/dmel/dmel_adapters_config.yaml
@@ -652,7 +652,7 @@ reactome_reaction:
     cls: ReactomeAdapter
     args:
       filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
-      pubmed_map_path: ./samples/reactome/ReactionPMIDS.txt
+      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 7227
   outdir: reactome

--- a/config/dmel/dmel_adapters_config.yaml
+++ b/config/dmel/dmel_adapters_config.yaml
@@ -3,7 +3,7 @@ bgee_gene_expressed_in_anatomical_entity:
     module: biocypher_metta.adapters.bgee_adapter
     cls: BgeeAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
       label: expressed_in
       anatomy_label: gene_expressed_in_anatomy
       developmental_stage_label: gene_expressed_in_developmental_stage
@@ -17,8 +17,8 @@ rna_central_non_coding_rna:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       label: non_coding_rna
       type: non_coding_rna
       taxon_id: 7227
@@ -31,8 +31,8 @@ rna_central_non_coding_rna_biological_process:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: biological process rna
       label: biological_process_rna
       taxon_id: 7227
@@ -45,8 +45,8 @@ rna_central_non_coding_rna_molecular_function:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: molecular function rna
       label: molecular_function_rna
       taxon_id: 7227
@@ -59,8 +59,8 @@ rna_central_non_coding_rna_cellular_component:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: cellular component rna
       label: cellular_component_rna
       taxon_id: 7227
@@ -74,8 +74,8 @@ dmel_gene_group:
     cls: GeneGroupAdapter
     args:
       label: gene_group
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_group_data_fb_2025_03.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_groups_HGNC_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: True
   edges: False
@@ -86,8 +86,8 @@ dmel_gene_to_gene_group:
     cls: GeneGroupAdapter
     args:
       label: grouped_into
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_group_data_fb_2025_03.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_groups_HGNC_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: False
   edges: True
@@ -98,8 +98,8 @@ dmel_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/signaling_pathway_group_data_fb_2025_03.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_groups_HGNC_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -110,8 +110,8 @@ dmel_gene_to_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/signaling_pathway_group_data_fb_2025_03.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_groups_HGNC_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -122,8 +122,8 @@ dmel_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/metabolic_pathway_group_data_fb_2025_03.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_groups_HGNC_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -134,8 +134,8 @@ dmel_gene_to_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/metabolic_pathway_group_data_fb_2025_03.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_groups_HGNC_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -146,7 +146,7 @@ dmel_disease_model:
     cls: DiseaseModelAdapter
     args:
       label: dmel_disease_model
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/disease_model_annotations_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: True
   edges: False
@@ -158,7 +158,7 @@ dmel_gene_to_disease_model:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_human_disease
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/disease_model_annotations_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -169,7 +169,7 @@ dmel_gene_to_do_term:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_do_term
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/disease_model_annotations_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -180,8 +180,8 @@ dmel_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genotype
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/genotype_phenotype_data_fb_2025_03.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbrf_pmid_pmcid_doi_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -192,8 +192,8 @@ dmel_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
       label: phenotype_set
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/genotype_phenotype_data_fb_2025_03.tsv.gz
-      dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbrf_pmid_pmcid_doi_fb_2025_03.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+      dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -204,8 +204,8 @@ dmel_allele_to_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
        label: involved_in
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/genotype_phenotype_data_fb_2025_03.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbrf_pmid_pmcid_doi_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -216,8 +216,8 @@ dmel_phenotype_set_to_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genetically_informed_by
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/genotype_phenotype_data_fb_2025_03.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbrf_pmid_pmcid_doi_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -229,8 +229,8 @@ dmel_phenotype_set_to_ontology:
     cls: GenotypePhenotypeAdapter
     args:
        label: characterized_by
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/genotype_phenotype_data_fb_2025_03.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbrf_pmid_pmcid_doi_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -241,8 +241,8 @@ dmel_phenotype_set_to_cellular_component:
     cls: GenotypePhenotypeAdapter
     args:
        label: inheres_in
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/genotype_phenotype_data_fb_2025_03.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbrf_pmid_pmcid_doi_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -254,9 +254,9 @@ dmel_ptp_physical_interaction:
     cls: PhysicalInteractionAdapter
     args:
        filepaths: [
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/physical_interactions_mitab_fb_2025_03.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbgn_fbtr_fbpp_expanded_fb_2025_03.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbgn_uniprot_fb_2025_03.tsv.gz
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptp_physically_interacts_with
   outdir: flybase/mi_interactions
@@ -270,9 +270,9 @@ dmel_ptt_physical_interaction:
     cls: PhysicalInteractionAdapter
     args:
        filepaths: [
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/physical_interactions_mitab_fb_2025_03.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbgn_fbtr_fbpp_expanded_fb_2025_03.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbgn_uniprot_fb_2025_03.tsv.gz
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptt_physically_interacts_with  
   outdir: flybase/mi_interactions
@@ -284,7 +284,7 @@ orthology_adapter:
         module: biocypher_metta.adapters.dmel.orthology_adapter
         cls: OrthologyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/dmel_human_orthologs_disease_fb_2025_03.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
     outdir: orthologs
     nodes: False
     edges: True
@@ -294,7 +294,7 @@ paralogy_adapter:
         module: biocypher_metta.adapters.dmel.paralogy_adapter
         cls: ParalogyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/dmel_paralogs_fb_2025_03.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_paralogs_fb_2026_01.tsv.gz
     outdir: paralogs
     nodes: False
     edges: True
@@ -304,7 +304,7 @@ allele:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbal_to_fbgn_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: allele
   outdir: allele
   nodes: True
@@ -315,7 +315,7 @@ dmel_allele_to_gene:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbal_to_fbgn_fb_2025_03.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: variant_of
   outdir: allele
   nodes: False
@@ -326,7 +326,7 @@ dmel_gene_genetic_adapter:
         module: biocypher_metta.adapters.dmel.gene_genetic_association_adapter
         cls: GeneGeneticAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_genetic_interactions_fb_2025_03.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_genetic_interactions_fb_2026_01.tsv.gz
     outdir: flybase/gene_genetic
     nodes: False
     edges: True
@@ -337,8 +337,8 @@ dmel_allele_to_allele_genetic_interaction_adapter:
         cls: AlleleGeneticInteractionAdapter
         args:
           label: allele_to_allele_genetic_interaction
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/allele_genetic_interactions_fb_2025_03.tsv.gz
-          dmel_fbal_to_fbgn_file: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbal_to_fbgn_fb_2025_03.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/allele_genetic_interactions_fb_2026_01.tsv.gz
+          dmel_fbal_to_fbgn_file: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
     outdir: flybase/allele_genetic
     nodes: False
     edges: True
@@ -348,7 +348,7 @@ dmel_expressed_in:
     module: biocypher_metta.adapters.dmel.expressed_in_adapter
     cls: ExpressedInAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/scRNA-Seq_gene_expression_fb_2025_03.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz
   outdir: expressed_in
   nodes: False
   edges: True
@@ -358,7 +358,7 @@ dmel_gene_to_sequence_ontology:
     module: biocypher_metta.adapters.dmel.gene_so_adapter
     cls: GeneToSequenceOntologyAdapter
     args:
-       filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/dmel_gene_sequence_ontology_annotations_fb_2025_03.tsv.gz
+       filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_gene_sequence_ontology_annotations_fb_2026_01.tsv.gz
   outdir: so_classified_as
   nodes: False
   edges: True
@@ -369,14 +369,14 @@ RNASeq_library:
     cls: RnaseqLibraryAdapter
     args:
       filepaths: [
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/scRNA-Seq_gene_expression_fb_2025_03.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/high-throughput_gene_expression_fb_2025_03.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_rpkm_report_fb_2025_03.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_gene_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
       ]
   outdir: rnaseq
   nodes: True
@@ -389,17 +389,17 @@ expression_value:
     cls: ExpressionValueAdapter
     args:
       data_filepaths: [
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/scRNA-Seq_gene_expression_fb_2025_03.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/high-throughput_gene_expression_fb_2025_03.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_rpkm_report_fb_2025_03.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_gene_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-                             /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+                             /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
       ]      
       aux_filepaths: [
-                        /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/fbgn_fbtr_fbpp_expanded_fb_2025_03.tsv.gz,
+                        /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
       ]      
   outdir: rnaseq
   nodes: False
@@ -495,7 +495,7 @@ gencode_gene:
     module: biocypher_metta.adapters.gencode_gene_adapter
     cls: GencodeGeneAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       gene_alias_file_path: ./aux_files/dmel/Drosophila_melanogaster.gene_info.gz
       label: gene
       taxon_id: 7227
@@ -508,7 +508,7 @@ gencode_transcripts:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcript
       label: transcript
       taxon_id: 7227
@@ -521,7 +521,7 @@ transcribes_to:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcribes to
       label: transcribes_to
       taxon_id: 7227
@@ -534,7 +534,7 @@ gencode_exon:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       target_type: None
       label: exon
       taxon_id: 7227
@@ -547,7 +547,7 @@ exon_part_of_transcript:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_transcript
       target_type: transcript
       taxon_id: 7227
@@ -560,7 +560,7 @@ exon_part_of_gene:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_gene
       target_type: gene      
       taxon_id: 7227
@@ -573,7 +573,7 @@ gaf_biological_process_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: biological_process_gene_product
       taxon_id: 7227
@@ -586,7 +586,7 @@ gaf_molecular_function_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: molecular_function_gene_product
       taxon_id: 7227
@@ -599,7 +599,7 @@ gaf_cellular_component_gene_product_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_part_of
       taxon_id: 7227
@@ -612,7 +612,7 @@ gaf_cellular_component_gene_product_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_located_in
       taxon_id: 7227
@@ -625,7 +625,7 @@ coexpression:
     module: biocypher_metta.adapters.coxpresdb_adapter
     cls: CoxpresdbAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/coexpressdb/
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/coxpressdb/
       entrez_to_ensemble_path: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
       label: coexpressed_with
       taxon_id: 7227
@@ -638,8 +638,8 @@ pathway:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/reactome/ReactomePathways.txt
-      pubmed_map_path: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/reactome/ReactionPMIDS.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathways.txt
+      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
       label: pathway
       taxon_id: 7227
   outdir: reactome
@@ -651,7 +651,7 @@ reactome_reaction:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
       pubmed_map_path: ./samples/reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 7227
@@ -664,7 +664,7 @@ reactome_reaction_to_pathway:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
       label: reaction_to_pathway
       taxon_id: 7227
   outdir: reactome
@@ -676,7 +676,7 @@ reactome_input_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
       label: enables
       pathway_label: protein_enables_pathway
       reaction_label: protein_enables_reaction
@@ -690,7 +690,7 @@ reactome_output_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
       label: produced_by
       pathway_label: protein_produced_by_pathway
       reaction_label: protein_produced_by_reaction
@@ -704,7 +704,7 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
       label: regulates
       pathway_label: protein_regulates_pathway
       reaction_label: protein_regulates_reaction
@@ -718,7 +718,7 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
       label: negatively_regulates
       pathway_label: protein_negatively_regulates_pathway
       reaction_label: protein_negatively_regulates_reaction
@@ -732,7 +732,7 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
       label: positively_regulates
       pathway_label: protein_positively_regulates_pathway
       reaction_label: protein_positively_regulates_reaction
@@ -746,7 +746,7 @@ genes_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: genes_pathways
       taxon_id: 7227
@@ -759,7 +759,7 @@ protein_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: protein_pathways
       taxon_id: 7227
@@ -772,7 +772,7 @@ transcript_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: transcript_pathways
       taxon_id: 7227
@@ -785,7 +785,7 @@ gene_or_gene_product_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: gene_or_gene_product_reaction
       taxon_id: 7227
@@ -798,7 +798,7 @@ protein_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: protein_reaction
       taxon_id: 7227
@@ -811,7 +811,7 @@ transcript_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: transcript_reaction
       taxon_id: 7227
@@ -824,7 +824,7 @@ chebi_small_molecule_to_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/ChEBI2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ChEBI2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: small_molecule_to_pathway
       taxon_id: 7227
@@ -837,7 +837,7 @@ chebi_small_molecule_to_reactions:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/ChEBI2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ChEBI2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: small_molecule_to_reaction
       taxon_id: 7227
@@ -850,7 +850,7 @@ parent_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/reactome/ReactomePathwaysRelation.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: parent_pathway_of
       taxon_id: 7227
@@ -863,7 +863,7 @@ child_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/reactome/ReactomePathwaysRelation.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: child_pathway_of
       taxon_id: 7227
@@ -876,7 +876,7 @@ uniprotkb_sprot:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein
       taxon_id: 7227
   outdir: uniprot/uniprot
@@ -888,7 +888,7 @@ uniprotkb_sprot_translates_to:
     module: biocypher_metta.adapters.uniprot_adapter
     cls: UniprotAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       type: translates to
       label: translates_to
       taxon_id: 7227
@@ -901,7 +901,7 @@ uniprot_dbxref_bgee_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: BGEE
       taxon_id: 7227
@@ -914,7 +914,7 @@ uniprot_dbxref_ensembl_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -927,7 +927,7 @@ uniprot_dbxref_ensembl_transcript:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_transcript
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -940,7 +940,7 @@ uniprot_dbxref_ensembl_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -953,7 +953,7 @@ uniprot_dbxref_string_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: STRING
       taxon_id: 7227
@@ -966,7 +966,7 @@ uniprot_dbxref_biological_process:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_biological_process
       dbxref: GO
       taxon_id: 7227
@@ -979,7 +979,7 @@ uniprot_dbxref_cellular_component:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_cellular_component
       dbxref: GO
       taxon_id: 7227
@@ -992,7 +992,7 @@ uniprot_dbxref_molecular_function:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_molecular_function
       dbxref: GO
       taxon_id: 7227
@@ -1005,7 +1005,7 @@ uniprot_has_xref_catalytic_activity:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_catalytic_activity
       taxon_id: 7227
       dbxref: CHEBI
@@ -1018,7 +1018,7 @@ uniprot_has_xref_cofactor:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_cofactor
       taxon_id: 7227
       dbxref: CHEBI
@@ -1031,7 +1031,7 @@ uniprot_has_xref_binding_site_ligand:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_binding_site_ligand
       taxon_id: 7227
       dbxref: CHEBI
@@ -1044,7 +1044,7 @@ uniprot_chebi_part_of_chebi:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: chemical_substance_part_of_chemical_substance
       taxon_id: 7227
       dbxref: CHEBI
@@ -1057,7 +1057,7 @@ tflink:
         module: biocypher_metta.adapters.tflink_adapter
         cls: TFLinkAdapter
         args:
-          filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
+          filepath: /mnt/hdd_1/biocypher-kg/input/dmel/tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
           entrez_to_ensemble_map: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
           label: tf_gene
           taxon_id: 7227
@@ -1070,7 +1070,7 @@ string:
     module: biocypher_metta.adapters.string_ppi_adapter
     cls: StringPPIAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/string/7227.protein.links.v12.0.txt.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/string/7227.protein.links.v12.0.txt.gz
       ensembl_to_uniprot_map: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: interacts_with
       taxon_id: 7227
@@ -1282,7 +1282,7 @@ epd_promoter_dmel:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/epd/Dm_EPDnew.bed.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/epd/Dm_EPDnew.bed.gz
       hgnc_to_ensembl_map: ./aux_files/dmel/flybase_synonym_mapping.pkl
       label: promoter
       type: promoter
@@ -1296,7 +1296,7 @@ epd_promoter_regulates_gene_dmel:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/full/epd/Dm_EPDnew.bed.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/epd/Dm_EPDnew.bed.gz
       hgnc_to_ensembl_map: ./aux_files/dmel/flybase_synonym_mapping.pkl
       label: promoter_gene
       type: promoter_gene
@@ -1310,7 +1310,7 @@ alliance_gene_orthology:
     module: biocypher_metta.adapters.alliance_gene_orthology_adapter
     cls: AllianceGeneOrthologyAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/multi/alliance/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/agr/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 7227
       label: orthologs_genes
   outdir: alliance/orthology

--- a/config/dmel/dmel_data_source_config.yaml
+++ b/config/dmel/dmel_data_source_config.yaml
@@ -1,5 +1,6 @@
 # ---
 agr:    # agr: alliance of genome resource
+  name: Alliance Genome Resource
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
     - https://fms.alliancegenome.org/download/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz  # gene orthology
@@ -17,33 +18,33 @@ enhancer_atlas:
   url: http://www.enhanceratlas.org/data/download/enhancer_atlas_2.0/9606_all_tissues.bed   
 
 flybase: 
-  name: Flybase 2025_05
+  name: Flybase 2026_01
   url: 
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/alleles/allele_genetic_interactions_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/alleles/fbal_to_fbgn_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/alleles/genotype_phenotype_data_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/best_gene_summary_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/dmel_gene_sequence_ontology_annotations_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/dmel_unique_protein_isoforms_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/fbgn_fbtr_fbpp_expanded_fb_2025_05.tsv.gz
-    # - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/FlyCellAtlas_slimmed_gene_expression_fb_2025_05.tsv.gz  nao existe!!!!!!!!!!!!!!
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/gene_genetic_interactions_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/gene_group_data_fb_2025_05.tsv.gz    
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/gene_groups_HGNC_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/gene_rpkm_report_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/high-throughput_gene_expression_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/metabolic_pathway_group_data_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/physical_interactions_mitab_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/scRNA-Seq_gene_expression_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/genes/signaling_pathway_group_data_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/human_disease/disease_model_annotations_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/orthologs/dmel_human_orthologs_disease_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/orthologs/dmel_paralogs_fb_2025_05.tsv.gz
-    - https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/references/fbrf_pmid_pmcid_doi_fb_2025_05.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/alleles/allele_genetic_interactions_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/alleles/fbal_to_fbgn_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/alleles/genotype_phenotype_data_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/best_gene_summary_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/dmel_gene_sequence_ontology_annotations_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/dmel_unique_protein_isoforms_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz
+    # - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/FlyCellAtlas_slimmed_gene_expression_fb_2026_01.tsv.gz  nao existe!!!!!!!!!!!!!!
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/gene_genetic_interactions_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/gene_group_data_fb_2026_01.tsv.gz    
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/gene_groups_HGNC_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/gene_rpkm_report_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/high-throughput_gene_expression_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/physical_interactions_mitab_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/genes/signaling_pathway_group_data_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/human_disease/disease_model_annotations_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/orthologs/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/orthologs/dmel_paralogs_fb_2026_01.tsv.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/references/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
     
 goa:
   name: GO Annotation File (GAF) from Flybase
-  url: https://s3ftp.flybase.org/releases/FB2025_05/precomputed_files/go/gene_association.fb.gz
+  url: https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/go/gene_association.fb.gz
 
 gencode:
   name: GENCODE v54

--- a/config/dmel/dmel_data_source_config.yaml
+++ b/config/dmel/dmel_data_source_config.yaml
@@ -1,4 +1,9 @@
 # ---
+agr:    # agr: alliance of genome resource
+  url:
+    - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
+    - https://fms.alliancegenome.org/download/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz  # gene orthology
+
 bgee:
   name: Bgee Expression Data
   url: https://www.bgee.org/ftp/current/download/calls/expr_calls/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz

--- a/config/dmel/dmel_data_source_config.yaml
+++ b/config/dmel/dmel_data_source_config.yaml
@@ -41,10 +41,7 @@ flybase:
     - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/orthologs/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
     - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/orthologs/dmel_paralogs_fb_2026_01.tsv.gz
     - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/references/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
-    
-goa:
-  name: GO Annotation File (GAF) from Flybase
-  url: https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/go/gene_association.fb.gz
+    - https://s3ftp.flybase.org/releases/FB2026_01/precomputed_files/go/gene_association.fb.gz  # GOA (GO annotation)
 
 gencode:
   name: GENCODE v54

--- a/config/dmel/net_act_adapters_config.yaml
+++ b/config/dmel/net_act_adapters_config.yaml
@@ -664,7 +664,7 @@ reactome_reaction:
     cls: ReactomeAdapter
     args:
       filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt   # there is no file like ReactomePathways.txt for reactions in the Reactome portal (www.reactome.org)
-      pubmed_map_path: ./samples/reactome/ReactionPMIDS.txt
+      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 7227
   outdir: reactome

--- a/config/dmel/net_act_adapters_config.yaml
+++ b/config/dmel/net_act_adapters_config.yaml
@@ -382,7 +382,7 @@ coexpression:
       filepath: /mnt/hdd_1/biocypher-kg/input/dmel/coxpressdb/
       entrez_to_ensemble_path: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
       label: coexpressed_with
-      taxon_id: 9606
+      taxon_id: 7227
   outdir: coxpressdb
   nodes: False
   edges: True

--- a/config/dmel/net_act_adapters_config.yaml
+++ b/config/dmel/net_act_adapters_config.yaml
@@ -3,7 +3,7 @@ bgee_gene_expressed_in_anatomical_entity:
     module: biocypher_metta.adapters.bgee_adapter
     cls: BgeeAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
       label: expressed_in
       taxon_id: 7227
   outdir: bgee
@@ -15,8 +15,8 @@ rna_central_non_coding_rna:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       label: non_coding_rna
       type: non_coding_rna
       taxon_id: 7227
@@ -29,8 +29,8 @@ rna_central_non_coding_rna_biological_process:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: biological process rna
       label: biological_process_rna
       taxon_id: 7227
@@ -43,8 +43,8 @@ rna_central_non_coding_rna_molecular_function:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: molecular function rna
       label: molecular_function_rna
       taxon_id: 7227
@@ -57,8 +57,8 @@ rna_central_non_coding_rna_cellular_component:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: cellular component rna
       label: cellular_component_rna
       taxon_id: 7227
@@ -72,8 +72,8 @@ dmel_gene_group:
     cls: GeneGroupAdapter
     args:
       label: gene_group
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_group_data_fb_2025_05.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_groups_HGNC_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: True
   edges: False
@@ -84,8 +84,8 @@ dmel_gene_to_gene_group:
     cls: GeneGroupAdapter
     args:
       label: grouped_into
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_group_data_fb_2025_05.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_groups_HGNC_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: False
   edges: True
@@ -96,8 +96,8 @@ dmel_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/signaling_pathway_group_data_fb_2025_05.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_groups_HGNC_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -108,8 +108,8 @@ dmel_gene_to_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/signaling_pathway_group_data_fb_2025_05.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_groups_HGNC_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -120,8 +120,8 @@ dmel_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/metabolic_pathway_group_data_fb_2025_05.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_groups_HGNC_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -132,8 +132,8 @@ dmel_gene_to_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/metabolic_pathway_group_data_fb_2025_05.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_groups_HGNC_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -145,7 +145,7 @@ dmel_disease_model:
     cls: DiseaseModelAdapter
     args:
       label: dmel_disease_model
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/disease_model_annotations_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: True
   edges: False
@@ -157,7 +157,7 @@ dmel_gene_to_disease_model:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_human_disease
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/disease_model_annotations_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -168,7 +168,7 @@ dmel_gene_to_do_term:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_do_term
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/disease_model_annotations_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -179,8 +179,8 @@ dmel_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genotype
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/genotype_phenotype_data_fb_2025_05.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbrf_pmid_pmcid_doi_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -191,8 +191,8 @@ dmel_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
       label: phenotype_set
-      dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/genotype_phenotype_data_fb_2025_05.tsv.gz
-      dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbrf_pmid_pmcid_doi_fb_2025_05.tsv.gz
+      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+      dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -203,8 +203,8 @@ dmel_allele_to_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
        label: involved_in
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/genotype_phenotype_data_fb_2025_05.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbrf_pmid_pmcid_doi_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -217,8 +217,8 @@ dmel_phenotype_set_to_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genetically_informed_by
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/genotype_phenotype_data_fb_2025_05.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbrf_pmid_pmcid_doi_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -230,8 +230,8 @@ dmel_phenotype_set_to_ontology:
     cls: GenotypePhenotypeAdapter
     args:
        label: characterized_by
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/genotype_phenotype_data_fb_2025_05.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbrf_pmid_pmcid_doi_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -242,8 +242,8 @@ dmel_phenotype_set_to_cellular_component:
     cls: GenotypePhenotypeAdapter
     args:
        label: inheres_in
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/genotype_phenotype_data_fb_2025_05.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbrf_pmid_pmcid_doi_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -257,9 +257,9 @@ dmel_ptp_physical_interaction:
     args:
       #  dmel_ensembl_to_uniprot_map: ./aux_files/dmel_string_ensembl_to_uniprot_map.pkl
        filepaths: [
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/physical_interactions_mitab_fb_2025_05.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbgn_fbtr_fbpp_expanded_fb_2025_05.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbgn_uniprot_fb_2025_05.tsv.gz
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptp_physically_interacts_with
   outdir: flybase/mi_interactions
@@ -274,9 +274,9 @@ dmel_ptt_physical_interaction:
     args:
       #  dmel_ensembl_to_uniprot_map: ./aux_files/dmel_string_ensembl_to_uniprot_map.pkl
        filepaths: [
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/physical_interactions_mitab_fb_2025_05.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbgn_fbtr_fbpp_expanded_fb_2025_05.tsv.gz,
-          /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbgn_uniprot_fb_2025_05.tsv.gz
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptt_physically_interacts_with  
   outdir: flybase/mi_interactions
@@ -289,7 +289,7 @@ orthology_adapter:
         module: biocypher_metta.adapters.dmel.orthology_adapter
         cls: OrthologyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/dmel_human_orthologs_disease_fb_2025_05.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
     outdir: orthologs
     nodes: False
     edges: True
@@ -300,7 +300,7 @@ paralogy_adapter:
         module: biocypher_metta.adapters.dmel.paralogy_adapter
         cls: ParalogyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/dmel_paralogs_fb_2025_05.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_paralogs_fb_2026_01.tsv.gz
     outdir: paralogs
     nodes: False
     edges: True
@@ -311,7 +311,7 @@ allele:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbal_to_fbgn_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: allele
   outdir: allele
   nodes: True
@@ -323,7 +323,7 @@ dmel_allele_to_gene:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbal_to_fbgn_fb_2025_05.tsv.gz
+       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: variant_of
   outdir: allele
   nodes: False
@@ -335,7 +335,7 @@ dmel_gene_genetic_adapter:
         module: biocypher_metta.adapters.dmel.gene_genetic_association_adapter
         cls: GeneGeneticAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_genetic_interactions_fb_2025_05.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_genetic_interactions_fb_2026_01.tsv.gz
     outdir: flybase/gene_genetic
     nodes: False
     edges: True
@@ -347,8 +347,8 @@ dmel_allele_to_allele_genetic_interaction_adapter:
         cls: AlleleGeneticInteractionAdapter
         args:
           label: allele_to_allele_genetic_interaction
-          dmel_data_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/allele_genetic_interactions_fb_2025_05.tsv.gz
-          dmel_fbal_to_fbgn_file: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbal_to_fbgn_fb_2025_05.tsv.gz
+          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/allele_genetic_interactions_fb_2026_01.tsv.gz
+          dmel_fbal_to_fbgn_file: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
     outdir: flybase/allele_genetic
     nodes: False
     edges: True
@@ -359,7 +359,7 @@ dmel_expressed_in:
     module: biocypher_metta.adapters.dmel.expressed_in_adapter
     cls: ExpressedInAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/scRNA-Seq_gene_expression_fb_2025_05.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz
   outdir: expressed_in
   nodes: False
   edges: True
@@ -369,7 +369,7 @@ dmel_gene_to_sequence_ontology:
     module: biocypher_metta.adapters.dmel.gene_so_adapter
     cls: GeneToSequenceOntologyAdapter
     args:
-       filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/dmel_gene_sequence_ontology_annotations_fb_2025_05.tsv.gz
+       filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_gene_sequence_ontology_annotations_fb_2026_01.tsv.gz
   outdir: so_classified_as
   nodes: False
   edges: True
@@ -379,7 +379,7 @@ coexpression:
     module: biocypher_metta.adapters.coxpresdb_adapter
     cls: CoxpresdbAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/coxpressdb/
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/coxpressdb/
       entrez_to_ensemble_path: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
       label: coexpressed_with
       taxon_id: 9606
@@ -393,14 +393,14 @@ coexpression:
 #     cls: RnaseqLibraryAdapter
 #     args:
 #       filepaths: [
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/scRNA-Seq_gene_expression_fb_2025_05.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/high-throughput_gene_expression_fb_2025_05.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_rpkm_report_fb_2025_05.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_gene_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
 #       ]
 #   outdir: rnaseq
 #   nodes: True
@@ -413,17 +413,17 @@ coexpression:
 #     cls: ExpressionValueAdapter
 #     args:
 #       data_filepaths: [
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/scRNA-Seq_gene_expression_fb_2025_05.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/high-throughput_gene_expression_fb_2025_05.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_rpkm_report_fb_2025_05.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_gene_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-#                              /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+#                              /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
 #       ]      
 #       aux_filepaths: [
-#                         /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/fbgn_fbtr_fbpp_expanded_fb_2025_05.tsv.gz,
+#                         /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
 #       ]      
 #   outdir: rnaseq
 #   nodes: False
@@ -519,9 +519,9 @@ gencode_gene:
     module: biocypher_metta.adapters.gencode_gene_adapter
     cls: GencodeGeneAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       gene_alias_file_path: ./aux_files/dmel/Drosophila_melanogaster.gene_info.gz
-      # summaries_filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/best_gene_summary_fb_2025_05.tsv.gz
+      # summaries_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/best_gene_summary_fb_2026_01.tsv.gz
       label: gene
       taxon_id: 7227
   outdir: gencode/gene
@@ -533,7 +533,7 @@ gencode_transcripts:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcript
       label: transcript
       taxon_id: 7227
@@ -546,7 +546,7 @@ transcribes_to:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcribes to
       label: transcribes_to
       taxon_id: 7227
@@ -559,7 +559,7 @@ gencode_exon:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       target_type: None
       label: exon
       taxon_id: 7227
@@ -572,7 +572,7 @@ exon_part_of_transcript:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_transcript
       target_type: transcript
       taxon_id: 7227
@@ -585,7 +585,7 @@ exon_part_of_gene:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_gene
       target_type: gene      
       taxon_id: 7227
@@ -598,7 +598,7 @@ gaf_biological_process_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: biological_process_gene_product
       taxon_id: 7227
@@ -611,7 +611,7 @@ gaf_molecular_function_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: molecular_function_gene_product
       taxon_id: 7227
@@ -624,7 +624,7 @@ gaf_cellular_component_gene_product_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_part_of
       taxon_id: 7227
@@ -637,7 +637,7 @@ gaf_cellular_component_gene_product_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/flybase/gene_association.fb.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_located_in
       taxon_id: 7227
@@ -650,8 +650,8 @@ pathway:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/reactome/ReactomePathways.txt
-      pubmed_map_path: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/reactome/ReactionPMIDS.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathways.txt
+      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
       label: pathway
       taxon_id: 7227
   outdir: reactome
@@ -663,7 +663,7 @@ reactome_reaction:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/reactome/Ensembl2ReactomeReactions.txt   # there is no file like ReactomePathways.txt for reactions in the Reactome portal (www.reactome.org)
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt   # there is no file like ReactomePathways.txt for reactions in the Reactome portal (www.reactome.org)
       pubmed_map_path: ./samples/reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 7227
@@ -676,7 +676,7 @@ genes_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: genes_pathways
       taxon_id: 7227
@@ -689,7 +689,7 @@ gene_or_gene_product_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: gene_or_gene_product_reaction
       taxon_id: 7227
@@ -702,7 +702,7 @@ parent_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/reactome/ReactomePathwaysRelation.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: parent_pathway_of
       taxon_id: 7227
@@ -715,7 +715,7 @@ child_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/reactome/ReactomePathwaysRelation.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: child_pathway_of
       taxon_id: 7227
@@ -729,7 +729,7 @@ uniprotkb_sprot:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein
       taxon_id: 7227
   outdir: uniprot/uniprot
@@ -742,7 +742,7 @@ uniprotkb_sprot_translates_to:
     module: biocypher_metta.adapters.uniprot_adapter
     cls: UniprotAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       type: translates to
       label: translates_to
       taxon_id: 7227
@@ -755,7 +755,7 @@ uniprot_dbxref_bgee_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: BGEE
       taxon_id: 7227
@@ -768,7 +768,7 @@ uniprot_dbxref_ensembl_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -781,7 +781,7 @@ uniprot_dbxref_ensembl_transcript:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_transcript
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -794,7 +794,7 @@ uniprot_dbxref_ensembl_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -808,7 +808,7 @@ uniprot_dbxref_string_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: STRING
       taxon_id: 7227
@@ -821,7 +821,7 @@ uniprot_dbxref_biological_process:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_biological_process
       dbxref: GO
       taxon_id: 7227
@@ -834,7 +834,7 @@ uniprot_dbxref_cellular_component:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_cellular_component
       dbxref: GO
       taxon_id: 7227
@@ -847,7 +847,7 @@ uniprot_dbxref_molecular_function:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_molecular_function
       dbxref: GO
       taxon_id: 7227
@@ -861,7 +861,7 @@ tflink:
         module: biocypher_metta.adapters.tflink_adapter
         cls: TFLinkAdapter
         args:
-          filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
+          filepath: /mnt/hdd_1/biocypher-kg/input/dmel/tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
           entrez_to_ensemble_map: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
           label: tf_gene
           taxon_id: 7227
@@ -874,7 +874,7 @@ string:
     module: biocypher_metta.adapters.string_ppi_adapter
     cls: StringPPIAdapter
     args:
-      filepath: /mnt/hdd_1/saulo/snet/rejuve.bio/das/shared_rep/data/input/net_act_sources/string/7227.protein.links.v12.0.txt.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/string/7227.protein.links.v12.0.txt.gz
       ensembl_to_uniprot_map: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: interacts_with
       taxon_id: 7227

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -3,7 +3,7 @@ gencode_gene:
     module: biocypher_metta.adapters.gencode_gene_adapter
     cls: GencodeGeneAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
       label: gene
       taxon_id: 9606      # multi-species version needs this
   outdir: gencode/gene
@@ -15,7 +15,7 @@ gencode_transcripts:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
       type: transcript
       label: transcript
       taxon_id: 9606      # multi-species version needs this
@@ -28,7 +28,7 @@ transcribes_to:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
       type: transcribes to
       label: transcribes_to
       taxon_id: 9606      # multi-species version needs this
@@ -41,7 +41,7 @@ gencode_exon:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
       target_type: exon   # it could be anything here
       label: exon
       taxon_id: 9606      # multi-species version needs this
@@ -54,7 +54,7 @@ exon_part_of_transcript: # replaces transcript_includes_exon
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
       label: part_of_transcript
       target_type: transcript
       taxon_id: 9606      
@@ -67,7 +67,7 @@ exon_part_of_gene:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
       label: part_of_gene
       target_type: gene
       taxon_id: 9606      
@@ -80,7 +80,7 @@ uniprotkb_sprot:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein
       taxon_id: 9606      # multi-species version needs this
   outdir: uniprot
@@ -92,7 +92,7 @@ uniprotkb_sprot_translates_to:
     module: biocypher_metta.adapters.uniprot_adapter
     cls: UniprotAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       type: translates to
       label: translates_to
       taxon_id: 9606      # multi-species version needs this
@@ -105,8 +105,8 @@ pathway:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/ReactomePathways.txt
-      pubmed_map_path: /mnt/hdd_1/abdu/biocypher_data/reactome/ReactionPMIDS.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactomePathways.txt
+      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactionPMIDS.txt
       label: pathway
       taxon_id: 9606
   outdir: reactome
@@ -118,8 +118,8 @@ reactome_reaction:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
-      pubmed_map_path: /mnt/hdd_1/abdu/biocypher_data/reactome/ReactionPMIDS.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
+      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 9606
   outdir: reactome
@@ -131,7 +131,7 @@ reactome_reaction_to_pathway:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
       label: reaction_to_pathway
       taxon_id: 9606
   outdir: reactome
@@ -143,7 +143,7 @@ reactome_input_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
       label: enables
       pathway_label: protein_enables_pathway
       reaction_label: protein_enables_reaction
@@ -157,7 +157,7 @@ reactome_output_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
       label: produced_by
       pathway_label: protein_produced_by_pathway
       reaction_label: protein_produced_by_reaction
@@ -171,7 +171,7 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
       label: regulates
       pathway_label: protein_regulates_pathway
       reaction_label: protein_regulates_reaction
@@ -185,7 +185,7 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
       label: negatively_regulates
       pathway_label: protein_negatively_regulates_pathway
       reaction_label: protein_negatively_regulates_reaction
@@ -199,7 +199,7 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
       label: positively_regulates
       pathway_label: protein_positively_regulates_pathway
       reaction_label: protein_positively_regulates_reaction
@@ -213,7 +213,7 @@ genes_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2Reactome_All_Levels.txt
       label: genes_pathways
       taxon_id: 9606
   outdir: reactome
@@ -225,7 +225,7 @@ protein_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2Reactome_All_Levels.txt
       label: protein_pathways
       taxon_id: 9606
   outdir: reactome
@@ -237,7 +237,7 @@ transcript_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2Reactome_All_Levels.txt
       label: transcript_pathways
       taxon_id: 9606
   outdir: reactome
@@ -249,7 +249,7 @@ gene_or_gene_product_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
       label: gene_or_gene_product_reaction
       taxon_id: 9606
   outdir: reactome
@@ -261,7 +261,7 @@ protein_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
       label: protein_reaction
       taxon_id: 9606
   outdir: reactome
@@ -273,7 +273,7 @@ transcript_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Ensembl2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
       label: transcript_reaction
       taxon_id: 9606
   outdir: reactome
@@ -285,7 +285,7 @@ chebi_small_molecule_to_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/ChEBI2Reactome_All_Levels.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ChEBI2Reactome_All_Levels.txt
       label: small_molecule_to_pathway
       taxon_id: 9606
   outdir: reactome
@@ -297,7 +297,7 @@ chebi_small_molecule_to_reactions:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/ChEBI2ReactomeReactions.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ChEBI2ReactomeReactions.txt
       label: small_molecule_to_reaction
       taxon_id: 9606
   outdir: reactome
@@ -309,7 +309,7 @@ parent_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/ReactomePathwaysRelation.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactomePathwaysRelation.txt
       label: parent_pathway_of
       taxon_id: 9606
   outdir: reactome
@@ -321,7 +321,7 @@ child_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/ReactomePathwaysRelation.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactomePathwaysRelation.txt
       label: child_pathway_of
       taxon_id: 9606
   outdir: reactome
@@ -333,7 +333,7 @@ pathway_to_biological_process:
     module: biocypher_metta.adapters.reactome_pathway_go_adapter
     cls: ReactomePathwayGOAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Pathways2GoTerms_human.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Pathways2GoTerms_human.txt
       write_properties: true
       add_provenance: true
       label: pathway_to_biological_process
@@ -353,7 +353,7 @@ pathway_to_biological_process:
 #     module: biocypher_metta.adapters.reactome_pathway_go_adapter  
 #     cls: ReactomePathwayGOAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Pathways2GoTerms_human.txt
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Pathways2GoTerms_human.txt
 #       write_properties: true
 #       add_provenance: true
 #       subontology: molecular_function
@@ -368,7 +368,7 @@ pathway_to_biological_process:
 #     module: biocypher_metta.adapters.reactome_pathway_go_adapter
 #     cls: ReactomePathwayGOAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/reactome/Pathways2GoTerms_human.txt
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Pathways2GoTerms_human.txt
 #       write_properties: true
 #       add_provenance: true
 #       subontology: cellular_component  
@@ -473,7 +473,7 @@ gaf_biological_process_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: biological_process_gene_product
       taxon_id: 9606
   outdir: gaf
@@ -485,7 +485,7 @@ gaf_molecular_function_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: molecular_function_gene_product
       taxon_id: 9606
   outdir: gaf
@@ -497,7 +497,7 @@ gaf_cellular_component_gene_product_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: cellular_component_gene_product_part_of
       taxon_id: 9606
   outdir: gaf
@@ -509,7 +509,7 @@ gaf_cellular_component_gene_product_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: cellular_component_gene_product_located_in
       taxon_id: 9606
   outdir: gaf
@@ -521,7 +521,7 @@ gaf_biological_process_gene:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: biological_process_gene
       taxon_id: 9606
   outdir: gaf
@@ -533,7 +533,7 @@ gaf_molecular_function_gene:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: molecular_function_gene
       taxon_id: 9606
   outdir: gaf
@@ -545,7 +545,7 @@ gaf_cellular_component_gene_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: cellular_component_gene_part_of
       taxon_id: 9606
   outdir: gaf
@@ -557,7 +557,7 @@ gaf_cellular_component_gene_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/go/goa_human.gaf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
       label: cellular_component_gene_located_in
       taxon_id: 9606
   outdir: gaf
@@ -569,7 +569,7 @@ coexpression:
     module: biocypher_metta.adapters.coxpresdb_adapter
     cls: CoxpresdbAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/coxpressdb
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/coxpressdb
       label: coexpressed_with
       taxon_id: 9606
   outdir: coxpressdb
@@ -581,7 +581,7 @@ tflink:
     module: biocypher_metta.adapters.tflink_adapter
     cls: TFLinkAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/tflink/tflink_homo_sapiens_interactions.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tflink/tflink_homo_sapiens_interactions.tsv.gz
       label: tf_gene
       taxon_id: 9606
   outdir: tflink
@@ -593,7 +593,7 @@ string:
     module: biocypher_metta.adapters.string_ppi_adapter
     cls: StringPPIAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/string/string_human_ppi_v12.0.txt.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/string/string_human_ppi_v12.0.txt.gz
       label: interacts_with
       taxon_id: 9606
   outdir: string
@@ -617,7 +617,7 @@ tadmap:
     module: biocypher_metta.adapters.tadmap_adapter
     cls: TADMapAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/tadmap/TADMap_geneset_hs.csv
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tadmap/TADMap_geneset_hs.csv
       label: tad
       taxon_id: 9606
   outdir: tadmap
@@ -629,7 +629,7 @@ tadmap_gene:
     module: biocypher_metta.adapters.tadmap_adapter
     cls: TADMapAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/tadmap/TADMap_geneset_hs.csv
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tadmap/TADMap_geneset_hs.csv
       label: in_tad_region
       taxon_id: 9606
   outdir: tadmap
@@ -641,7 +641,7 @@ gtex_eqtl:
     module: biocypher_metta.adapters.hsa.gtex_eqtl_adapter
     cls: GTExEQTLAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gtex/eqtl/gtex.forgedb.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gtex/eqtl/gtex.forgedb.csv.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       label: gtex_variant_gene
   outdir: gtex/eqtl
@@ -653,7 +653,7 @@ gtex_expression:
     module: biocypher_metta.adapters.hsa.gtex_expression_adapter
     cls: GTExExpressionAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gtex/eqtl/gtex.forgedb.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gtex/eqtl/gtex.forgedb.csv.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       label: expressed_in
       anatomy_label: gene_expressed_in_anatomy
@@ -667,8 +667,8 @@ hocomoco:
     module: biocypher_metta.adapters.hocomoco_motif_adapter
     cls: HoCoMoCoMotifAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/hocomoco/pwm
-      annotation_file: /mnt/hdd_1/abdu/biocypher_data/hocomoco/HOCOMOCOv11_core_annotation_HUMAN_mono.tsv
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/hocomoco/pwm
+      annotation_file: /mnt/hdd_1/biocypher-kg/input/hsa/hocomoco/HOCOMOCOv11_core_annotation_HUMAN_mono.tsv
       label: motif
       taxon_id: 9606
   outdir: hocomoco
@@ -680,7 +680,7 @@ roadmap_chromatin_state:
     module: biocypher_metta.adapters.hsa.roadmap_state_adapter
     cls: RoadMapChromatinStateAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/forgedb/roadmap/chromatin_state
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/roadmap/chromatin_state
       cell_to_ontology_id_map: ./aux_files/hsa/roadmap_ids_to_ontology.pkl
       tissue_to_ontology_id_map: ./aux_files/hsa/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
@@ -697,7 +697,7 @@ roadmap_h3_mark:
     module: biocypher_metta.adapters.hsa.roadmap_h3_marks_adapter
     cls: RoadMapH3MarkAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/forgedb/roadmap/h3_marks
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/roadmap/h3_marks
       cell_to_ontology_id_map: ./aux_files/hsa/roadmap_ids_to_ontology.pkl
       tissue_to_ontology_id_map: ./aux_files/hsa/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
@@ -714,7 +714,7 @@ roadmap_dhs:
     module: biocypher_metta.adapters.hsa.roadmap_dhs_adapter
     cls: RoadMapDHSAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/forgedb/roadmap/dhs/forge2.erc2-DHS.forgedb.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/roadmap/dhs/forge2.erc2-DHS.forgedb.csv.gz
       cell_to_ontology_id_map: ./aux_files/hsa/roadmap_ids_to_ontology.pkl
       tissue_to_ontology_id_map: ./aux_files/hsa/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
@@ -731,7 +731,7 @@ abc:
     module: biocypher_metta.adapters.hsa.abc_adapter
     cls: ABCAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/forgedb/abc.forgedb.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/abc.forgedb.csv.gz
       tissue_to_ontology_id_map: ./aux_files/hsa/abc_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None # will be provided by import script
       chr: chr16
@@ -745,7 +745,7 @@ cadd:
     module: biocypher_metta.adapters.hsa.cadd_adapter
     cls: CADDAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/forgedb/cadd.forgedb.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/cadd.forgedb.csv.gz
       dbsnp_rsid_map: None # will be provided by import script
       chr: chr16
       label: snp
@@ -758,7 +758,7 @@ refseq_closest_gene:
     module: biocypher_metta.adapters.hsa.refseq_closest_gene_adapter
     cls: RefSeqClosestGeneAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/forgedb/closest_gene.forgedb.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/closest_gene.forgedb.csv.gz
       dbsnp_rsid_map: None # will be provided by import script
       label: closest_gene
   outdir: refseq
@@ -771,7 +771,7 @@ topld_afr:
     module: biocypher_metta.adapters.hsa.topld_adapter
     cls: TopLDAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/topld/AFR/AFR_chr16_no_filter_0.2_1000000_LD.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/AFR/AFR_chr16_no_filter_0.2_1000000_LD.csv.gz
       ancestry: AFR
       dbsnp_pos_map: None # will be provided by import script
       chr: chr16
@@ -787,7 +787,7 @@ topld_eas:
     module: biocypher_metta.adapters.hsa.topld_adapter
     cls: TopLDAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/topld/EAS/EAS_chr16_no_filter_0.2_1000000_LD.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/EAS/EAS_chr16_no_filter_0.2_1000000_LD.csv.gz
       ancestry: EAS
       dbsnp_pos_map: None # will be provided by import script
       chr: chr16
@@ -803,7 +803,7 @@ topld_eur:
     module: biocypher_metta.adapters.hsa.topld_adapter
     cls: TopLDAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/topld/EUR/EUR_chr16_no_filter_0.2_1000000_LD.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/EUR/EUR_chr16_no_filter_0.2_1000000_LD.csv.gz
       ancestry: EUR
       dbsnp_pos_map: None # will be provided by import script
       chr: chr16
@@ -819,7 +819,7 @@ topld_sas:
        module: biocypher_metta.adapters.hsa.topld_adapter
        cls: TopLDAdapter
        args:
-           filepath: /mnt/hdd_1/abdu/biocypher_data/topld/SAS/SAS_chr16_no_filter_0.2_1000000_LD.csv.gz
+           filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/SAS/SAS_chr16_no_filter_0.2_1000000_LD.csv.gz
            ancestry: SAS
            dbsnp_pos_map: None # will be provided by import script
            chr: chr16
@@ -835,8 +835,8 @@ rna_central_non_coding_rna:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
       label: non_coding_rna
       type: non_coding_rna
       taxon_id: 9606
@@ -849,8 +849,8 @@ rna_central_non_coding_rna_biological_process:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: biological process rna
       label: biological_process_rna
       taxon_id: 9606
@@ -863,8 +863,8 @@ rna_central_non_coding_rna_molecular_function:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: molecular function rna
       label: molecular_function_rna
       taxon_id: 9606
@@ -877,8 +877,8 @@ rna_central_non_coding_rna_cellular_component:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/abdu/biocypher_data/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
       type: cellular component rna
       label: cellular_component_rna
       taxon_id: 9606
@@ -891,7 +891,7 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #   outdir: dgv
 #   nodes: True
@@ -902,10 +902,10 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
 #           label: gene
 #           type: gtf
 #   outdir: dgv
@@ -917,10 +917,10 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/abdu/biocypher_data/rna_central/homo_sapiens.GRCh38.bed.gz
+#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
 #           label: non_coding_rna
 #           type: bed
 #   outdir: dgv
@@ -932,10 +932,10 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/abdu/biocypher_data/epd/Hs_EPDnew.bed
+#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
 #           label: promoter
 #           type: bed
 #           delimiter: ' '
@@ -948,7 +948,7 @@ hpo_gene_phenotype:
     module: biocypher_metta.adapters.hsa.hpo_gene_phenotype_adapter
     cls: HPOAdapter  
     args:  
-      filepath: /mnt/hdd_1/abdu/biocypher_data/hpo/genes_to_phenotype.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/hpo/genes_to_phenotype.txt
       # entrez_to_ensembl_map: None #./aux_files/hsa/entrez_ensembl/entrez_ensembl_mapping.pkl
   outdir: human_phenotype_ontology
   nodes: False  
@@ -959,7 +959,7 @@ hpo_gene_disease:
     module: biocypher_metta.adapters.hsa.hpo_gene_disease_adapter
     cls: HPOGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/hpo/genes_to_disease.txt
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/hpo/genes_to_disease.txt
       # entrez_to_ensembl_map: None #./aux_files/hsa/entrez_ensembl/entrez_ensembl_mapping.pkl
   outdir: human_phenotype_ontology
   nodes: False
@@ -970,7 +970,7 @@ epd_promoter:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/epd/Hs_EPDnew.bed
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
       label: promoter
       taxon_id: 9606
   outdir: epd
@@ -982,7 +982,7 @@ epd_promoter_regulates_gene:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/epd/Hs_EPDnew.bed
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
       type: promoter to gene association
       label: promoter_gene
       taxon_id: 9606
@@ -995,7 +995,7 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/dbvar/GRCh38.variant_call.all.vcf.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #   outdir: dbvar
 #   nodes: True
@@ -1006,10 +1006,10 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/dbvar/GRCh38.variant_call.all.vcf.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/abdu/biocypher_data/gencode/gencode.v49.annotation.gtf.gz  
+#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
 #           label: gene
 #           type: gtf
 #   outdir: dbvar
@@ -1021,10 +1021,10 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/dbvar/GRCh38.variant_call.all.vcf.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/abdu/biocypher_data/rna_central/homo_sapiens.GRCh38.bed.gz
+#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
 #           label: non_coding_rna
 #           type: bed
 #   outdir: dbvar
@@ -1036,10 +1036,10 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/GRCh38.variant_call.all.vcf.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/abdu/biocypher_data/epd/Hs_EPDnew.bed
+#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
 #           label: promoter
 #           type: bed
 #           delimiter: ' '
@@ -1052,9 +1052,9 @@ peregrine_enhancer:
     module: biocypher_metta.adapters.hsa.peregrine_adapter
     cls: PEREGRINEAdapter
     args:
-      enhancers_file: /mnt/hdd_1/abdu/biocypher_data/peregrine/PEREGRINEenhancershg38.gz
-      enhancer_gene_link: /mnt/hdd_1/abdu/biocypher_data/peregrine/enhancer_gene_link_18.tsv.gz
-      source_file: /mnt/hdd_1/abdu/biocypher_data/peregrine/PEREGRINEenhancersources.gz
+      enhancers_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancershg38.gz
+      enhancer_gene_link: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/enhancer_gene_link_18.tsv.gz
+      source_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancersources.gz
       tissue_ontology_map: ./aux_files/hsa/peregrine_tissues_to_ontology_map.pkl
       label: enhancer
   outdir: peregrine
@@ -1066,9 +1066,9 @@ peregrine_enhancer_regulates:
     module: biocypher_metta.adapters.hsa.peregrine_adapter
     cls: PEREGRINEAdapter
     args:
-      enhancers_file: /mnt/hdd_1/abdu/biocypher_data/peregrine/PEREGRINEenhancershg38.gz
-      enhancer_gene_link: /mnt/hdd_1/abdu/biocypher_data/peregrine/enhancer_gene_link_18.tsv.gz
-      source_file: /mnt/hdd_1/abdu/biocypher_data/peregrine/PEREGRINEenhancersources.gz
+      enhancers_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancershg38.gz
+      enhancer_gene_link: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/enhancer_gene_link_18.tsv.gz
+      source_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancersources.gz
       tissue_ontology_map: ./aux_files/hsa/peregrine_tissues_to_ontology_map.pkl
       type: enhancer to gene association
       label: enhancer_gene
@@ -1081,7 +1081,7 @@ dbsuper_super_enhancer:
     module: biocypher_metta.adapters.hsa.dbsuper_adapter
     cls: DBSuperAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
       dbsuper_tissues_map: ./aux_files/hsa/dbsuper_tissues_map.pkl
       label: super_enhancer      
   outdir: dbsuper
@@ -1093,7 +1093,7 @@ dbsuper_super_enhancer_regulates_gene:
     module: biocypher_metta.adapters.hsa.dbsuper_adapter
     cls: DBSuperAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
       dbsuper_tissues_map: ./aux_files/hsa/dbsuper_tissues_map.pkl
       type: super enhancer to gene association
       label: super_enhancer_gene
@@ -1106,7 +1106,7 @@ dbsnp_snps:
     module: biocypher_metta.adapters.hsa.dbsnp_adapter
     cls: DBSNPAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/dbsnp/00-common_all.vcf.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbsnp/00-common_all.vcf.gz
       label: snp
   outdir: dbsnp
   nodes: True
@@ -1286,8 +1286,7 @@ motif_diff_tf_snp:
     module: biocypher_metta.adapters.hsa.motif_diff_adapter
     cls: MotifDiffAdapter
     args:
-      # filepath: /mnt/hdd_1/abdu/biocypher_data/motif_diff/motif_diff_mono_probNorm_average.diff
-      filepath: /mnt/hdd_1/abdu/motif_diff/_mono_probNorm_average.diff
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/motif_diff/_mono_probNorm_average.diff
       label: tf_snp
   outdir: MotifDiff
   nodes: False
@@ -1424,7 +1423,7 @@ chebi_chebi_subclass_of:
 #     module: biocypher_metta.adapters.hsa.polyphen2_adapter
 #     cls: PolyPhen2Adapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/polyphen2/dbNsfpPolyPhen2.bed.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/polyphen2/dbNsfpPolyPhen2.bed.gz
 #       label: polyphen2_variant
 #   outdir: polyphen-2
 #   nodes: True
@@ -1435,7 +1434,7 @@ bgee_gene_expressed_in_anatomical_entity:
     module: biocypher_metta.adapters.bgee_adapter
     cls: BgeeAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/bgee/Homo_sapiens_expr_simple_all_conditions.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/bgee/Homo_sapiens_expr_simple_all_conditions.tsv.gz
       label: expressed_in
       anatomy_label: gene_expressed_in_anatomy
       developmental_stage_label: gene_expressed_in_developmental_stage
@@ -1449,7 +1448,7 @@ transcription_factor_binding_site:
     module: biocypher_metta.adapters.tfbs_adapter
     cls: TfbsAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/tfbs/EncRegTfbsClustered.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tfbs/EncRegTfbsClustered.csv.gz
       label: tfbs
       taxon_id: 9606        
   outdir: tfbs
@@ -1461,7 +1460,7 @@ gene_tfbs_association:
     module: biocypher_metta.adapters.tfbs_adapter
     cls: TfbsAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/tfbs/EncRegTfbsClustered.csv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tfbs/EncRegTfbsClustered.csv.gz
       label: gene_tfbs
       taxon_id: 9606        
   outdir: tfbs
@@ -1473,7 +1472,7 @@ snp_to_upstream_gene:
     module: biocypher_metta.adapters.hsa.gwas_adapter
     cls: GWASAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gwas/gwas-catalog-associations_ontology-annotated.tsv
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gwas/gwas-catalog-associations_ontology-annotated.tsv
       label: snp_upstream_gene
   outdir: gwas/upstream
   nodes: False
@@ -1484,7 +1483,7 @@ snp_to_downstream_gene:
     module: biocypher_metta.adapters.hsa.gwas_adapter
     cls: GWASAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gwas/gwas-catalog-associations_ontology-annotated.tsv
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gwas/gwas-catalog-associations_ontology-annotated.tsv
       label: snp_downstream_gene
   outdir: gwas/downstream
   nodes: False
@@ -1495,7 +1494,7 @@ snp_to_in_gene:
     module: biocypher_metta.adapters.hsa.gwas_adapter
     cls: GWASAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/gwas/gwas-catalog-associations_ontology-annotated.tsv
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gwas/gwas-catalog-associations_ontology-annotated.tsv
       label: snp_in_gene
   outdir: gwas/ingene
   nodes: False
@@ -1506,7 +1505,7 @@ proximal_enhancer_ccre:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer
       element_filter: proximal
       taxon_id: 9606        
@@ -1519,7 +1518,7 @@ proximal_enhancer_ccre_associates_with_gene:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-All.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-All.tsv.gz
       label: enhancer_gene
       element_filter: proximal
       taxon_id: 9606        
@@ -1532,7 +1531,7 @@ proximal_enhancer_ccre_associates_with_gene_coding_only:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer_gene
       element_filter: proximal
       taxon_id: 9606        
@@ -1545,7 +1544,7 @@ distal_enhancer_ccre:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer
       element_filter: distal
       taxon_id: 9606        
@@ -1558,7 +1557,7 @@ distal_enhancer_ccre_associates_with_gene:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-All.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-All.tsv.gz
       label: enhancer_gene
       element_filter: distal
       taxon_id: 9606        
@@ -1571,7 +1570,7 @@ distal_enhancer_ccre_associates_with_gene_coding_only:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer_gene
       element_filter: distal
       taxon_id: 9606        
@@ -1584,9 +1583,9 @@ promoter_ccre:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       edge_type: eqtl
-      eqtl_filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       label: promoter
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606
@@ -1599,10 +1598,10 @@ promoter_ccre_associates_with_gene_nearest_gene:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-All.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-All.tsv.gz
       edge_type: nearest
       label: promoter_gene
-      eqtl_filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606        
   outdir: ccre/promoter_ccre
@@ -1614,10 +1613,10 @@ promoter_ccre_associates_with_gene_nearest_gene_coding_only:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: promoter_gene
       edge_type: nearest
-      eqtl_filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606        
   outdir: ccre/promoter_ccre/coding_only
@@ -1629,10 +1628,10 @@ promoter_ccre_associates_with_gene_eqtl:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: promoter_gene
       edge_type: eqtl
-      eqtl_filepath: /mnt/hdd_1/abdu/biocypher_data/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606        
   outdir: ccre/promoter_ccre/eqtl
@@ -1751,7 +1750,7 @@ catlas_abc_promoter_to_gene:
 #     module: biocypher_metta.adapters.encode_re2g_adapter
 #     cls: ENCODERe2GAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/encode_re2g/ENCODE_rE2G_K562.bed.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/encode_re2g/ENCODE_rE2G_K562.bed.gz
 #       label: enhancer
 #       taxon_id: 9606
 #   outdir: encode_re2g
@@ -1763,7 +1762,7 @@ catlas_abc_promoter_to_gene:
 #     module: biocypher_metta.adapters.encode_re2g_adapter
 #     cls: ENCODERe2GAdapter
 #     args:
-#       filepath: /mnt/hdd_1/abdu/biocypher_data/encode_re2g/ENCODE_rE2G_K562.bed.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/encode_re2g/ENCODE_rE2G_K562.bed.gz
 #       label: enhancer_activity_by_contact
 #       taxon_id: 9606
 #       cell_ontology_id: "CLO:0007059"  # K562
@@ -1776,7 +1775,7 @@ uniprot_dbxref_bgee_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_gene
       dbxref: BGEE
       taxon_id: 9606
@@ -1789,7 +1788,7 @@ uniprot_dbxref_ensembl_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_gene
       dbxref: ENSEMBL
       taxon_id: 9606
@@ -1802,7 +1801,7 @@ uniprot_dbxref_ensembl_transcript:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_transcript
       dbxref: ENSEMBL
       taxon_id: 9606
@@ -1815,7 +1814,7 @@ uniprot_dbxref_ensembl_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_protein
       dbxref: ENSEMBL
       taxon_id: 9606
@@ -1828,7 +1827,7 @@ uniprot_dbxref_string_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_protein
       dbxref: STRING
       taxon_id: 9606
@@ -1841,7 +1840,7 @@ uniprot_dbxref_biological_process:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_biological_process
       dbxref: GO
       taxon_id: 9606
@@ -1854,7 +1853,7 @@ uniprot_dbxref_cellular_component:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_cellular_component
       dbxref: GO
       taxon_id: 9606
@@ -1867,7 +1866,7 @@ uniprot_dbxref_molecular_function:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_molecular_function
       dbxref: GO
       taxon_id: 9606
@@ -1880,7 +1879,7 @@ uniprot_has_xref_catalytic_activity:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_catalytic_activity
       taxon_id: 9606
       dbxref: CHEBI
@@ -1893,7 +1892,7 @@ uniprot_has_xref_cofactor:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_cofactor
       taxon_id: 9606
       dbxref: CHEBI
@@ -1906,7 +1905,7 @@ uniprot_has_xref_binding_site_ligand:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_binding_site_ligand
       taxon_id: 9606
       dbxref: CHEBI
@@ -1919,7 +1918,7 @@ uniprot_chebi_part_of_chebi:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/abdu/biocypher_data/uniprot/uniprot_sprot_human.dat.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
       label: chemical_substance_part_of_chemical_substance
       taxon_id: 9606
       dbxref: CHEBI
@@ -1960,7 +1959,7 @@ alliance_gene_disease_biomarker_orthology:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: biomarker_via_orthology
   outdir: disease
@@ -1972,7 +1971,7 @@ alliance_gene_disease_implicated_via_orthology:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: implicated_via_orthology
   outdir: disease
@@ -1984,7 +1983,7 @@ alliance_gene_disease_is_implicated_in:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: is_implicated_in
   outdir: disease
@@ -2000,7 +1999,7 @@ alliance_gene_disease_is_implicated_in:
 #     module: biocypher_metta.adapters.alliance_gene_disease_adapter
 #     cls: AllianceGeneDiseaseAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
 #       taxon_id: 9606
 #       label: is_model_of
 #   outdir: disease
@@ -2012,7 +2011,7 @@ alliance_gene_disease_is_marker_for:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: is_marker_for
   outdir: disease
@@ -2037,7 +2036,7 @@ alliance_gene_orthology:
     module: biocypher_metta.adapters.alliance_gene_orthology_adapter
     cls: AllianceGeneOrthologyAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/multi/alliance/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
+      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: orthologs_genes
   outdir: alliance/orthology

--- a/config/hsa/hsa_data_source_config.yaml
+++ b/config/hsa/hsa_data_source_config.yaml
@@ -2,6 +2,7 @@
 agr:    #agr: alliance of genome resource
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
+    - https://fms.alliancegenome.org/download/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz  # gene orthology
 
 bgee:
   name: Bgee Expression Data

--- a/config/hsa/hsa_data_source_config.yaml
+++ b/config/hsa/hsa_data_source_config.yaml
@@ -1,5 +1,6 @@
 ---
 agr:    #agr: alliance of genome resource
+  name: Alliance Genome Resource
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
     - https://fms.alliancegenome.org/download/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz  # gene orthology


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [ ] New processor / Processor fix
- [ ] Schema change
- [x] Adapters config change
- [x] Datasources config change
- [ ] CI / workflow change
- [ ] Bug fix / Refactor

---

## Summary

- **HSA**: replaced all `abdu/biocypher_data/` references (127 paths across  gencode, uniprot, reactome, GO/GAF, coxpressdb, tflink, string, tadmap, GTEx, hocomoco, forgedb, topld, rna_central, HPO, EPD, peregrine, dbSUPER, dbSNP, bgee, TFBS, GWAS, cCRE, motif_diff adapters) with the canonical `/mnt/hdd_1/biocypher-kg/input/hsa/`. Alliance disease and orthology paths unified under `hsa/agr/`.

- **dmel**: replaced all `saulo/snet/.../`, `abdu/biocypher_data/`, and `input/multi/` references (167 path occurrences) with `/mnt/hdd_1/biocypher-kg/input/dmel/`. Flybase filenames bumped from `fb_2025_03` → `fb_2026_01` to match the files already present in the canonical input directory.

- **net_act**: `config/dmel/net_act_adapters_config.yaml` replaced all `/saulo/snet/.../net_act_sources/` and `/abdu/biocypher_data/rna_central/` paths with `/mnt/hdd_1/biocypher-kg/input/dmel/`; bumped FlyBase version from `fb_2025_05` to `fb_2026_01` across 50 file references — all 75 adapters pass make check-paths

- **Datasource configs**: added `ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz` download URL to `hsa_data_source_config.yaml` (under existing `agr:` key) and added  a new `agr:` block to `dmel_data_source_config.yaml`.

- **README**: updated the pre-flight error example to reflect the canonical path.

## Verification

- [x] make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml
```
# INFO — Pre-flight check passed — all 98 adapter(s) have valid file paths.
```
- [x] make check-paths ADAPTERS_CONFIG=./config/dmel/dmel_adapters_config.yaml
```
# INFO — Pre-flight check passed — all 137 adapter(s) have valid file paths.
```
- [x] make check-paths ADAPTERS_CONFIG=./config/dmel/net_act_adapters_config.yaml
```
# INFO — Pre-flight check passed — all 75 adapter(s) have valid file paths.
```
---


