### PR TITLE
feat(config): make adapter input paths configurable via input_dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ run-interactive: check-uv
 	OUTPUT_DIR=$${OUTPUT_DIR:-./output}; \
 	echo "Using output directory: $$OUTPUT_DIR"; \
 	echo ""; \
-	read -p "📂 Enter base input directory (leave blank to use config default): " INPUT_DIR_VAL; \
+	read -p "📂 Enter base input directory [$(INPUT_DIR)]: " INPUT_DIR_VAL; \
+	INPUT_DIR_VAL=$${INPUT_DIR_VAL:-$(INPUT_DIR)}; \
 	if [ -n "$$INPUT_DIR_VAL" ]; then \
 		INPUT_DIR_FLAG="--input-dir $$INPUT_DIR_VAL"; \
 		echo "Using input directory: $$INPUT_DIR_VAL"; \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@
 # Path to the Neo4j env file; override with: make neo4j-up NEO4J_ENV_FILE=my.env
 NEO4J_ENV_FILE ?= docker/neo4j.env
 
+# Base input directory for resolving adapter config paths; overrides the input_dir: field in the YAML
+INPUT_DIR ?=
+
 # Default target
 help:
 	@echo "Available commands:"
@@ -33,11 +36,13 @@ help:
 	@echo "  make run-interactive - Same as 'make run'"
 	@echo "  make run-sample                    - Run with sample data (default: metta writer)"
 	@echo "  make run-sample WRITER_TYPE=prolog - Run with sample data using prolog writer"
-	@echo "  make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml"
-	@echo "  make run-direct ... SKIP_PREFLIGHT=yes   - Skip pre-flight file path validation"
 	@echo "  make run-sample     SKIP_PREFLIGHT=yes   - Same, for sample runs"
-	@echo "  make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env"
 	@echo "  make run-sample INCLUDE_TAXON_ID=no   - Run without taxon_id in output (single-species KG)"
+	@echo "  make run-direct ... SKIP_PREFLIGHT=yes   - Skip pre-flight file path validation"
+	@echo "  make run-direct ... INPUT_DIR=/data/hsa - Override base input directory from the YAML config"
+	@echo "  make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml"
+	@echo "  make check-paths ADAPTERS_CONFIG=... INPUT_DIR=/data/hsa"
+	@echo "  make neo4j-up NEO4J_ENV_FILE=docker/my-custom.env"
 	@echo "  make download                          - Interactive download (recommended)"
 	@echo "  make download-direct OUTPUT_DIR=./input SOURCE=uniprot  - Download a single source"
 	@echo "  make download-direct OUTPUT_DIR=./input CONFIG_FILE=./config/dmel/dmel_data_source_config.yaml"
@@ -77,6 +82,15 @@ run-interactive: check-uv
 	@read -p "📁 Enter output directory [./output]: " OUTPUT_DIR; \
 	OUTPUT_DIR=$${OUTPUT_DIR:-./output}; \
 	echo "Using output directory: $$OUTPUT_DIR"; \
+	echo ""; \
+	read -p "📂 Enter base input directory (leave blank to use config default): " INPUT_DIR_VAL; \
+	if [ -n "$$INPUT_DIR_VAL" ]; then \
+		INPUT_DIR_FLAG="--input-dir $$INPUT_DIR_VAL"; \
+		echo "Using input directory: $$INPUT_DIR_VAL"; \
+	else \
+		INPUT_DIR_FLAG=""; \
+		echo "Using input directory from config"; \
+	fi; \
 	echo ""; \
 	read -p "⚙️  Enter adapters config path [./config/hsa/hsa_adapters_config_sample.yaml]: " ADAPTERS_CONFIG; \
 	ADAPTERS_CONFIG=$${ADAPTERS_CONFIG:-./config/hsa/hsa_adapters_config_sample.yaml}; \
@@ -168,7 +182,8 @@ run-interactive: check-uv
 		$$WRITE_PROPERTIES_FLAG \
 		$$ADD_PROVENANCE_FLAG \
 		$$INCLUDE_TAXON_ID_FLAG \
-		$$SKIP_PREFLIGHT_FLAG && \
+		$$SKIP_PREFLIGHT_FLAG \
+		$$INPUT_DIR_FLAG && \
 	echo "✅ Knowledge graph creation completed! Check $$OUTPUT_DIR for results."
 
 run-direct: check-uv
@@ -205,7 +220,8 @@ run-direct: check-uv
 		$$WRITE_PROPERTIES_FLAG \
 		$$ADD_PROVENANCE_FLAG \
 		$$INCLUDE_TAXON_ID_FLAG \
-		$(if $(filter yes true,$(SKIP_PREFLIGHT)),--skip-preflight,)
+		$(if $(filter yes true,$(SKIP_PREFLIGHT)),--skip-preflight,) \
+		$(if $(INPUT_DIR),--input-dir $(INPUT_DIR),)
 
 # Run with sample configuration and data (with optional writer type)
 run-sample: check-uv
@@ -262,6 +278,7 @@ check-paths: check-uv
 	uv run python create_knowledge_graph.py \
 		--adapters-config $(ADAPTERS_CONFIG) \
 		$$INCLUDE_ADAPTERS_FLAG \
+		$(if $(INPUT_DIR),--input-dir $(INPUT_DIR),) \
 		--check-only
 
 # ─── Neo4j deployment targets ────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -31,13 +31,18 @@ make run-sample WRITER_TYPE=<metta,neo4j,prolog> [INCLUDE_TAXON_ID=no]
 #### Option 3: Direct Run with Parameters
 ```bash
 make run-direct OUTPUT_DIR=./output \
-               ADAPTERS_CONFIG=./config.yaml \
-               DBSNP_RSIDS=./rsids.txt \
-               DBSNP_POS=./pos.txt \
+               ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml \
+               SCHEMA_CONFIG=./config/hsa/hsa_schema_config.yaml \
                WRITER_TYPE=metta \
                WRITE_PROPERTIES=no \
                ADD_PROVENANCE=no \
                INCLUDE_TAXON_ID=no
+
+# Override the base input directory (e.g. on a different machine):
+make run-direct OUTPUT_DIR=./output \
+               ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml \
+               SCHEMA_CONFIG=./config/hsa/hsa_schema_config.yaml \
+               INPUT_DIR=/custom/path/to/hsa
 ```
 ### Interactive Mode Example
 When you run `make run`, you'll see:
@@ -98,6 +103,10 @@ To validate an adapters config in isolation — without a schema, output directo
 # Via make (recommended)
 make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml
 
+# Override the base input directory
+make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml \
+                 INPUT_DIR=/custom/path/to/hsa
+
 # Check only specific adapters
 make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml \
                  INCLUDE_ADAPTERS="gencode_gene uniprotkb_sprot bgee_gene_expressed_in_anatomical_entity"
@@ -105,6 +114,12 @@ make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml \
 # Directly via the CLI
 uv run python create_knowledge_graph.py \
     --adapters-config ./config/hsa/hsa_adapters_config.yaml \
+    --check-only
+
+# With input-dir override
+uv run python create_knowledge_graph.py \
+    --adapters-config ./config/hsa/hsa_adapters_config.yaml \
+    --input-dir /custom/path/to/hsa \
     --check-only
 ```
 
@@ -122,6 +137,38 @@ make run-sample     SKIP_PREFLIGHT=yes
 # Directly via the CLI
 uv run python create_knowledge_graph.py ... --skip-preflight
 ```
+
+#### Configuring the input data directory
+
+Full adapter configs (e.g. `config/hsa/hsa_adapters_config.yaml`) declare an `input_dir:` field at the top that serves as the base directory for all input data paths:
+
+```yaml
+input_dir: /mnt/hdd_1/biocypher-kg/input/hsa
+
+gencode_gene:
+  adapter:
+    args:
+      filepath: gencode/gencode.v49.annotation.gtf.gz   # resolved as input_dir/gencode/...
+```
+
+To use a different data location without editing the YAML, pass `--input-dir` (CLI) or `INPUT_DIR=` (make):
+
+```bash
+# Makefile
+make run-direct OUTPUT_DIR=./output \
+               ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml \
+               SCHEMA_CONFIG=./config/hsa/hsa_schema_config.yaml \
+               INPUT_DIR=/my/data/hsa
+
+# CLI
+uv run python create_knowledge_graph.py \
+    --output-dir ./output \
+    --adapters-config ./config/hsa/hsa_adapters_config.yaml \
+    --schema-config ./config/hsa/hsa_schema_config.yaml \
+    --input-dir /my/data/hsa
+```
+
+Relative paths starting with `./` or `../` (e.g. `./aux_files/`, `./samples/`) are always treated as repository-relative and are never affected by `input_dir`.
 
 
 ## BioCypher Knowledge Graph CLI Tool (Option 2)

--- a/config/dmel/dmel_adapters_config.yaml
+++ b/config/dmel/dmel_adapters_config.yaml
@@ -1,9 +1,11 @@
+input_dir: /mnt/hdd_1/biocypher-kg/input/dmel
+
 bgee_gene_expressed_in_anatomical_entity:
   adapter:
     module: biocypher_metta.adapters.bgee_adapter
     cls: BgeeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
+      filepath: bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
       label: expressed_in
       anatomy_label: gene_expressed_in_anatomy
       developmental_stage_label: gene_expressed_in_developmental_stage
@@ -17,8 +19,8 @@ rna_central_non_coding_rna:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       label: non_coding_rna
       type: non_coding_rna
       taxon_id: 7227
@@ -31,8 +33,8 @@ rna_central_non_coding_rna_biological_process:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: biological process rna
       label: biological_process_rna
       taxon_id: 7227
@@ -45,8 +47,8 @@ rna_central_non_coding_rna_molecular_function:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: molecular function rna
       label: molecular_function_rna
       taxon_id: 7227
@@ -59,8 +61,8 @@ rna_central_non_coding_rna_cellular_component:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: cellular component rna
       label: cellular_component_rna
       taxon_id: 7227
@@ -74,8 +76,8 @@ dmel_gene_group:
     cls: GeneGroupAdapter
     args:
       label: gene_group
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: True
   edges: False
@@ -86,8 +88,8 @@ dmel_gene_to_gene_group:
     cls: GeneGroupAdapter
     args:
       label: grouped_into
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: False
   edges: True
@@ -98,8 +100,8 @@ dmel_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -110,8 +112,8 @@ dmel_gene_to_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -122,8 +124,8 @@ dmel_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -134,8 +136,8 @@ dmel_gene_to_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -146,7 +148,7 @@ dmel_disease_model:
     cls: DiseaseModelAdapter
     args:
       label: dmel_disease_model
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: True
   edges: False
@@ -158,7 +160,7 @@ dmel_gene_to_disease_model:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_human_disease
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -169,7 +171,7 @@ dmel_gene_to_do_term:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_do_term
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -180,8 +182,8 @@ dmel_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genotype
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -192,8 +194,8 @@ dmel_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
       label: phenotype_set
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-      dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+      dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -204,8 +206,8 @@ dmel_allele_to_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
        label: involved_in
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -216,8 +218,8 @@ dmel_phenotype_set_to_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genetically_informed_by
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -229,8 +231,8 @@ dmel_phenotype_set_to_ontology:
     cls: GenotypePhenotypeAdapter
     args:
        label: characterized_by
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -241,8 +243,8 @@ dmel_phenotype_set_to_cellular_component:
     cls: GenotypePhenotypeAdapter
     args:
        label: inheres_in
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -254,9 +256,9 @@ dmel_ptp_physical_interaction:
     cls: PhysicalInteractionAdapter
     args:
        filepaths: [
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
+          flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptp_physically_interacts_with
   outdir: flybase/mi_interactions
@@ -270,9 +272,9 @@ dmel_ptt_physical_interaction:
     cls: PhysicalInteractionAdapter
     args:
        filepaths: [
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
+          flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptt_physically_interacts_with  
   outdir: flybase/mi_interactions
@@ -284,7 +286,7 @@ orthology_adapter:
         module: biocypher_metta.adapters.dmel.orthology_adapter
         cls: OrthologyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
     outdir: orthologs
     nodes: False
     edges: True
@@ -294,7 +296,7 @@ paralogy_adapter:
         module: biocypher_metta.adapters.dmel.paralogy_adapter
         cls: ParalogyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_paralogs_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/dmel_paralogs_fb_2026_01.tsv.gz
     outdir: paralogs
     nodes: False
     edges: True
@@ -304,7 +306,7 @@ allele:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: allele
   outdir: allele
   nodes: True
@@ -315,7 +317,7 @@ dmel_allele_to_gene:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: variant_of
   outdir: allele
   nodes: False
@@ -326,7 +328,7 @@ dmel_gene_genetic_adapter:
         module: biocypher_metta.adapters.dmel.gene_genetic_association_adapter
         cls: GeneGeneticAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_genetic_interactions_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/gene_genetic_interactions_fb_2026_01.tsv.gz
     outdir: flybase/gene_genetic
     nodes: False
     edges: True
@@ -337,8 +339,8 @@ dmel_allele_to_allele_genetic_interaction_adapter:
         cls: AlleleGeneticInteractionAdapter
         args:
           label: allele_to_allele_genetic_interaction
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/allele_genetic_interactions_fb_2026_01.tsv.gz
-          dmel_fbal_to_fbgn_file: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/allele_genetic_interactions_fb_2026_01.tsv.gz
+          dmel_fbal_to_fbgn_file: flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
     outdir: flybase/allele_genetic
     nodes: False
     edges: True
@@ -348,7 +350,7 @@ dmel_expressed_in:
     module: biocypher_metta.adapters.dmel.expressed_in_adapter
     cls: ExpressedInAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz
+      filepath: flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz
   outdir: expressed_in
   nodes: False
   edges: True
@@ -358,7 +360,7 @@ dmel_gene_to_sequence_ontology:
     module: biocypher_metta.adapters.dmel.gene_so_adapter
     cls: GeneToSequenceOntologyAdapter
     args:
-       filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_gene_sequence_ontology_annotations_fb_2026_01.tsv.gz
+       filepath: flybase/dmel_gene_sequence_ontology_annotations_fb_2026_01.tsv.gz
   outdir: so_classified_as
   nodes: False
   edges: True
@@ -369,14 +371,14 @@ RNASeq_library:
     cls: RnaseqLibraryAdapter
     args:
       filepaths: [
-                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+                             flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+                             flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+                             flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+                             fca2/fca2_fbgn_gene_output.tsv.gz,
+                             fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+                             fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+                             fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+                             afca/afca_afca_annotation_group_by_mean.tsv.gz,
       ]
   outdir: rnaseq
   nodes: True
@@ -389,17 +391,17 @@ expression_value:
     cls: ExpressionValueAdapter
     args:
       data_filepaths: [
-                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-                             /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+                             flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+                             flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+                             flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+                             fca2/fca2_fbgn_gene_output.tsv.gz,
+                             fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+                             fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+                             fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+                             afca/afca_afca_annotation_group_by_mean.tsv.gz,
       ]      
       aux_filepaths: [
-                        /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+                        flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
       ]      
   outdir: rnaseq
   nodes: False
@@ -495,7 +497,7 @@ gencode_gene:
     module: biocypher_metta.adapters.gencode_gene_adapter
     cls: GencodeGeneAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       gene_alias_file_path: ./aux_files/dmel/Drosophila_melanogaster.gene_info.gz
       label: gene
       taxon_id: 7227
@@ -508,7 +510,7 @@ gencode_transcripts:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcript
       label: transcript
       taxon_id: 7227
@@ -521,7 +523,7 @@ transcribes_to:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcribes to
       label: transcribes_to
       taxon_id: 7227
@@ -534,7 +536,7 @@ gencode_exon:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       target_type: None
       label: exon
       taxon_id: 7227
@@ -547,7 +549,7 @@ exon_part_of_transcript:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_transcript
       target_type: transcript
       taxon_id: 7227
@@ -560,7 +562,7 @@ exon_part_of_gene:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_gene
       target_type: gene      
       taxon_id: 7227
@@ -573,7 +575,7 @@ gaf_biological_process_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: biological_process_gene_product
       taxon_id: 7227
@@ -586,7 +588,7 @@ gaf_molecular_function_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: molecular_function_gene_product
       taxon_id: 7227
@@ -599,7 +601,7 @@ gaf_cellular_component_gene_product_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_part_of
       taxon_id: 7227
@@ -612,7 +614,7 @@ gaf_cellular_component_gene_product_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_located_in
       taxon_id: 7227
@@ -625,7 +627,7 @@ coexpression:
     module: biocypher_metta.adapters.coxpresdb_adapter
     cls: CoxpresdbAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/coxpressdb/
+      filepath: coxpressdb/
       entrez_to_ensemble_path: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
       label: coexpressed_with
       taxon_id: 7227
@@ -638,8 +640,8 @@ pathway:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathways.txt
-      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
+      filepath: reactome/ReactomePathways.txt
+      pubmed_map_path: reactome/ReactionPMIDS.txt
       label: pathway
       taxon_id: 7227
   outdir: reactome
@@ -651,8 +653,8 @@ reactome_reaction:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
-      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
+      pubmed_map_path: reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 7227
   outdir: reactome
@@ -664,7 +666,7 @@ reactome_reaction_to_pathway:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: reaction_to_pathway
       taxon_id: 7227
   outdir: reactome
@@ -676,7 +678,7 @@ reactome_input_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: enables
       pathway_label: protein_enables_pathway
       reaction_label: protein_enables_reaction
@@ -690,7 +692,7 @@ reactome_output_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: produced_by
       pathway_label: protein_produced_by_pathway
       reaction_label: protein_produced_by_reaction
@@ -704,7 +706,7 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: regulates
       pathway_label: protein_regulates_pathway
       reaction_label: protein_regulates_reaction
@@ -718,7 +720,7 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: negatively_regulates
       pathway_label: protein_negatively_regulates_pathway
       reaction_label: protein_negatively_regulates_reaction
@@ -732,7 +734,7 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: positively_regulates
       pathway_label: protein_positively_regulates_pathway
       reaction_label: protein_positively_regulates_reaction
@@ -746,7 +748,7 @@ genes_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: genes_pathways
       taxon_id: 7227
@@ -759,7 +761,7 @@ protein_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: protein_pathways
       taxon_id: 7227
@@ -772,7 +774,7 @@ transcript_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: transcript_pathways
       taxon_id: 7227
@@ -785,7 +787,7 @@ gene_or_gene_product_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: gene_or_gene_product_reaction
       taxon_id: 7227
@@ -798,7 +800,7 @@ protein_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: protein_reaction
       taxon_id: 7227
@@ -811,7 +813,7 @@ transcript_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: transcript_reaction
       taxon_id: 7227
@@ -824,7 +826,7 @@ chebi_small_molecule_to_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ChEBI2Reactome_All_Levels.txt
+      filepath: reactome/ChEBI2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: small_molecule_to_pathway
       taxon_id: 7227
@@ -837,7 +839,7 @@ chebi_small_molecule_to_reactions:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ChEBI2ReactomeReactions.txt
+      filepath: reactome/ChEBI2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: small_molecule_to_reaction
       taxon_id: 7227
@@ -850,7 +852,7 @@ parent_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
+      filepath: reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: parent_pathway_of
       taxon_id: 7227
@@ -863,7 +865,7 @@ child_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
+      filepath: reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: child_pathway_of
       taxon_id: 7227
@@ -876,7 +878,7 @@ uniprotkb_sprot:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein
       taxon_id: 7227
   outdir: uniprot/uniprot
@@ -888,7 +890,7 @@ uniprotkb_sprot_translates_to:
     module: biocypher_metta.adapters.uniprot_adapter
     cls: UniprotAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       type: translates to
       label: translates_to
       taxon_id: 7227
@@ -901,7 +903,7 @@ uniprot_dbxref_bgee_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: BGEE
       taxon_id: 7227
@@ -914,7 +916,7 @@ uniprot_dbxref_ensembl_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -927,7 +929,7 @@ uniprot_dbxref_ensembl_transcript:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_transcript
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -940,7 +942,7 @@ uniprot_dbxref_ensembl_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -953,7 +955,7 @@ uniprot_dbxref_string_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: STRING
       taxon_id: 7227
@@ -966,7 +968,7 @@ uniprot_dbxref_biological_process:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_biological_process
       dbxref: GO
       taxon_id: 7227
@@ -979,7 +981,7 @@ uniprot_dbxref_cellular_component:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_cellular_component
       dbxref: GO
       taxon_id: 7227
@@ -992,7 +994,7 @@ uniprot_dbxref_molecular_function:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_molecular_function
       dbxref: GO
       taxon_id: 7227
@@ -1005,7 +1007,7 @@ uniprot_has_xref_catalytic_activity:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_catalytic_activity
       taxon_id: 7227
       dbxref: CHEBI
@@ -1018,7 +1020,7 @@ uniprot_has_xref_cofactor:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_cofactor
       taxon_id: 7227
       dbxref: CHEBI
@@ -1031,7 +1033,7 @@ uniprot_has_xref_binding_site_ligand:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_binding_site_ligand
       taxon_id: 7227
       dbxref: CHEBI
@@ -1044,7 +1046,7 @@ uniprot_chebi_part_of_chebi:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: chemical_substance_part_of_chemical_substance
       taxon_id: 7227
       dbxref: CHEBI
@@ -1057,7 +1059,7 @@ tflink:
         module: biocypher_metta.adapters.tflink_adapter
         cls: TFLinkAdapter
         args:
-          filepath: /mnt/hdd_1/biocypher-kg/input/dmel/tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
+          filepath: tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
           entrez_to_ensemble_map: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
           label: tf_gene
           taxon_id: 7227
@@ -1070,7 +1072,7 @@ string:
     module: biocypher_metta.adapters.string_ppi_adapter
     cls: StringPPIAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/string/7227.protein.links.v12.0.txt.gz
+      filepath: string/7227.protein.links.v12.0.txt.gz
       ensembl_to_uniprot_map: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: interacts_with
       taxon_id: 7227
@@ -1282,7 +1284,7 @@ epd_promoter_dmel:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/epd/Dm_EPDnew.bed.gz
+      filepath: epd/Dm_EPDnew.bed.gz
       hgnc_to_ensembl_map: ./aux_files/dmel/flybase_synonym_mapping.pkl
       label: promoter
       type: promoter
@@ -1296,7 +1298,7 @@ epd_promoter_regulates_gene_dmel:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/epd/Dm_EPDnew.bed.gz
+      filepath: epd/Dm_EPDnew.bed.gz
       hgnc_to_ensembl_map: ./aux_files/dmel/flybase_synonym_mapping.pkl
       label: promoter_gene
       type: promoter_gene
@@ -1310,7 +1312,7 @@ alliance_gene_orthology:
     module: biocypher_metta.adapters.alliance_gene_orthology_adapter
     cls: AllianceGeneOrthologyAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/agr/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
+      filepath: agr/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 7227
       label: orthologs_genes
   outdir: alliance/orthology

--- a/config/dmel/net_act_adapters_config.yaml
+++ b/config/dmel/net_act_adapters_config.yaml
@@ -1,9 +1,11 @@
+input_dir: /mnt/hdd_1/biocypher-kg/input/dmel
+
 bgee_gene_expressed_in_anatomical_entity:
   adapter:
     module: biocypher_metta.adapters.bgee_adapter
     cls: BgeeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
+      filepath: bgee/Drosophila_melanogaster_expr_simple_all_conditions.tsv.gz
       label: expressed_in
       taxon_id: 7227
   outdir: bgee
@@ -15,8 +17,8 @@ rna_central_non_coding_rna:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       label: non_coding_rna
       type: non_coding_rna
       taxon_id: 7227
@@ -29,8 +31,8 @@ rna_central_non_coding_rna_biological_process:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: biological process rna
       label: biological_process_rna
       taxon_id: 7227
@@ -43,8 +45,8 @@ rna_central_non_coding_rna_molecular_function:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: molecular function rna
       label: molecular_function_rna
       taxon_id: 7227
@@ -57,8 +59,8 @@ rna_central_non_coding_rna_cellular_component:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/drosophila_melanogaster.BDGP6.46.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: cellular component rna
       label: cellular_component_rna
       taxon_id: 7227
@@ -72,8 +74,8 @@ dmel_gene_group:
     cls: GeneGroupAdapter
     args:
       label: gene_group
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: True
   edges: False
@@ -84,8 +86,8 @@ dmel_gene_to_gene_group:
     cls: GeneGroupAdapter
     args:
       label: grouped_into
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/gene_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/gene_groups
   nodes: False
   edges: True
@@ -96,8 +98,8 @@ dmel_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -108,8 +110,8 @@ dmel_gene_to_signaling_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: signaling_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/signaling_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -120,8 +122,8 @@ dmel_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_gene_group
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: True
   edges: False
@@ -132,8 +134,8 @@ dmel_gene_to_metabolic_pathway_gene_group:
     cls: GeneGroupAdapter
     args:
       label: metabolic_pathway_grouped_into
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
-      dmel_groups_hgnc_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/metabolic_pathway_group_data_fb_2026_01.tsv.gz
+      dmel_groups_hgnc_filepath: flybase/gene_groups_HGNC_fb_2026_01.tsv.gz
   outdir: flybase/pathway_gene_groups
   nodes: False
   edges: True
@@ -145,7 +147,7 @@ dmel_disease_model:
     cls: DiseaseModelAdapter
     args:
       label: dmel_disease_model
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: True
   edges: False
@@ -157,7 +159,7 @@ dmel_gene_to_disease_model:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_human_disease
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -168,7 +170,7 @@ dmel_gene_to_do_term:
     cls: DiseaseModelAdapter
     args:
        label: modelled_to_do_term
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/disease_model_annotations_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/disease_model_annotations_fb_2026_01.tsv.gz
   outdir: flybase/disease_model
   nodes: False
   edges: True
@@ -179,8 +181,8 @@ dmel_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genotype
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -191,8 +193,8 @@ dmel_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
       label: phenotype_set
-      dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-      dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+      dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+      dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: True
   edges: False
@@ -203,8 +205,8 @@ dmel_allele_to_phenotype_set:
     cls: GenotypePhenotypeAdapter
     args:
        label: involved_in
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -217,8 +219,8 @@ dmel_phenotype_set_to_genotype:
     cls: GenotypePhenotypeAdapter
     args:
        label: genetically_informed_by
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -230,8 +232,8 @@ dmel_phenotype_set_to_ontology:
     cls: GenotypePhenotypeAdapter
     args:
        label: characterized_by
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -242,8 +244,8 @@ dmel_phenotype_set_to_cellular_component:
     cls: GenotypePhenotypeAdapter
     args:
        label: inheres_in
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
-       dmel_fbrf_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/genotype_phenotype_data_fb_2026_01.tsv.gz
+       dmel_fbrf_filepath: flybase/fbrf_pmid_pmcid_doi_fb_2026_01.tsv.gz
   outdir: flybase/genotype_phenotype_set
   nodes: False
   edges: True
@@ -257,9 +259,9 @@ dmel_ptp_physical_interaction:
     args:
       #  dmel_ensembl_to_uniprot_map: ./aux_files/dmel_string_ensembl_to_uniprot_map.pkl
        filepaths: [
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
+          flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptp_physically_interacts_with
   outdir: flybase/mi_interactions
@@ -274,9 +276,9 @@ dmel_ptt_physical_interaction:
     args:
       #  dmel_ensembl_to_uniprot_map: ./aux_files/dmel_string_ensembl_to_uniprot_map.pkl
        filepaths: [
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
-          /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_uniprot_fb_2026_01.tsv.gz
+          flybase/physical_interactions_mitab_fb_2026_01.tsv.gz,
+          flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+          flybase/fbgn_uniprot_fb_2026_01.tsv.gz
        ]
        label: ptt_physically_interacts_with  
   outdir: flybase/mi_interactions
@@ -289,7 +291,7 @@ orthology_adapter:
         module: biocypher_metta.adapters.dmel.orthology_adapter
         cls: OrthologyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/dmel_human_orthologs_disease_fb_2026_01.tsv.gz
     outdir: orthologs
     nodes: False
     edges: True
@@ -300,7 +302,7 @@ paralogy_adapter:
         module: biocypher_metta.adapters.dmel.paralogy_adapter
         cls: ParalogyAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_paralogs_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/dmel_paralogs_fb_2026_01.tsv.gz
     outdir: paralogs
     nodes: False
     edges: True
@@ -311,7 +313,7 @@ allele:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: allele
   outdir: allele
   nodes: True
@@ -323,7 +325,7 @@ dmel_allele_to_gene:
     module: biocypher_metta.adapters.dmel.allele_adapter
     cls: AlleleAdapter
     args:
-       dmel_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
+       dmel_filepath: flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
        label: variant_of
   outdir: allele
   nodes: False
@@ -335,7 +337,7 @@ dmel_gene_genetic_adapter:
         module: biocypher_metta.adapters.dmel.gene_genetic_association_adapter
         cls: GeneGeneticAssociationAdapter
         args:
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_genetic_interactions_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/gene_genetic_interactions_fb_2026_01.tsv.gz
     outdir: flybase/gene_genetic
     nodes: False
     edges: True
@@ -347,8 +349,8 @@ dmel_allele_to_allele_genetic_interaction_adapter:
         cls: AlleleGeneticInteractionAdapter
         args:
           label: allele_to_allele_genetic_interaction
-          dmel_data_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/allele_genetic_interactions_fb_2026_01.tsv.gz
-          dmel_fbal_to_fbgn_file: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
+          dmel_data_filepath: flybase/allele_genetic_interactions_fb_2026_01.tsv.gz
+          dmel_fbal_to_fbgn_file: flybase/fbal_to_fbgn_fb_2026_01.tsv.gz
     outdir: flybase/allele_genetic
     nodes: False
     edges: True
@@ -359,7 +361,7 @@ dmel_expressed_in:
     module: biocypher_metta.adapters.dmel.expressed_in_adapter
     cls: ExpressedInAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz
+      filepath: flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz
   outdir: expressed_in
   nodes: False
   edges: True
@@ -369,7 +371,7 @@ dmel_gene_to_sequence_ontology:
     module: biocypher_metta.adapters.dmel.gene_so_adapter
     cls: GeneToSequenceOntologyAdapter
     args:
-       filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/dmel_gene_sequence_ontology_annotations_fb_2026_01.tsv.gz
+       filepath: flybase/dmel_gene_sequence_ontology_annotations_fb_2026_01.tsv.gz
   outdir: so_classified_as
   nodes: False
   edges: True
@@ -379,7 +381,7 @@ coexpression:
     module: biocypher_metta.adapters.coxpresdb_adapter
     cls: CoxpresdbAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/coxpressdb/
+      filepath: coxpressdb/
       entrez_to_ensemble_path: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
       label: coexpressed_with
       taxon_id: 7227
@@ -393,14 +395,14 @@ coexpression:
 #     cls: RnaseqLibraryAdapter
 #     args:
 #       filepaths: [
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+#                              flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+#                              flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+#                              flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+#                              fca2/fca2_fbgn_gene_output.tsv.gz,
+#                              fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+#                              fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+#                              fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+#                              afca/afca_afca_annotation_group_by_mean.tsv.gz,
 #       ]
 #   outdir: rnaseq
 #   nodes: True
@@ -413,17 +415,17 @@ coexpression:
 #     cls: ExpressionValueAdapter
 #     args:
 #       data_filepaths: [
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_gene_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_gene_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
-#                              /mnt/hdd_1/biocypher-kg/input/dmel/afca/afca_afca_annotation_group_by_mean.tsv.gz,
+#                              flybase/scRNA-Seq_gene_expression_fb_2026_01.tsv.gz,
+#                              flybase/high-throughput_gene_expression_fb_2026_01.tsv.gz,
+#                              flybase/gene_rpkm_report_fb_2026_01.tsv.gz,
+#                              fca2/fca2_fbgn_gene_output.tsv.gz,
+#                              fca2/fca2_fbgn_transcriptGene_output.tsv.gz,
+#                              fca2/fca2_fbgn_mir_gene_output.tsv.gz,
+#                              fca2/fca2_fbgn_mir_transcript_output.tsv.gz,
+#                              afca/afca_afca_annotation_group_by_mean.tsv.gz,
 #       ]      
 #       aux_filepaths: [
-#                         /mnt/hdd_1/biocypher-kg/input/dmel/flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
+#                         flybase/fbgn_fbtr_fbpp_expanded_fb_2026_01.tsv.gz,
 #       ]      
 #   outdir: rnaseq
 #   nodes: False
@@ -519,9 +521,9 @@ gencode_gene:
     module: biocypher_metta.adapters.gencode_gene_adapter
     cls: GencodeGeneAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       gene_alias_file_path: ./aux_files/dmel/Drosophila_melanogaster.gene_info.gz
-      # summaries_filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/best_gene_summary_fb_2026_01.tsv.gz
+      # summaries_filepath: flybase/best_gene_summary_fb_2026_01.tsv.gz
       label: gene
       taxon_id: 7227
   outdir: gencode/gene
@@ -533,7 +535,7 @@ gencode_transcripts:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcript
       label: transcript
       taxon_id: 7227
@@ -546,7 +548,7 @@ transcribes_to:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       type: transcribes to
       label: transcribes_to
       taxon_id: 7227
@@ -559,7 +561,7 @@ gencode_exon:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       target_type: None
       label: exon
       taxon_id: 7227
@@ -572,7 +574,7 @@ exon_part_of_transcript:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_transcript
       target_type: transcript
       taxon_id: 7227
@@ -585,7 +587,7 @@ exon_part_of_gene:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: gencode/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
       label: part_of_gene
       target_type: gene      
       taxon_id: 7227
@@ -598,7 +600,7 @@ gaf_biological_process_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: biological_process_gene_product
       taxon_id: 7227
@@ -611,7 +613,7 @@ gaf_molecular_function_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: molecular_function_gene_product
       taxon_id: 7227
@@ -624,7 +626,7 @@ gaf_cellular_component_gene_product_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_part_of
       taxon_id: 7227
@@ -637,7 +639,7 @@ gaf_cellular_component_gene_product_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/flybase/gene_association.fb.gz
+      filepath: flybase/gene_association.fb.gz
       gaf_type: 'flybase'
       label: cellular_component_gene_product_located_in
       taxon_id: 7227
@@ -650,8 +652,8 @@ pathway:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathways.txt
-      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
+      filepath: reactome/ReactomePathways.txt
+      pubmed_map_path: reactome/ReactionPMIDS.txt
       label: pathway
       taxon_id: 7227
   outdir: reactome
@@ -663,8 +665,8 @@ reactome_reaction:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt   # there is no file like ReactomePathways.txt for reactions in the Reactome portal (www.reactome.org)
-      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactionPMIDS.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt   # there is no file like ReactomePathways.txt for reactions in the Reactome portal (www.reactome.org)
+      pubmed_map_path: reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 7227
   outdir: reactome
@@ -676,7 +678,7 @@ genes_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: reactome/Ensembl2Reactome_All_Levels.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: genes_pathways
       taxon_id: 7227
@@ -689,7 +691,7 @@ gene_or_gene_product_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/Ensembl2ReactomeReactions.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: gene_or_gene_product_reaction
       taxon_id: 7227
@@ -702,7 +704,7 @@ parent_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
+      filepath: reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: parent_pathway_of
       taxon_id: 7227
@@ -715,7 +717,7 @@ child_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/reactome/ReactomePathwaysRelation.txt
+      filepath: reactome/ReactomePathwaysRelation.txt
       ensembl_uniprot_map_path: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: child_pathway_of
       taxon_id: 7227
@@ -729,7 +731,7 @@ uniprotkb_sprot:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein
       taxon_id: 7227
   outdir: uniprot/uniprot
@@ -742,7 +744,7 @@ uniprotkb_sprot_translates_to:
     module: biocypher_metta.adapters.uniprot_adapter
     cls: UniprotAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       type: translates to
       label: translates_to
       taxon_id: 7227
@@ -755,7 +757,7 @@ uniprot_dbxref_bgee_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: BGEE
       taxon_id: 7227
@@ -768,7 +770,7 @@ uniprot_dbxref_ensembl_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_gene
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -781,7 +783,7 @@ uniprot_dbxref_ensembl_transcript:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_transcript
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -794,7 +796,7 @@ uniprot_dbxref_ensembl_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: ENSEMBL
       taxon_id: 7227
@@ -808,7 +810,7 @@ uniprot_dbxref_string_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_protein
       dbxref: STRING
       taxon_id: 7227
@@ -821,7 +823,7 @@ uniprot_dbxref_biological_process:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_biological_process
       dbxref: GO
       taxon_id: 7227
@@ -834,7 +836,7 @@ uniprot_dbxref_cellular_component:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_cellular_component
       dbxref: GO
       taxon_id: 7227
@@ -847,7 +849,7 @@ uniprot_dbxref_molecular_function:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
+      filepath: uniprot/uniprot_sprot_invertebrates_DMEL.dat.gz
       label: protein_has_xref_molecular_function
       dbxref: GO
       taxon_id: 7227
@@ -861,7 +863,7 @@ tflink:
         module: biocypher_metta.adapters.tflink_adapter
         cls: TFLinkAdapter
         args:
-          filepath: /mnt/hdd_1/biocypher-kg/input/dmel/tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
+          filepath: tflink/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv.gz
           entrez_to_ensemble_map: ./aux_files/dmel/dmel_entrez_to_ensembl.pkl
           label: tf_gene
           taxon_id: 7227
@@ -874,7 +876,7 @@ string:
     module: biocypher_metta.adapters.string_ppi_adapter
     cls: StringPPIAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/dmel/string/7227.protein.links.v12.0.txt.gz
+      filepath: string/7227.protein.links.v12.0.txt.gz
       ensembl_to_uniprot_map: ./aux_files/dmel/dmel_string_ensembl_to_uniprot_map.pkl
       label: interacts_with
       taxon_id: 7227

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -1,9 +1,11 @@
+input_dir: /mnt/hdd_1/biocypher-kg/input/hsa
+
 gencode_gene:
   adapter:
     module: biocypher_metta.adapters.gencode_gene_adapter
     cls: GencodeGeneAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: gencode/gencode.v49.annotation.gtf.gz  
       label: gene
       taxon_id: 9606      # multi-species version needs this
   outdir: gencode/gene
@@ -15,7 +17,7 @@ gencode_transcripts:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: gencode/gencode.v49.annotation.gtf.gz  
       type: transcript
       label: transcript
       taxon_id: 9606      # multi-species version needs this
@@ -28,7 +30,7 @@ transcribes_to:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: gencode/gencode.v49.annotation.gtf.gz  
       type: transcribes to
       label: transcribes_to
       taxon_id: 9606      # multi-species version needs this
@@ -41,7 +43,7 @@ gencode_exon:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: gencode/gencode.v49.annotation.gtf.gz  
       target_type: exon   # it could be anything here
       label: exon
       taxon_id: 9606      # multi-species version needs this
@@ -54,7 +56,7 @@ exon_part_of_transcript: # replaces transcript_includes_exon
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: gencode/gencode.v49.annotation.gtf.gz  
       label: part_of_transcript
       target_type: transcript
       taxon_id: 9606      
@@ -67,7 +69,7 @@ exon_part_of_gene:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+      filepath: gencode/gencode.v49.annotation.gtf.gz  
       label: part_of_gene
       target_type: gene
       taxon_id: 9606      
@@ -80,7 +82,7 @@ uniprotkb_sprot:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein
       taxon_id: 9606      # multi-species version needs this
   outdir: uniprot
@@ -92,7 +94,7 @@ uniprotkb_sprot_translates_to:
     module: biocypher_metta.adapters.uniprot_adapter
     cls: UniprotAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       type: translates to
       label: translates_to
       taxon_id: 9606      # multi-species version needs this
@@ -105,8 +107,8 @@ pathway:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactomePathways.txt
-      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactionPMIDS.txt
+      filepath: reactome/ReactomePathways.txt
+      pubmed_map_path: reactome/ReactionPMIDS.txt
       label: pathway
       taxon_id: 9606
   outdir: reactome
@@ -118,8 +120,8 @@ reactome_reaction:
     module: biocypher_metta.adapters.reactome_adapter
     cls: ReactomeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
-      pubmed_map_path: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactionPMIDS.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
+      pubmed_map_path: reactome/ReactionPMIDS.txt
       label: reaction
       taxon_id: 9606
   outdir: reactome
@@ -131,7 +133,7 @@ reactome_reaction_to_pathway:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: reaction_to_pathway
       taxon_id: 9606
   outdir: reactome
@@ -143,7 +145,7 @@ reactome_input_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: enables
       pathway_label: protein_enables_pathway
       reaction_label: protein_enables_reaction
@@ -157,7 +159,7 @@ reactome_output_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: produced_by
       pathway_label: protein_produced_by_pathway
       reaction_label: protein_produced_by_reaction
@@ -171,7 +173,7 @@ reactome_catalyst_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: regulates
       pathway_label: protein_regulates_pathway
       reaction_label: protein_regulates_reaction
@@ -185,7 +187,7 @@ reactome_negative_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: negatively_regulates
       pathway_label: protein_negatively_regulates_pathway
       reaction_label: protein_negatively_regulates_reaction
@@ -199,7 +201,7 @@ reactome_positive_role_protein_to_reaction_or_pathway:
     module: biocypher_metta.adapters.reactome_inference_edges_adapter
     cls: ReactomeInferenceEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome_reaction_exporter_All_species.txt
+      filepath: reactome/reactome_reaction_exporter_All_species.txt
       label: positively_regulates
       pathway_label: protein_positively_regulates_pathway
       reaction_label: protein_positively_regulates_reaction
@@ -213,7 +215,7 @@ genes_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: reactome/Ensembl2Reactome_All_Levels.txt
       label: genes_pathways
       taxon_id: 9606
   outdir: reactome
@@ -225,7 +227,7 @@ protein_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: reactome/Ensembl2Reactome_All_Levels.txt
       label: protein_pathways
       taxon_id: 9606
   outdir: reactome
@@ -237,7 +239,7 @@ transcript_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2Reactome_All_Levels.txt
+      filepath: reactome/Ensembl2Reactome_All_Levels.txt
       label: transcript_pathways
       taxon_id: 9606
   outdir: reactome
@@ -249,7 +251,7 @@ gene_or_gene_product_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
       label: gene_or_gene_product_reaction
       taxon_id: 9606
   outdir: reactome
@@ -261,7 +263,7 @@ protein_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
       label: protein_reaction
       taxon_id: 9606
   outdir: reactome
@@ -273,7 +275,7 @@ transcript_reaction:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Ensembl2ReactomeReactions.txt
+      filepath: reactome/Ensembl2ReactomeReactions.txt
       label: transcript_reaction
       taxon_id: 9606
   outdir: reactome
@@ -285,7 +287,7 @@ chebi_small_molecule_to_pathways:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ChEBI2Reactome_All_Levels.txt
+      filepath: reactome/ChEBI2Reactome_All_Levels.txt
       label: small_molecule_to_pathway
       taxon_id: 9606
   outdir: reactome
@@ -297,7 +299,7 @@ chebi_small_molecule_to_reactions:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ChEBI2ReactomeReactions.txt
+      filepath: reactome/ChEBI2ReactomeReactions.txt
       label: small_molecule_to_reaction
       taxon_id: 9606
   outdir: reactome
@@ -309,7 +311,7 @@ parent_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactomePathwaysRelation.txt
+      filepath: reactome/ReactomePathwaysRelation.txt
       label: parent_pathway_of
       taxon_id: 9606
   outdir: reactome
@@ -321,7 +323,7 @@ child_pathway_of:
     module: biocypher_metta.adapters.reactome_edges_adapter
     cls: ReactomeEdgesAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/ReactomePathwaysRelation.txt
+      filepath: reactome/ReactomePathwaysRelation.txt
       label: child_pathway_of
       taxon_id: 9606
   outdir: reactome
@@ -333,7 +335,7 @@ pathway_to_biological_process:
     module: biocypher_metta.adapters.reactome_pathway_go_adapter
     cls: ReactomePathwayGOAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Pathways2GoTerms_human.txt
+      filepath: reactome/Pathways2GoTerms_human.txt
       write_properties: true
       add_provenance: true
       label: pathway_to_biological_process
@@ -353,7 +355,7 @@ pathway_to_biological_process:
 #     module: biocypher_metta.adapters.reactome_pathway_go_adapter  
 #     cls: ReactomePathwayGOAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Pathways2GoTerms_human.txt
+#       filepath: reactome/Pathways2GoTerms_human.txt
 #       write_properties: true
 #       add_provenance: true
 #       subontology: molecular_function
@@ -368,7 +370,7 @@ pathway_to_biological_process:
 #     module: biocypher_metta.adapters.reactome_pathway_go_adapter
 #     cls: ReactomePathwayGOAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/Pathways2GoTerms_human.txt
+#       filepath: reactome/Pathways2GoTerms_human.txt
 #       write_properties: true
 #       add_provenance: true
 #       subontology: cellular_component  
@@ -473,7 +475,7 @@ gaf_biological_process_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: biological_process_gene_product
       taxon_id: 9606
   outdir: gaf
@@ -485,7 +487,7 @@ gaf_molecular_function_gene_product:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: molecular_function_gene_product
       taxon_id: 9606
   outdir: gaf
@@ -497,7 +499,7 @@ gaf_cellular_component_gene_product_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: cellular_component_gene_product_part_of
       taxon_id: 9606
   outdir: gaf
@@ -509,7 +511,7 @@ gaf_cellular_component_gene_product_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: cellular_component_gene_product_located_in
       taxon_id: 9606
   outdir: gaf
@@ -521,7 +523,7 @@ gaf_biological_process_gene:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: biological_process_gene
       taxon_id: 9606
   outdir: gaf
@@ -533,7 +535,7 @@ gaf_molecular_function_gene:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: molecular_function_gene
       taxon_id: 9606
   outdir: gaf
@@ -545,7 +547,7 @@ gaf_cellular_component_gene_part_of:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: cellular_component_gene_part_of
       taxon_id: 9606
   outdir: gaf
@@ -557,7 +559,7 @@ gaf_cellular_component_gene_located_in:
     module: biocypher_metta.adapters.gaf_adapter
     cls: GAFAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gaf/goa_human.gaf.gz
+      filepath: gaf/goa_human.gaf.gz
       label: cellular_component_gene_located_in
       taxon_id: 9606
   outdir: gaf
@@ -569,7 +571,7 @@ coexpression:
     module: biocypher_metta.adapters.coxpresdb_adapter
     cls: CoxpresdbAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/coxpressdb
+      filepath: coxpressdb
       label: coexpressed_with
       taxon_id: 9606
   outdir: coxpressdb
@@ -581,7 +583,7 @@ tflink:
     module: biocypher_metta.adapters.tflink_adapter
     cls: TFLinkAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tflink/tflink_homo_sapiens_interactions.tsv.gz
+      filepath: tflink/tflink_homo_sapiens_interactions.tsv.gz
       label: tf_gene
       taxon_id: 9606
   outdir: tflink
@@ -593,7 +595,7 @@ string:
     module: biocypher_metta.adapters.string_ppi_adapter
     cls: StringPPIAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/string/string_human_ppi_v12.0.txt.gz
+      filepath: string/string_human_ppi_v12.0.txt.gz
       label: interacts_with
       taxon_id: 9606
   outdir: string
@@ -605,7 +607,7 @@ reactome_ppi:
     module: biocypher_metta.adapters.reactome_ppi_adapter
     cls: ReactomePPIAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/reactome/reactome.homo_sapiens.interactions.tab-delimited.txt
+      filepath: reactome/reactome.homo_sapiens.interactions.tab-delimited.txt
       label: interacts_with
       taxon_id: 9606
   outdir: reactome/ppi
@@ -617,7 +619,7 @@ tadmap:
     module: biocypher_metta.adapters.tadmap_adapter
     cls: TADMapAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tadmap/TADMap_geneset_hs.csv
+      filepath: tadmap/TADMap_geneset_hs.csv
       label: tad
       taxon_id: 9606
   outdir: tadmap
@@ -629,7 +631,7 @@ tadmap_gene:
     module: biocypher_metta.adapters.tadmap_adapter
     cls: TADMapAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tadmap/TADMap_geneset_hs.csv
+      filepath: tadmap/TADMap_geneset_hs.csv
       label: in_tad_region
       taxon_id: 9606
   outdir: tadmap
@@ -641,7 +643,7 @@ gtex_eqtl:
     module: biocypher_metta.adapters.hsa.gtex_eqtl_adapter
     cls: GTExEQTLAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gtex/eqtl/gtex.forgedb.csv.gz
+      filepath: gtex/eqtl/gtex.forgedb.csv.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       label: gtex_variant_gene
   outdir: gtex/eqtl
@@ -653,7 +655,7 @@ gtex_expression:
     module: biocypher_metta.adapters.hsa.gtex_expression_adapter
     cls: GTExExpressionAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gtex/eqtl/gtex.forgedb.csv.gz
+      filepath: gtex/eqtl/gtex.forgedb.csv.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       label: expressed_in
       anatomy_label: gene_expressed_in_anatomy
@@ -667,8 +669,8 @@ hocomoco:
     module: biocypher_metta.adapters.hocomoco_motif_adapter
     cls: HoCoMoCoMotifAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/hocomoco/pwm
-      annotation_file: /mnt/hdd_1/biocypher-kg/input/hsa/hocomoco/HOCOMOCOv11_core_annotation_HUMAN_mono.tsv
+      filepath: hocomoco/pwm
+      annotation_file: hocomoco/HOCOMOCOv11_core_annotation_HUMAN_mono.tsv
       label: motif
       taxon_id: 9606
   outdir: hocomoco
@@ -680,7 +682,7 @@ roadmap_chromatin_state:
     module: biocypher_metta.adapters.hsa.roadmap_state_adapter
     cls: RoadMapChromatinStateAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/roadmap/chromatin_state
+      filepath: forgedb/roadmap/chromatin_state
       cell_to_ontology_id_map: ./aux_files/hsa/roadmap_ids_to_ontology.pkl
       tissue_to_ontology_id_map: ./aux_files/hsa/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
@@ -697,7 +699,7 @@ roadmap_h3_mark:
     module: biocypher_metta.adapters.hsa.roadmap_h3_marks_adapter
     cls: RoadMapH3MarkAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/roadmap/h3_marks
+      filepath: forgedb/roadmap/h3_marks
       cell_to_ontology_id_map: ./aux_files/hsa/roadmap_ids_to_ontology.pkl
       tissue_to_ontology_id_map: ./aux_files/hsa/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
@@ -714,7 +716,7 @@ roadmap_dhs:
     module: biocypher_metta.adapters.hsa.roadmap_dhs_adapter
     cls: RoadMapDHSAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/roadmap/dhs/forge2.erc2-DHS.forgedb.csv.gz
+      filepath: forgedb/roadmap/dhs/forge2.erc2-DHS.forgedb.csv.gz
       cell_to_ontology_id_map: ./aux_files/hsa/roadmap_ids_to_ontology.pkl
       tissue_to_ontology_id_map: ./aux_files/hsa/roadmap_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None
@@ -731,7 +733,7 @@ abc:
     module: biocypher_metta.adapters.hsa.abc_adapter
     cls: ABCAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/abc.forgedb.csv.gz
+      filepath: forgedb/abc.forgedb.csv.gz
       tissue_to_ontology_id_map: ./aux_files/hsa/abc_tissues_to_ontology_map.pkl
       dbsnp_rsid_map: None # will be provided by import script
       chr: chr16
@@ -745,7 +747,7 @@ cadd:
     module: biocypher_metta.adapters.hsa.cadd_adapter
     cls: CADDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/cadd.forgedb.csv.gz
+      filepath: forgedb/cadd.forgedb.csv.gz
       dbsnp_rsid_map: None # will be provided by import script
       chr: chr16
       label: snp
@@ -758,7 +760,7 @@ refseq_closest_gene:
     module: biocypher_metta.adapters.hsa.refseq_closest_gene_adapter
     cls: RefSeqClosestGeneAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/forgedb/closest_gene.forgedb.csv.gz
+      filepath: forgedb/closest_gene.forgedb.csv.gz
       dbsnp_rsid_map: None # will be provided by import script
       label: closest_gene
   outdir: refseq
@@ -771,7 +773,7 @@ topld_afr:
     module: biocypher_metta.adapters.hsa.topld_adapter
     cls: TopLDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/AFR/AFR_chr16_no_filter_0.2_1000000_LD.csv.gz
+      filepath: topld/AFR/AFR_chr16_no_filter_0.2_1000000_LD.csv.gz
       ancestry: AFR
       dbsnp_pos_map: None # will be provided by import script
       chr: chr16
@@ -787,7 +789,7 @@ topld_eas:
     module: biocypher_metta.adapters.hsa.topld_adapter
     cls: TopLDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/EAS/EAS_chr16_no_filter_0.2_1000000_LD.csv.gz
+      filepath: topld/EAS/EAS_chr16_no_filter_0.2_1000000_LD.csv.gz
       ancestry: EAS
       dbsnp_pos_map: None # will be provided by import script
       chr: chr16
@@ -803,7 +805,7 @@ topld_eur:
     module: biocypher_metta.adapters.hsa.topld_adapter
     cls: TopLDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/EUR/EUR_chr16_no_filter_0.2_1000000_LD.csv.gz
+      filepath: topld/EUR/EUR_chr16_no_filter_0.2_1000000_LD.csv.gz
       ancestry: EUR
       dbsnp_pos_map: None # will be provided by import script
       chr: chr16
@@ -819,7 +821,7 @@ topld_sas:
        module: biocypher_metta.adapters.hsa.topld_adapter
        cls: TopLDAdapter
        args:
-           filepath: /mnt/hdd_1/biocypher-kg/input/hsa/topld/SAS/SAS_chr16_no_filter_0.2_1000000_LD.csv.gz
+           filepath: topld/SAS/SAS_chr16_no_filter_0.2_1000000_LD.csv.gz
            ancestry: SAS
            dbsnp_pos_map: None # will be provided by import script
            chr: chr16
@@ -835,8 +837,8 @@ rna_central_non_coding_rna:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       label: non_coding_rna
       type: non_coding_rna
       taxon_id: 9606
@@ -849,8 +851,8 @@ rna_central_non_coding_rna_biological_process:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: biological process rna
       label: biological_process_rna
       taxon_id: 9606
@@ -863,8 +865,8 @@ rna_central_non_coding_rna_molecular_function:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: molecular function rna
       label: molecular_function_rna
       taxon_id: 9606
@@ -877,8 +879,8 @@ rna_central_non_coding_rna_cellular_component:
     module: biocypher_metta.adapters.rna_central_adapter
     cls: RNACentralAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
-      rfam_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/rnacentral_rfam_annotations.tsv.gz
+      filepath: rna_central/homo_sapiens.GRCh38.bed.gz
+      rfam_filepath: rna_central/rnacentral_rfam_annotations.tsv.gz
       type: cellular component rna
       label: cellular_component_rna
       taxon_id: 9606
@@ -891,7 +893,7 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #   outdir: dgv
 #   nodes: True
@@ -902,10 +904,10 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+#         - path: gencode/gencode.v49.annotation.gtf.gz  
 #           label: gene
 #           type: gtf
 #   outdir: dgv
@@ -917,10 +919,10 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
+#         - path: rna_central/homo_sapiens.GRCh38.bed.gz
 #           label: non_coding_rna
 #           type: bed
 #   outdir: dgv
@@ -932,10 +934,10 @@ rna_central_non_coding_rna_cellular_component:
 #     module: biocypher_metta.adapters.hsa.dgv_variant_adapter
 #     cls: DGVVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dgv/GRCh38_hg38_variants_2025-12-01.txt 
+#       filepath: dgv/GRCh38_hg38_variants_2025-12-01.txt 
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
+#         - path: epd/Hs_EPDnew.bed
 #           label: promoter
 #           type: bed
 #           delimiter: ' '
@@ -948,7 +950,7 @@ hpo_gene_phenotype:
     module: biocypher_metta.adapters.hsa.hpo_gene_phenotype_adapter
     cls: HPOAdapter  
     args:  
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/hpo/genes_to_phenotype.txt
+      filepath: hpo/genes_to_phenotype.txt
       # entrez_to_ensembl_map: None #./aux_files/hsa/entrez_ensembl/entrez_ensembl_mapping.pkl
   outdir: human_phenotype_ontology
   nodes: False  
@@ -959,7 +961,7 @@ hpo_gene_disease:
     module: biocypher_metta.adapters.hsa.hpo_gene_disease_adapter
     cls: HPOGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/hpo/genes_to_disease.txt
+      filepath: hpo/genes_to_disease.txt
       # entrez_to_ensembl_map: None #./aux_files/hsa/entrez_ensembl/entrez_ensembl_mapping.pkl
   outdir: human_phenotype_ontology
   nodes: False
@@ -970,7 +972,7 @@ epd_promoter:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
+      filepath: epd/Hs_EPDnew.bed
       label: promoter
       taxon_id: 9606
   outdir: epd
@@ -982,7 +984,7 @@ epd_promoter_regulates_gene:
     module: biocypher_metta.adapters.epd_adapter
     cls: EPDAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
+      filepath: epd/Hs_EPDnew.bed
       type: promoter to gene association
       label: promoter_gene
       taxon_id: 9606
@@ -995,7 +997,7 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
+#       filepath: dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #   outdir: dbvar
 #   nodes: True
@@ -1006,10 +1008,10 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
+#       filepath: dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/gencode/gencode.v49.annotation.gtf.gz  
+#         - path: gencode/gencode.v49.annotation.gtf.gz  
 #           label: gene
 #           type: gtf
 #   outdir: dbvar
@@ -1021,10 +1023,10 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
+#       filepath: dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/rna_central/homo_sapiens.GRCh38.bed.gz
+#         - path: rna_central/homo_sapiens.GRCh38.bed.gz
 #           label: non_coding_rna
 #           type: bed
 #   outdir: dbvar
@@ -1036,10 +1038,10 @@ epd_promoter_regulates_gene:
 #     module: biocypher_metta.adapters.hsa.dbvar_adapter
 #     cls: DBVarVariantAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbvar/GRCh38.variant_call.all.vcf.gz
+#       filepath: dbvar/GRCh38.variant_call.all.vcf.gz
 #       label: structural_variant
 #       feature_files:
-#         - path: /mnt/hdd_1/biocypher-kg/input/hsa/epd/Hs_EPDnew.bed
+#         - path: epd/Hs_EPDnew.bed
 #           label: promoter
 #           type: bed
 #           delimiter: ' '
@@ -1052,9 +1054,9 @@ peregrine_enhancer:
     module: biocypher_metta.adapters.hsa.peregrine_adapter
     cls: PEREGRINEAdapter
     args:
-      enhancers_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancershg38.gz
-      enhancer_gene_link: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/enhancer_gene_link_18.tsv.gz
-      source_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancersources.gz
+      enhancers_file: peregrine/PEREGRINEenhancershg38.gz
+      enhancer_gene_link: peregrine/enhancer_gene_link_18.tsv.gz
+      source_file: peregrine/PEREGRINEenhancersources.gz
       tissue_ontology_map: ./aux_files/hsa/peregrine_tissues_to_ontology_map.pkl
       label: enhancer
   outdir: peregrine
@@ -1066,9 +1068,9 @@ peregrine_enhancer_regulates:
     module: biocypher_metta.adapters.hsa.peregrine_adapter
     cls: PEREGRINEAdapter
     args:
-      enhancers_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancershg38.gz
-      enhancer_gene_link: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/enhancer_gene_link_18.tsv.gz
-      source_file: /mnt/hdd_1/biocypher-kg/input/hsa/peregrine/PEREGRINEenhancersources.gz
+      enhancers_file: peregrine/PEREGRINEenhancershg38.gz
+      enhancer_gene_link: peregrine/enhancer_gene_link_18.tsv.gz
+      source_file: peregrine/PEREGRINEenhancersources.gz
       tissue_ontology_map: ./aux_files/hsa/peregrine_tissues_to_ontology_map.pkl
       type: enhancer to gene association
       label: enhancer_gene
@@ -1081,7 +1083,7 @@ dbsuper_super_enhancer:
     module: biocypher_metta.adapters.hsa.dbsuper_adapter
     cls: DBSuperAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
+      filepath: dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
       dbsuper_tissues_map: ./aux_files/hsa/dbsuper_tissues_map.pkl
       label: super_enhancer      
   outdir: dbsuper
@@ -1093,7 +1095,7 @@ dbsuper_super_enhancer_regulates_gene:
     module: biocypher_metta.adapters.hsa.dbsuper_adapter
     cls: DBSuperAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
+      filepath: dbsuper/dbSUPER_SuperEnhancers_hg19.tsv.gz
       dbsuper_tissues_map: ./aux_files/hsa/dbsuper_tissues_map.pkl
       type: super enhancer to gene association
       label: super_enhancer_gene
@@ -1106,7 +1108,7 @@ dbsnp_snps:
     module: biocypher_metta.adapters.hsa.dbsnp_adapter
     cls: DBSNPAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/dbsnp/00-common_all.vcf.gz
+      filepath: dbsnp/00-common_all.vcf.gz
       label: snp
   outdir: dbsnp
   nodes: True
@@ -1117,8 +1119,8 @@ enhancer_atlas_enhancer:
     module: biocypher_metta.adapters.enhancer_atlas_adapter
     cls: EnhancerAtlasAdapter
     args:
-      enhancer_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/enhancer_atlas/hs.bed
-      enhancer_gene_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/enhancer_atlas/enhancer_gene
+      enhancer_filepath: enhancer_atlas/hs.bed
+      enhancer_gene_filepath: enhancer_atlas/enhancer_gene
       tissue_to_ontology_filepath: ./aux_files/hsa/enhancer_atlas_tissues_to_ontology.pkl
       label: enhancer
       taxon_id: 9606  
@@ -1131,8 +1133,8 @@ enhancer_atlas_enhancer_regulates:
     module: biocypher_metta.adapters.enhancer_atlas_adapter
     cls: EnhancerAtlasAdapter
     args:
-      enhancer_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/enhancer_atlas/hs.bed
-      enhancer_gene_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/enhancer_atlas/enhancer_gene
+      enhancer_filepath: enhancer_atlas/hs.bed
+      enhancer_gene_filepath: enhancer_atlas/enhancer_gene
       tissue_to_ontology_filepath: ./aux_files/hsa/enhancer_atlas_tissues_to_ontology.pkl
       type: enhancer to gene association
       label: enhancer_gene
@@ -1286,7 +1288,7 @@ motif_diff_tf_snp:
     module: biocypher_metta.adapters.hsa.motif_diff_adapter
     cls: MotifDiffAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/motif_diff/_mono_probNorm_average.diff
+      filepath: motif_diff/_mono_probNorm_average.diff
       label: tf_snp
   outdir: MotifDiff
   nodes: False
@@ -1423,7 +1425,7 @@ chebi_chebi_subclass_of:
 #     module: biocypher_metta.adapters.hsa.polyphen2_adapter
 #     cls: PolyPhen2Adapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/polyphen2/dbNsfpPolyPhen2.bed.gz
+#       filepath: polyphen2/dbNsfpPolyPhen2.bed.gz
 #       label: polyphen2_variant
 #   outdir: polyphen-2
 #   nodes: True
@@ -1434,7 +1436,7 @@ bgee_gene_expressed_in_anatomical_entity:
     module: biocypher_metta.adapters.bgee_adapter
     cls: BgeeAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/bgee/Homo_sapiens_expr_simple_all_conditions.tsv.gz
+      filepath: bgee/Homo_sapiens_expr_simple_all_conditions.tsv.gz
       label: expressed_in
       anatomy_label: gene_expressed_in_anatomy
       developmental_stage_label: gene_expressed_in_developmental_stage
@@ -1448,7 +1450,7 @@ transcription_factor_binding_site:
     module: biocypher_metta.adapters.tfbs_adapter
     cls: TfbsAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tfbs/EncRegTfbsClustered.csv.gz
+      filepath: tfbs/EncRegTfbsClustered.csv.gz
       label: tfbs
       taxon_id: 9606        
   outdir: tfbs
@@ -1460,7 +1462,7 @@ gene_tfbs_association:
     module: biocypher_metta.adapters.tfbs_adapter
     cls: TfbsAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/tfbs/EncRegTfbsClustered.csv.gz
+      filepath: tfbs/EncRegTfbsClustered.csv.gz
       label: gene_tfbs
       taxon_id: 9606        
   outdir: tfbs
@@ -1472,7 +1474,7 @@ snp_to_upstream_gene:
     module: biocypher_metta.adapters.hsa.gwas_adapter
     cls: GWASAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gwas/gwas-catalog-associations_ontology-annotated.tsv
+      filepath: gwas/gwas-catalog-associations_ontology-annotated.tsv
       label: snp_upstream_gene
   outdir: gwas/upstream
   nodes: False
@@ -1483,7 +1485,7 @@ snp_to_downstream_gene:
     module: biocypher_metta.adapters.hsa.gwas_adapter
     cls: GWASAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gwas/gwas-catalog-associations_ontology-annotated.tsv
+      filepath: gwas/gwas-catalog-associations_ontology-annotated.tsv
       label: snp_downstream_gene
   outdir: gwas/downstream
   nodes: False
@@ -1494,7 +1496,7 @@ snp_to_in_gene:
     module: biocypher_metta.adapters.hsa.gwas_adapter
     cls: GWASAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/gwas/gwas-catalog-associations_ontology-annotated.tsv
+      filepath: gwas/gwas-catalog-associations_ontology-annotated.tsv
       label: snp_in_gene
   outdir: gwas/ingene
   nodes: False
@@ -1505,7 +1507,7 @@ proximal_enhancer_ccre:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer
       element_filter: proximal
       taxon_id: 9606        
@@ -1518,7 +1520,7 @@ proximal_enhancer_ccre_associates_with_gene:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-All.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-All.tsv.gz
       label: enhancer_gene
       element_filter: proximal
       taxon_id: 9606        
@@ -1531,7 +1533,7 @@ proximal_enhancer_ccre_associates_with_gene_coding_only:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer_gene
       element_filter: proximal
       taxon_id: 9606        
@@ -1544,7 +1546,7 @@ distal_enhancer_ccre:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer
       element_filter: distal
       taxon_id: 9606        
@@ -1557,7 +1559,7 @@ distal_enhancer_ccre_associates_with_gene:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-All.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-All.tsv.gz
       label: enhancer_gene
       element_filter: distal
       taxon_id: 9606        
@@ -1570,7 +1572,7 @@ distal_enhancer_ccre_associates_with_gene_coding_only:
     module: biocypher_metta.adapters.candidate_cis_regulatory_enhancer_adapter
     cls: EnhancercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: enhancer_gene
       element_filter: distal
       taxon_id: 9606        
@@ -1583,9 +1585,9 @@ promoter_ccre:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       edge_type: eqtl
-      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       label: promoter
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606
@@ -1598,10 +1600,10 @@ promoter_ccre_associates_with_gene_nearest_gene:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-All.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-All.tsv.gz
       edge_type: nearest
       label: promoter_gene
-      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606        
   outdir: ccre/promoter_ccre
@@ -1613,10 +1615,10 @@ promoter_ccre_associates_with_gene_nearest_gene_coding_only:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: promoter_gene
       edge_type: nearest
-      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606        
   outdir: ccre/promoter_ccre/coding_only
@@ -1628,10 +1630,10 @@ promoter_ccre_associates_with_gene_eqtl:
     module: biocypher_metta.adapters.candidate_cis_regulatory_promoter_adapter
     cls: PromotercCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/GRCh38-Closest-Genes-PC.tsv.gz
+      filepath: cCRE/GRCh38-Closest-Genes-PC.tsv.gz
       label: promoter_gene
       edge_type: eqtl
-      eqtl_filepath: /mnt/hdd_1/biocypher-kg/input/hsa/cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
+      eqtl_filepath: cCRE/V4-hg38.Gene-Links.eQTLs.txt.gz
       gtex_tissue_ontology_map: ./aux_files/hsa/gtex_tissues_to_ontology_map.pkl
       taxon_id: 9606        
   outdir: ccre/promoter_ccre/eqtl
@@ -1643,7 +1645,7 @@ catlas_ccre_promoter:
     module: biocypher_metta.adapters.hsa.catlas_ccre_adapter
     cls: CAtlasCCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCRE_hg38.tsv.gz
+      filepath: catlasv1/cCRE_hg38.tsv.gz
       class_filter: promoter
       taxon_id: 9606
       input_coordinate_system: bed
@@ -1656,7 +1658,7 @@ catlas_ccre_enhancer:
     module: biocypher_metta.adapters.hsa.catlas_ccre_adapter
     cls: CAtlasCCREAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCRE_hg38.tsv.gz
+      filepath: catlasv1/cCRE_hg38.tsv.gz
       class_filter: enhancer
       taxon_id: 9606
       input_coordinate_system: bed
@@ -1669,12 +1671,12 @@ catlas_enhancer_accessible_in:
     module: biocypher_metta.adapters.hsa.catlas_ccre_cell_type_adapter
     cls: CAtlasCCRECellTypeAdapter
     args:
-      cres_dirpath: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCREs
+      cres_dirpath: catlasv1/cCREs
       ccre_label_pkl: ./aux_files/hsa/catlas/catlas_ccre_label_map.pkl
       cell_ontology_pkl: ./aux_files/hsa/catlas/catlas_cell_ontology_map.pkl
-      cell_ontology_tsv: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/Cell_ontology.tsv
+      cell_ontology_tsv: catlasv1/Cell_ontology.tsv
       ccre_type: enhancer
-      ccre_master_tsv: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCRE_hg38.tsv.gz
+      ccre_master_tsv: catlasv1/cCRE_hg38.tsv.gz
   optional_paths:
     - ccre_label_pkl      # generated from ccre_master_tsv on first run
     - cell_ontology_pkl   # generated from cell_ontology_tsv on first run
@@ -1688,12 +1690,12 @@ catlas_promoter_accessible_in:
     module: biocypher_metta.adapters.hsa.catlas_ccre_cell_type_adapter
     cls: CAtlasCCRECellTypeAdapter
     args:
-      cres_dirpath: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCREs
+      cres_dirpath: catlasv1/cCREs
       ccre_label_pkl: ./aux_files/hsa/catlas/catlas_ccre_label_map.pkl
       cell_ontology_pkl: ./aux_files/hsa/catlas/catlas_cell_ontology_map.pkl
-      cell_ontology_tsv: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/Cell_ontology.tsv
+      cell_ontology_tsv: catlasv1/Cell_ontology.tsv
       ccre_type: promoter
-      ccre_master_tsv: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCRE_hg38.tsv.gz
+      ccre_master_tsv: catlasv1/cCRE_hg38.tsv.gz
   optional_paths:
     - ccre_label_pkl      # generated from ccre_master_tsv on first run
     - cell_ontology_pkl   # generated from cell_ontology_tsv on first run
@@ -1707,8 +1709,8 @@ catlas_abc_enhancer_to_gene:
     module: biocypher_metta.adapters.hsa.catlas_abc_score_adapter
     cls: CAtlasABCScoreAdapter
     args:
-      dirpath: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/ABC_scores
-      ccre_master_tsv: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCRE_hg38.tsv.gz
+      dirpath: catlasv1/ABC_scores
+      ccre_master_tsv: catlasv1/cCRE_hg38.tsv.gz
       hgnc_mapping_pkl: ./aux_files/hsa/hgnc/hgnc_mapping.pkl
       ccre_label_pkl: ./aux_files/hsa/catlas/catlas_ccre_label_map.pkl
       cell_ontology_pkl: ./aux_files/hsa/catlas/catlas_abc_cell_ontology_map.pkl
@@ -1728,8 +1730,8 @@ catlas_abc_promoter_to_gene:
     module: biocypher_metta.adapters.hsa.catlas_abc_score_adapter
     cls: CAtlasABCScoreAdapter
     args:
-      dirpath: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/ABC_scores
-      ccre_master_tsv: /mnt/hdd_1/biocypher-kg/input/hsa/catlasv1/cCRE_hg38.tsv.gz
+      dirpath: catlasv1/ABC_scores
+      ccre_master_tsv: catlasv1/cCRE_hg38.tsv.gz
       hgnc_mapping_pkl: ./aux_files/hsa/hgnc/hgnc_mapping.pkl
       ccre_label_pkl: ./aux_files/hsa/catlas/catlas_ccre_label_map.pkl
       cell_ontology_pkl: ./aux_files/hsa/catlas/catlas_abc_cell_ontology_map.pkl
@@ -1750,7 +1752,7 @@ catlas_abc_promoter_to_gene:
 #     module: biocypher_metta.adapters.encode_re2g_adapter
 #     cls: ENCODERe2GAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/encode_re2g/ENCODE_rE2G_K562.bed.gz
+#       filepath: encode_re2g/ENCODE_rE2G_K562.bed.gz
 #       label: enhancer
 #       taxon_id: 9606
 #   outdir: encode_re2g
@@ -1762,7 +1764,7 @@ catlas_abc_promoter_to_gene:
 #     module: biocypher_metta.adapters.encode_re2g_adapter
 #     cls: ENCODERe2GAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/encode_re2g/ENCODE_rE2G_K562.bed.gz
+#       filepath: encode_re2g/ENCODE_rE2G_K562.bed.gz
 #       label: enhancer_activity_by_contact
 #       taxon_id: 9606
 #       cell_ontology_id: "CLO:0007059"  # K562
@@ -1775,7 +1777,7 @@ uniprot_dbxref_bgee_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_gene
       dbxref: BGEE
       taxon_id: 9606
@@ -1788,7 +1790,7 @@ uniprot_dbxref_ensembl_gene:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_gene
       dbxref: ENSEMBL
       taxon_id: 9606
@@ -1801,7 +1803,7 @@ uniprot_dbxref_ensembl_transcript:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_transcript
       dbxref: ENSEMBL
       taxon_id: 9606
@@ -1814,7 +1816,7 @@ uniprot_dbxref_ensembl_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_protein
       dbxref: ENSEMBL
       taxon_id: 9606
@@ -1827,7 +1829,7 @@ uniprot_dbxref_string_protein:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_protein
       dbxref: STRING
       taxon_id: 9606
@@ -1840,7 +1842,7 @@ uniprot_dbxref_biological_process:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_biological_process
       dbxref: GO
       taxon_id: 9606
@@ -1853,7 +1855,7 @@ uniprot_dbxref_cellular_component:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_cellular_component
       dbxref: GO
       taxon_id: 9606
@@ -1866,7 +1868,7 @@ uniprot_dbxref_molecular_function:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_molecular_function
       dbxref: GO
       taxon_id: 9606
@@ -1879,7 +1881,7 @@ uniprot_has_xref_catalytic_activity:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_catalytic_activity
       taxon_id: 9606
       dbxref: CHEBI
@@ -1892,7 +1894,7 @@ uniprot_has_xref_cofactor:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_cofactor
       taxon_id: 9606
       dbxref: CHEBI
@@ -1905,7 +1907,7 @@ uniprot_has_xref_binding_site_ligand:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: protein_has_xref_binding_site_ligand
       taxon_id: 9606
       dbxref: CHEBI
@@ -1918,7 +1920,7 @@ uniprot_chebi_part_of_chebi:
     module: biocypher_metta.adapters.uniprot_protein_adapter
     cls: UniprotProteinAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/uniprot/uniprot_sprot_human.dat.gz
+      filepath: uniprot/uniprot_sprot_human.dat.gz
       label: chemical_substance_part_of_chemical_substance
       taxon_id: 9606
       dbxref: CHEBI
@@ -1959,7 +1961,7 @@ alliance_gene_disease_biomarker_orthology:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: biomarker_via_orthology
   outdir: disease
@@ -1971,7 +1973,7 @@ alliance_gene_disease_implicated_via_orthology:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: implicated_via_orthology
   outdir: disease
@@ -1983,7 +1985,7 @@ alliance_gene_disease_is_implicated_in:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: is_implicated_in
   outdir: disease
@@ -1999,7 +2001,7 @@ alliance_gene_disease_is_implicated_in:
 #     module: biocypher_metta.adapters.alliance_gene_disease_adapter
 #     cls: AllianceGeneDiseaseAdapter
 #     args:
-#       filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+#       filepath: agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
 #       taxon_id: 9606
 #       label: is_model_of
 #   outdir: disease
@@ -2011,7 +2013,7 @@ alliance_gene_disease_is_marker_for:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter
     cls: AllianceGeneDiseaseAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
+      filepath: agr/DISEASE-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: is_marker_for
   outdir: disease
@@ -2036,7 +2038,7 @@ alliance_gene_orthology:
     module: biocypher_metta.adapters.alliance_gene_orthology_adapter
     cls: AllianceGeneOrthologyAdapter
     args:
-      filepath: /mnt/hdd_1/biocypher-kg/input/hsa/agr/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
+      filepath: agr/ORTHOLOGY-ALLIANCE_COMBINED.tsv.gz
       taxon_id: 9606
       label: orthologs_genes
   outdir: alliance/orthology

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -308,6 +308,10 @@ def _resolve_input_paths(adapters_dict: dict, input_dir: Path) -> None:
 
 def _has_bare_paths(adapters_dict: dict) -> bool:
     """Return True if any path-holding adapter arg has a bare (un-prefixed) value."""
+    def _is_bare(s: str) -> bool:
+        v = s.strip()
+        return bool(v) and not v.startswith("/") and not v.startswith("./") and not v.startswith("../")
+
     for adapter_entry in adapters_dict.values():
         if not isinstance(adapter_entry, dict):
             continue
@@ -316,8 +320,16 @@ def _has_bare_paths(adapters_dict: dict) -> bool:
             if not _is_path_arg(key):
                 continue
             if isinstance(value, str):
-                v = value.strip()
-                if v and not v.startswith("/") and not v.startswith("./") and not v.startswith("../"):
+                if _is_bare(value):
+                    return True
+            elif key == "feature_files" and isinstance(value, list):
+                if any(
+                    isinstance(item, dict) and isinstance(item.get("path"), str) and _is_bare(item["path"])
+                    for item in value
+                ):
+                    return True
+            elif isinstance(value, list):
+                if any(isinstance(v, str) and _is_bare(v) for v in value):
                     return True
     return False
 
@@ -917,6 +929,13 @@ def main(
         )
         logger.error(
             "  2. Provide all manual parameters (--output-dir, --adapters-config, --schema-config)"
+        )
+        raise typer.Exit(1)
+
+    if species == "all" and input_dir:
+        logger.error(
+            "--input-dir cannot be used with --species all: each species requires its own "
+            "input directory. Use the input_dir: field in each species-specific adapter config instead."
         )
         raise typer.Exit(1)
 

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -266,14 +266,22 @@ def _add_file_logger(output_dir: Path) -> logging.FileHandler:
     return handler
 
 
+# Suffixes and exact names that identify path-holding adapter args.
+# Only these are resolved against input_dir; all other string args are left untouched.
+_PATH_ARG_SUFFIXES = ("filepath", "dirpath", "_file", "_path", "_tsv", "_pkl")
+_PATH_ARG_NAMES = {"filepaths", "data_filepaths", "aux_filepaths", "feature_files"}
+
+
+def _is_path_arg(name: str) -> bool:
+    return name in _PATH_ARG_NAMES or any(name.endswith(s) for s in _PATH_ARG_SUFFIXES)
+
+
 def _maybe_prepend(value: str, input_dir: Path) -> str:
     """Prepend input_dir to a bare path string (no leading /, ./, ../)."""
     v = value.strip()
-    if v.startswith("/") or v.startswith("./") or v.startswith("../"):
+    if not v or v.startswith("/") or v.startswith("./") or v.startswith("../"):
         return v
-    if "/" in v or ("." in v.split("/")[-1]):
-        return str(input_dir / v)
-    return v
+    return str(input_dir / v)
 
 
 def _resolve_input_paths(adapters_dict: dict, input_dir: Path) -> None:
@@ -283,6 +291,8 @@ def _resolve_input_paths(adapters_dict: dict, input_dir: Path) -> None:
             continue
         args = (adapter_entry.get("adapter") or {}).get("args") or {}
         for key, value in list(args.items()):
+            if not _is_path_arg(key):
+                continue
             if key == "feature_files" and isinstance(value, list):
                 for item in value:
                     if isinstance(item, dict) and isinstance(item.get("path"), str):
@@ -297,17 +307,18 @@ def _resolve_input_paths(adapters_dict: dict, input_dir: Path) -> None:
 
 
 def _has_bare_paths(adapters_dict: dict) -> bool:
-    """Return True if any adapter arg looks like a bare relative path (no / ./ ../ prefix)."""
+    """Return True if any path-holding adapter arg has a bare (un-prefixed) value."""
     for adapter_entry in adapters_dict.values():
         if not isinstance(adapter_entry, dict):
             continue
         args = (adapter_entry.get("adapter") or {}).get("args") or {}
-        for value in args.values():
+        for key, value in args.items():
+            if not _is_path_arg(key):
+                continue
             if isinstance(value, str):
                 v = value.strip()
                 if v and not v.startswith("/") and not v.startswith("./") and not v.startswith("../"):
-                    if "/" in v or ("." in v.split("/")[-1]):
-                        return True
+                    return True
     return False
 
 

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -266,14 +266,71 @@ def _add_file_logger(output_dir: Path) -> logging.FileHandler:
     return handler
 
 
-def _load_adapters_config(config_path: Path, context: str) -> dict:
+def _maybe_prepend(value: str, input_dir: Path) -> str:
+    """Prepend input_dir to a bare path string (no leading /, ./, ../)."""
+    v = value.strip()
+    if v.startswith("/") or v.startswith("./") or v.startswith("../"):
+        return v
+    if "/" in v or ("." in v.split("/")[-1]):
+        return str(input_dir / v)
+    return v
+
+
+def _resolve_input_paths(adapters_dict: dict, input_dir: Path) -> None:
+    """Prepend input_dir to every bare relative path string in adapter args."""
+    for adapter_entry in adapters_dict.values():
+        if not isinstance(adapter_entry, dict):
+            continue
+        args = (adapter_entry.get("adapter") or {}).get("args") or {}
+        for key, value in list(args.items()):
+            if key == "feature_files" and isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict) and isinstance(item.get("path"), str):
+                        item["path"] = _maybe_prepend(item["path"], input_dir)
+            elif isinstance(value, list):
+                args[key] = [
+                    _maybe_prepend(v, input_dir) if isinstance(v, str) else v
+                    for v in value
+                ]
+            elif isinstance(value, str):
+                args[key] = _maybe_prepend(value, input_dir)
+
+
+def _has_bare_paths(adapters_dict: dict) -> bool:
+    """Return True if any adapter arg looks like a bare relative path (no / ./ ../ prefix)."""
+    for adapter_entry in adapters_dict.values():
+        if not isinstance(adapter_entry, dict):
+            continue
+        args = (adapter_entry.get("adapter") or {}).get("args") or {}
+        for value in args.values():
+            if isinstance(value, str):
+                v = value.strip()
+                if v and not v.startswith("/") and not v.startswith("./") and not v.startswith("../"):
+                    if "/" in v or ("." in v.split("/")[-1]):
+                        return True
+    return False
+
+
+def _load_adapters_config(
+    config_path: Path, context: str, input_dir: Optional[Path] = None
+) -> dict:
     with open(config_path, "r") as fp:
         try:
-            return load_yaml_with_includes(fp)
+            adapters_dict = load_yaml_with_includes(fp)
         except yaml.YAMLError as exc:
             logger.error(f"Error loading adapter config for {context}")
             logger.error(exc)
             raise typer.Exit(1)
+    yaml_input_dir = adapters_dict.pop("input_dir", None)
+    resolved = input_dir or (Path(yaml_input_dir) if yaml_input_dir else None)
+    if resolved is not None:
+        _resolve_input_paths(adapters_dict, resolved)
+    elif _has_bare_paths(adapters_dict):
+        logger.warning(
+            "Adapter config contains bare (un-prefixed) paths but no input_dir was set. "
+            "Pass --input-dir or add 'input_dir:' to the config."
+        )
+    return adapters_dict
 
 
 def _strip_taxon_id(items, is_edge: bool):
@@ -310,6 +367,15 @@ def _check_adapter_file_paths(adapters_dict: dict) -> dict:
                         path = item.get("path")
                         if isinstance(path, str) and not Path(path).exists():
                             adapter_missing[f"feature_files[{i}].path"] = path
+                continue
+            if isinstance(value, list):
+                for i, item in enumerate(value):
+                    if not isinstance(item, str):
+                        continue
+                    if not (item.startswith("/") or item.startswith("./") or item.startswith("../")):
+                        continue
+                    if not Path(item).exists():
+                        adapter_missing[f"{arg_name}[{i}]"] = item
                 continue
             if not isinstance(value, str):
                 continue
@@ -799,6 +865,14 @@ def main(
             "Only --adapters-config is required in this mode."
         ),
     ),
+    input_dir: Optional[Path] = typer.Option(
+        None,
+        "--input-dir",
+        help=(
+            "Base directory for resolving bare (relative) input paths in the adapters config. "
+            "Overrides the input_dir field declared in the config YAML."
+        ),
+    ),
 ):
     """
     Main function. Call individual adapters to download and process data. Build
@@ -808,7 +882,7 @@ def main(
         if adapters_config is None:
             logger.error("--adapters-config is required with --check-only")
             raise typer.Exit(1)
-        adapters_dict = _load_adapters_config(adapters_config, str(adapters_config))
+        adapters_dict = _load_adapters_config(adapters_config, str(adapters_config), input_dir=input_dir)
         if include_adapters:
             include_lower = [a.lower() for a in include_adapters]
             adapters_dict = {k: v for k, v in adapters_dict.items() if k.lower() in include_lower}
@@ -896,7 +970,7 @@ def main(
                         bc.overwrite = overwrite
 
                     schema_dict = preprocess_schema(sp_schema_config)
-                    sp_adapters_dict = _load_adapters_config(sp_adapters_config, sp)
+                    sp_adapters_dict = _load_adapters_config(sp_adapters_config, sp, input_dir=input_dir)
 
                     if include_adapters:
                         original_count = len(sp_adapters_dict)
@@ -1081,7 +1155,7 @@ def main(
             bc.overwrite = overwrite
 
         schema_dict = preprocess_schema(schema_config)
-        adapters_dict = _load_adapters_config(adapters_config, str(adapters_config))
+        adapters_dict = _load_adapters_config(adapters_config, str(adapters_config), input_dir=input_dir)
 
         if include_adapters:
             original_count = len(adapters_dict)

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -269,7 +269,7 @@ def _add_file_logger(output_dir: Path) -> logging.FileHandler:
 # Suffixes and exact names that identify path-holding adapter args.
 # Only these are resolved against input_dir; all other string args are left untouched.
 _PATH_ARG_SUFFIXES = ("filepath", "dirpath", "_file", "_path", "_tsv", "_pkl")
-_PATH_ARG_NAMES = {"filepaths", "data_filepaths", "aux_filepaths", "feature_files"}
+_PATH_ARG_NAMES = {"filepaths", "data_filepaths", "aux_filepaths", "feature_files", "enhancer_gene_link"}
 
 
 def _is_path_arg(name: str) -> bool:


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [ ] New processor / Processor fix
- [ ] Schema change
- [x] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [x] Refactor
- [x] Makefile
- [ ] Bug fix 

---

## Summary

- Add `input_dir:` top-level field to all three full adapter configs (`hsa_adapters_config.yaml`, `dmel_adapters_config.yaml`, `net_act_adapters_config.yaml`). All ~370 hardcoded absolute `/mnt/hdd_1/biocypher-kg/input/{species}/` prefixes are stripped; paths become bare relative strings resolved at load time against `input_dir`.
- Add `--input-dir` CLI option to `create_knowledge_graph.py` that overrides the YAML-declared `input_dir` value — allows running on any machine without editing config files.
- Extend `_check_adapter_file_paths` to also validate plain string-list args (`filepaths`, `data_filepaths`, `aux_filepaths`) which were previously skipped.
- Add `INPUT_DIR ?=` to the Makefile with pass-through in `run-direct`, `run-interactive`, and `check-paths`.
- Update README with `INPUT_DIR` examples and a new section explaining the `input_dir` mechanism.

## Behaviour

- Paths starting with `/`, `./`, or `../` are always used as-is (absolute paths and repo-relative `./aux_files/`, `./samples/` paths are never touched).
- Bare paths (e.g. `gencode/file.gtf.gz`) are prepended with `input_dir` at YAML load time, before pre-flight validation and adapter instantiation.
- Priority: `--input-dir` CLI > `input_dir:` in YAML > bare paths kept as-is with a warning.
- Default behaviour is fully preserved — the `input_dir:` values in the YAML point to the canonical `/mnt/hdd_1/biocypher-kg/input/{species}` paths, so existing workflows need no changes.

## Test plan

- [x] `make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config.yaml` → 137 adapters pass
- [x] `make check-paths ADAPTERS_CONFIG=./config/dmel/dmel_adapters_config.yaml` → 98 adapters pass
- [x] `make check-paths ADAPTERS_CONFIG=./config/dmel/net_act_adapters_config.yaml` → 75 adapters pass
- [x] `make check-paths ADAPTERS_CONFIG=./config/hsa/hsa_adapters_config_sample.yaml` → 144 adapters pass (unaffected)
- [x] `uv run python create_knowledge_graph.py --adapters-config ./config/hsa/hsa_adapters_config.yaml --input-dir /mnt/hdd_1/biocypher-kg/input/hsa --check-only` → passes
- [x] Sample run with a single adapter completes successfully