### PR TITLE
Enhance datasource schema generation and integrate it into KG builds

### DIFF
--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -26,6 +26,7 @@ from biocypher_metta.processors import DBSNPProcessor
 from biocypher_metta.prolog_writer import PrologWriter
 from checkpoint_manager import CheckpointManager, prompt_resume_or_restart
 from config.yaml_loader import load_yaml_with_includes
+from schema_generator.generate_data_source_schemas import SchemaGenerator
 
 
 app = typer.Typer()
@@ -333,6 +334,33 @@ def _report_missing_paths(missing: dict, include_hint: bool = True) -> None:
     if include_hint:
         logger.error("")
         logger.error("Fix the paths above or run with --skip-preflight to bypass this check.")
+
+
+def _default_data_source_schema_output_dir(
+    species_name: Optional[str],
+    kg_output_dir: Path,
+) -> Path:
+    if species_name:
+        return Path("data_source_schemas") / species_name
+    return kg_output_dir / "data_source_schemas"
+
+
+def _generate_data_source_schemas(
+    schema_config_path: Path,
+    adapters_config_path: Path,
+    adapters_dict: dict,
+    output_dir: Path,
+):
+    """Generate data source schemas for the same adapter set used by the KG run."""
+    logger.info(f"Generating data source schemas in {output_dir}")
+    generator = SchemaGenerator(
+        str(schema_config_path),
+        str(adapters_config_path),
+        "biocypher_metta/adapters",
+        str(output_dir),
+        adapter_config_data=adapters_dict,
+    )
+    generator.generate_all_schemas(filter_adapters=list(adapters_dict.keys()))
 
 
 def process_adapters(
@@ -772,6 +800,21 @@ def main(
         help="Specific adapters to include (space-separated, default: all)",
         case_sensitive=False,
     ),
+    generate_data_source_schemas: bool = typer.Option(
+        True,
+        "--generate-data-source-schemas/--no-generate-data-source-schemas",
+        help="Generate data source schema YAML files for the adapters used in this KG run.",
+    ),
+    data_source_schema_output_dir: Optional[Path] = typer.Option(
+        None,
+        file_okay=False,
+        dir_okay=True,
+        help=(
+            "Directory for generated data source schemas. Defaults to "
+            "data_source_schemas/<species> in species mode, or "
+            "<output-dir>/data_source_schemas in manual mode."
+        ),
+    ),
     no_checkpoint: bool = typer.Option(
         False,
         "--no-checkpoint",
@@ -949,6 +992,19 @@ def main(
                         datasets_dict,
                         kg_format=writer_type,
                     )
+
+                    if generate_data_source_schemas:
+                        schema_output_dir = (
+                            data_source_schema_output_dir / sp
+                            if data_source_schema_output_dir
+                            else _default_data_source_schema_output_dir(sp, sp_output_dir)
+                        )
+                        _generate_data_source_schemas(
+                            sp_schema_config,
+                            sp_adapters_config,
+                            sp_adapters_dict,
+                            schema_output_dir,
+                        )
 
                     if ckpt is not None:
                         ckpt.delete()
@@ -1135,6 +1191,21 @@ def main(
             datasets_dict,
             kg_format=writer_type,
         )
+
+        if generate_data_source_schemas:
+            schema_output_dir = (
+                data_source_schema_output_dir
+                or _default_data_source_schema_output_dir(
+                    species if species_mode else None,
+                    output_dir,
+                )
+            )
+            _generate_data_source_schemas(
+                schema_config,
+                adapters_config,
+                adapters_dict,
+                schema_output_dir,
+            )
 
         if ckpt is not None:
             ckpt.delete()

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -363,6 +363,23 @@ def _generate_data_source_schemas(
     generator.generate_all_schemas(filter_adapters=list(adapters_dict.keys()))
 
 
+def _try_generate_data_source_schemas(
+    schema_config_path: Path,
+    adapters_config_path: Path,
+    adapters_dict: dict,
+    output_dir: Path,
+) -> None:
+    try:
+        _generate_data_source_schemas(
+            schema_config_path,
+            adapters_config_path,
+            adapters_dict,
+            output_dir,
+        )
+    except Exception:
+        logger.exception("Data source schema generation failed; KG output was already written.")
+
+
 def process_adapters(
     adapters_dict,
     dbsnp_rsids_dict,
@@ -812,7 +829,8 @@ def main(
         help=(
             "Directory for generated data source schemas. Defaults to "
             "data_source_schemas/<species> in species mode, or "
-            "<output-dir>/data_source_schemas in manual mode."
+            "<output-dir>/data_source_schemas in manual mode. "
+            "When --species all is used, each species is written under this directory."
         ),
     ),
     no_checkpoint: bool = typer.Option(
@@ -994,12 +1012,11 @@ def main(
                     )
 
                     if generate_data_source_schemas:
-                        schema_output_dir = (
-                            data_source_schema_output_dir / sp
-                            if data_source_schema_output_dir
-                            else _default_data_source_schema_output_dir(sp, sp_output_dir)
-                        )
-                        _generate_data_source_schemas(
+                        if data_source_schema_output_dir:
+                            schema_output_dir = data_source_schema_output_dir / sp
+                        else:
+                            schema_output_dir = _default_data_source_schema_output_dir(sp, sp_output_dir)
+                        _try_generate_data_source_schemas(
                             sp_schema_config,
                             sp_adapters_config,
                             sp_adapters_dict,
@@ -1200,7 +1217,7 @@ def main(
                     output_dir,
                 )
             )
-            _generate_data_source_schemas(
+            _try_generate_data_source_schemas(
                 schema_config,
                 adapters_config,
                 adapters_dict,

--- a/data_source_schemas/hsa/ABC.yaml
+++ b/data_source_schemas/hsa/ABC.yaml
@@ -4,9 +4,9 @@ relationships:
   activity by contact:
     url: https://forgedb.cancer.gov/api/abc/v1.0/abc.forgedb.csv.gz
     input_label: activity_by_contact
-    output_label: activity_by_contact
+    output_label: activity by contact
     description: An association between a variant in a regulatory region and a gene
-      it predicted by the ABC model (Fulco et.al 2019)
+      predicted by the ABC model (Fulco et al. 2019)
     source: snp
     target: gene
     properties:

--- a/data_source_schemas/hsa/ABC.yaml
+++ b/data_source_schemas/hsa/ABC.yaml
@@ -4,7 +4,6 @@ relationships:
   activity by contact:
     url: https://forgedb.cancer.gov/api/abc/v1.0/abc.forgedb.csv.gz
     input_label: activity_by_contact
-    output_label: activity by contact
     description: An association between a variant in a regulatory region and a gene
       predicted by the ABC model (Fulco et al. 2019)
     source: snp

--- a/data_source_schemas/hsa/Alliance_for_Genome_Resources.yaml
+++ b/data_source_schemas/hsa/Alliance_for_Genome_Resources.yaml
@@ -9,19 +9,15 @@ relationships:
     source: gene
     target: disease
     properties:
-      date: string
-      species_name: string
-      reference: string
-      disease_name: string
-      with_ortholog: string
-      taxon_id: integer
-      inferred_from_id: string
-      gene_symbol: string
-      evidence_code_name: string
-      evidence_code: string
-      inferred_from_symbol: string
-      data_source: string
-    output_label: gene biomarker via orthology disease
+      data_source: str
+      date: str
+      evidence_code: str
+      evidence_code_name: str
+      inferred_from_id: str
+      inferred_from_symbol: str
+      reference: str
+      taxon_id: int
+      with_ortholog: str
   gene implicated via orthology disease:
     url: https://www.alliancegenome.org/
     input_label: implicated_via_orthology
@@ -30,19 +26,15 @@ relationships:
     source: gene
     target: disease
     properties:
-      date: string
-      species_name: string
-      reference: string
-      disease_name: string
-      with_ortholog: string
-      taxon_id: integer
-      inferred_from_id: string
-      gene_symbol: string
-      evidence_code_name: string
-      evidence_code: string
-      inferred_from_symbol: string
-      data_source: string
-    output_label: gene implicated via orthology disease
+      data_source: str
+      date: str
+      evidence_code: str
+      evidence_code_name: str
+      inferred_from_id: str
+      inferred_from_symbol: str
+      reference: str
+      taxon_id: int
+      with_ortholog: str
   gene is implicated in disease:
     url: https://www.alliancegenome.org/
     input_label: is_implicated_in
@@ -50,19 +42,15 @@ relationships:
     source: gene
     target: disease
     properties:
-      date: string
-      species_name: string
-      reference: string
-      disease_name: string
-      with_ortholog: string
-      taxon_id: integer
-      inferred_from_id: string
-      gene_symbol: string
-      evidence_code_name: string
-      evidence_code: string
-      inferred_from_symbol: string
-      data_source: string
-    output_label: gene is implicated in disease
+      data_source: str
+      date: str
+      evidence_code: str
+      evidence_code_name: str
+      inferred_from_id: str
+      inferred_from_symbol: str
+      reference: str
+      taxon_id: int
+      with_ortholog: str
   gene to disease marker association:
     url: https://www.alliancegenome.org/
     input_label: is_marker_for
@@ -70,19 +58,15 @@ relationships:
     source: gene
     target: disease
     properties:
-      date: string
-      species_name: string
-      reference: string
-      disease_name: string
-      with_ortholog: string
-      taxon_id: integer
-      inferred_from_id: string
-      gene_symbol: string
-      evidence_code_name: string
-      evidence_code: string
-      inferred_from_symbol: string
-      data_source: string
-    output_label: gene to disease marker association
+      data_source: str
+      date: str
+      evidence_code: str
+      evidence_code_name: str
+      inferred_from_id: str
+      inferred_from_symbol: str
+      reference: str
+      taxon_id: int
+      with_ortholog: str
   orthology association:
     url: https://www.alliancegenome.org/
     input_label: orthologs_genes
@@ -94,5 +78,21 @@ relationships:
     target: gene
     properties:
       source_organism: str
-      taxon_id: int
       target_organism_taxon_id: int
+      taxon_id: int
+  gene to disease model association:
+    url: https://www.alliancegenome.org/
+    input_label: is_model_of
+    description: Gene is a model for disease
+    source: gene
+    target: disease
+    properties:
+      data_source: str
+      date: str
+      evidence_code: str
+      evidence_code_name: str
+      inferred_from_id: str
+      inferred_from_symbol: str
+      reference: str
+      taxon_id: int
+      with_ortholog: str

--- a/data_source_schemas/hsa/Alliance_for_Genome_Resources.yaml
+++ b/data_source_schemas/hsa/Alliance_for_Genome_Resources.yaml
@@ -1,0 +1,98 @@
+name: Alliance for Genome Resources
+website: https://www.alliancegenome.org
+relationships:
+  gene biomarker via orthology disease:
+    url: https://www.alliancegenome.org/
+    input_label: biomarker_via_orthology
+    description: A gene is a biomarker for a disease via orthology relationship. From
+      Alliance for Genome Resources.
+    source: gene
+    target: disease
+    properties:
+      date: string
+      species_name: string
+      reference: string
+      disease_name: string
+      with_ortholog: string
+      taxon_id: integer
+      inferred_from_id: string
+      gene_symbol: string
+      evidence_code_name: string
+      evidence_code: string
+      inferred_from_symbol: string
+      data_source: string
+    output_label: gene biomarker via orthology disease
+  gene implicated via orthology disease:
+    url: https://www.alliancegenome.org/
+    input_label: implicated_via_orthology
+    description: A gene is implicated in a disease via orthology relationship. From
+      Alliance for Genome Resources.
+    source: gene
+    target: disease
+    properties:
+      date: string
+      species_name: string
+      reference: string
+      disease_name: string
+      with_ortholog: string
+      taxon_id: integer
+      inferred_from_id: string
+      gene_symbol: string
+      evidence_code_name: string
+      evidence_code: string
+      inferred_from_symbol: string
+      data_source: string
+    output_label: gene implicated via orthology disease
+  gene is implicated in disease:
+    url: https://www.alliancegenome.org/
+    input_label: is_implicated_in
+    description: A gene is implicated in a disease. From Alliance for Genome Resources.
+    source: gene
+    target: disease
+    properties:
+      date: string
+      species_name: string
+      reference: string
+      disease_name: string
+      with_ortholog: string
+      taxon_id: integer
+      inferred_from_id: string
+      gene_symbol: string
+      evidence_code_name: string
+      evidence_code: string
+      inferred_from_symbol: string
+      data_source: string
+    output_label: gene is implicated in disease
+  gene to disease marker association:
+    url: https://www.alliancegenome.org/
+    input_label: is_marker_for
+    description: Gene is a marker for a disease
+    source: gene
+    target: disease
+    properties:
+      date: string
+      species_name: string
+      reference: string
+      disease_name: string
+      with_ortholog: string
+      taxon_id: integer
+      inferred_from_id: string
+      gene_symbol: string
+      evidence_code_name: string
+      evidence_code: string
+      inferred_from_symbol: string
+      data_source: string
+    output_label: gene to disease marker association
+  orthology association:
+    url: https://www.alliancegenome.org/
+    input_label: orthologs_genes
+    output_label: ortholog_of
+    description: Non-directional association between two genes indicating that there
+      is an orthology relation among them. It  is a historical homology that involves
+      genes that diverged after a speciation event (purl.obolibrary.org/obo/RO_HOM0000017)
+    source: gene
+    target: gene
+    properties:
+      source_organism: str
+      taxon_id: int
+      target_organism_taxon_id: int

--- a/data_source_schemas/hsa/Bgee.yaml
+++ b/data_source_schemas/hsa/Bgee.yaml
@@ -5,8 +5,7 @@ relationships:
     url: https://www.bgee.org/download/gene-expression-calls?id=
     input_label: gene_expressed_in_anatomy
     output_label: expressed_in
-    description: holds between a gene and an anatomy ontology term in which it is
-      expressed
+    description: holds between a gene and an anatomical entity in which it is expressed
     source: gene
     target: anatomy
     properties:
@@ -18,7 +17,7 @@ relationships:
     output_label: expressed_in
     description: holds between a gene and a developmental stage in which it is expressed
     source: gene
-    target: developmental_stage
+    target: developmental stage
     properties:
       p_value: float
       score: float

--- a/data_source_schemas/hsa/Bgee.yaml
+++ b/data_source_schemas/hsa/Bgee.yaml
@@ -5,7 +5,8 @@ relationships:
     url: https://www.bgee.org/download/gene-expression-calls?id=
     input_label: gene_expressed_in_anatomy
     output_label: expressed_in
-    description: holds between a gene and an anatomy ontology term in which it is expressed
+    description: holds between a gene and an anatomy ontology term in which it is
+      expressed
     source: gene
     target: anatomy
     properties:

--- a/data_source_schemas/hsa/CADD.yaml
+++ b/data_source_schemas/hsa/CADD.yaml
@@ -7,3 +7,6 @@ nodes:
     output_label: snp
     description: A single nucleotide polymorphism (SNP) is a variation in a single
       nucleotide that occurs at a specific position in the genome
+    properties:
+      raw_cadd_score: float
+      phred_score: float

--- a/data_source_schemas/hsa/CADD.yaml
+++ b/data_source_schemas/hsa/CADD.yaml
@@ -4,9 +4,8 @@ nodes:
   snp:
     url: https://forgedb.cancer.gov/api/cadd/v1.0/cadd.forgedb.csv.gz
     input_label: snp
-    output_label: snp
     description: A single nucleotide polymorphism (SNP) is a variation in a single
       nucleotide that occurs at a specific position in the genome
     properties:
-      raw_cadd_score: float
       phred_score: float
+      raw_cadd_score: float

--- a/data_source_schemas/hsa/CATLAS.yaml
+++ b/data_source_schemas/hsa/CATLAS.yaml
@@ -1,94 +1,79 @@
 name: CATLAS
 website: https://catlas.org
 nodes:
-  enhancer:
-    url: https://catlas.org/
-    input_label: enhancer
-    output_label: enhancer
-    description: A distal cCRE (candidate cis-regulatory element) from the CATLAS
-      single-cell chromatin accessibility atlas.
-    properties:
-      chr: str
-      start: int
-      end: int
-      development_stage: str[]
-      ccre_module: int
-      taxon_id: str
   promoter:
     url: https://catlas.org/
     input_label: promoter
-    output_label: promoter
-    description: A promoter-proximal cCRE from the CATLAS single-cell chromatin accessibility
-      atlas.
     properties:
-      chr: str
-      start: int
-      end: int
-      development_stage: str[]
       ccre_module: int
+      chr: str
+      development_stage: str[]
+      end: int
+      start: int
+      taxon_id: str
+  enhancer:
+    url: https://catlas.org/
+    input_label: enhancer
+    properties:
+      ccre_module: int
+      chr: str
+      development_stage: str[]
+      end: int
+      start: int
       taxon_id: str
 relationships:
-  enhancer activity by contact:
-    url: https://catlas.org/
-    input_label: enhancer_activity_by_contact
-    output_label: activity_by_contact
-    description: An enhancer-to-gene association predicted by the ABC model (Activity-By-Contact,
-      Fulco et al. 2019) using CATLAS single-cell chromatin accessibility data.
-    source: enhancer
-    target: gene
-    properties:
-      abc_score: float
-      distance: int
-      biological_context: str
-      taxon_id: str
-      score: float
-  promoter to gene association:
-    url: https://catlas.org/
-    input_label: promoter_gene
-    output_label: associated_with
-    description: An association between a promoter cCRE and its target gene.
-    source: promoter
-    target: gene
-    properties:
-      biological_context: str
-      taxon_id: str
   enhancer accessible in cell type:
     url: https://catlas.org/
     input_label: enhancer_accessible_in_cell_type
     output_label: accessible_in
-    description: An enhancer cCRE that is chromatin-accessible in a given cell type
-      (CL ontology term).
+    description: An enhancer shows open chromatin in a cell type (CL term) as profiled
+      by scATAC-seq in the CATLAS dataset.
     source: enhancer
-    target: cell_type
-    properties:
-      taxon_id: str
+    target: cell type
   enhancer accessible in tissue:
     url: https://catlas.org/
     input_label: enhancer_accessible_in_tissue
     output_label: accessible_in
-    description: An enhancer cCRE that is chromatin-accessible in a given tissue (UBERON
-      ontology term).
+    description: An enhancer shows open chromatin in a tissue (UBERON term) as profiled
+      by scATAC-seq in the CATLAS dataset.
     source: enhancer
     target: anatomy
-    properties:
-      taxon_id: str
   promoter accessible in cell type:
     url: https://catlas.org/
     input_label: promoter_accessible_in_cell_type
     output_label: accessible_in
-    description: A promoter cCRE that is chromatin-accessible in a given cell type
-      (CL ontology term).
+    description: A promoter shows open chromatin in a cell type (CL term) as profiled
+      by scATAC-seq in the CATLAS dataset.
     source: promoter
-    target: cell_type
-    properties:
-      taxon_id: str
+    target: cell type
   promoter accessible in tissue:
     url: https://catlas.org/
     input_label: promoter_accessible_in_tissue
     output_label: accessible_in
-    description: A promoter cCRE that is chromatin-accessible in a given tissue (UBERON
-      ontology term).
+    description: A promoter shows open chromatin in a tissue (UBERON term) as profiled
+      by scATAC-seq in the CATLAS dataset.
     source: promoter
     target: anatomy
+  enhancer activity by contact:
+    url: https://catlas.org/
+    input_label: enhancer_activity_by_contact
+    output_label: activity_by_contact
+    description: An association between an enhancer cCRE and a gene predicted by the
+      ABC model (Activity-By-Contact, Fulco et al. 2019) using CATLAS single-cell
+      chromatin accessibility data, or by ENCODE rE2G.
+    source: enhancer
+    target: gene
     properties:
+      biological_context: str
+      distance: int
+      score: float
       taxon_id: str
+  promoter to gene association:
+    url: https://catlas.org/
+    input_label: promoter_gene
+    output_label: associated_with
+    description: An association between a promoter and a gene
+    source: promoter
+    target: gene
+    properties:
+      biological_context: str

--- a/data_source_schemas/hsa/CATLAS.yaml
+++ b/data_source_schemas/hsa/CATLAS.yaml
@@ -18,8 +18,8 @@ nodes:
     url: https://catlas.org/
     input_label: promoter
     output_label: promoter
-    description: A promoter-proximal cCRE from the CATLAS single-cell chromatin
-      accessibility atlas.
+    description: A promoter-proximal cCRE from the CATLAS single-cell chromatin accessibility
+      atlas.
     properties:
       chr: str
       start: int
@@ -32,9 +32,8 @@ relationships:
     url: https://catlas.org/
     input_label: enhancer_activity_by_contact
     output_label: activity_by_contact
-    description: An enhancer-to-gene association predicted by the ABC model
-      (Activity-By-Contact, Fulco et al. 2019) using CATLAS single-cell
-      chromatin accessibility data.
+    description: An enhancer-to-gene association predicted by the ABC model (Activity-By-Contact,
+      Fulco et al. 2019) using CATLAS single-cell chromatin accessibility data.
     source: enhancer
     target: gene
     properties:
@@ -42,6 +41,7 @@ relationships:
       distance: int
       biological_context: str
       taxon_id: str
+      score: float
   promoter to gene association:
     url: https://catlas.org/
     input_label: promoter_gene
@@ -66,8 +66,8 @@ relationships:
     url: https://catlas.org/
     input_label: enhancer_accessible_in_tissue
     output_label: accessible_in
-    description: An enhancer cCRE that is chromatin-accessible in a given tissue
-      (UBERON ontology term).
+    description: An enhancer cCRE that is chromatin-accessible in a given tissue (UBERON
+      ontology term).
     source: enhancer
     target: anatomy
     properties:
@@ -86,8 +86,8 @@ relationships:
     url: https://catlas.org/
     input_label: promoter_accessible_in_tissue
     output_label: accessible_in
-    description: A promoter cCRE that is chromatin-accessible in a given tissue
-      (UBERON ontology term).
+    description: A promoter cCRE that is chromatin-accessible in a given tissue (UBERON
+      ontology term).
     source: promoter
     target: anatomy
     properties:

--- a/data_source_schemas/hsa/CoXPresdb.yaml
+++ b/data_source_schemas/hsa/CoXPresdb.yaml
@@ -4,7 +4,6 @@ relationships:
   gene to gene coexpression association:
     url: https://coxpresdb.jp/
     input_label: coexpressed_with
-    output_label: gene to gene coexpression association
     description: Indicates that two genes are co-expressed, generally under the same
       conditions.
     source: gene

--- a/data_source_schemas/hsa/CoXPresdb.yaml
+++ b/data_source_schemas/hsa/CoXPresdb.yaml
@@ -4,7 +4,7 @@ relationships:
   gene to gene coexpression association:
     url: https://coxpresdb.jp/
     input_label: coexpressed_with
-    output_label: coexpressed_with
+    output_label: gene to gene coexpression association
     description: Indicates that two genes are co-expressed, generally under the same
       conditions.
     source: gene

--- a/data_source_schemas/hsa/ENCODE.yaml
+++ b/data_source_schemas/hsa/ENCODE.yaml
@@ -4,12 +4,12 @@ nodes:
   transcription binding site:
     url: https://genome.ucsc.edu/cgi-bin/hgTables
     input_label: tfbs
-    output_label: tfbs
+    output_label: transcription binding site
     description: A region of DNA where a transcription factor binds to regulate gene
       expression
     properties:
-      taxon_id: int
       end: int
+      taxon_id: int
       start: int
       chr: str
   promoter:
@@ -17,10 +17,10 @@ nodes:
     input_label: promoter
     output_label: promoter
     properties:
-      biological_context: str
       end: int
       start: int
       chr: str
+      biological_context: str
   enhancer:
     url: https://screen.wenglab.org/downloads
     input_label: enhancer

--- a/data_source_schemas/hsa/ENCODE.yaml
+++ b/data_source_schemas/hsa/ENCODE.yaml
@@ -4,31 +4,28 @@ nodes:
   transcription binding site:
     url: https://genome.ucsc.edu/cgi-bin/hgTables
     input_label: tfbs
-    output_label: transcription binding site
     description: A region of DNA where a transcription factor binds to regulate gene
       expression
     properties:
+      chr: str
       end: int
+      start: int
       taxon_id: int
-      start: int
-      chr: str
-  promoter:
-    url: https://screen.wenglab.org/downloads
-    input_label: promoter
-    output_label: promoter
-    properties:
-      end: int
-      start: int
-      chr: str
-      biological_context: str
   enhancer:
     url: https://screen.wenglab.org/downloads
     input_label: enhancer
-    output_label: enhancer
     properties:
+      chr: str
       end: int
       start: int
+  promoter:
+    url: https://screen.wenglab.org/downloads
+    input_label: promoter
+    properties:
+      biological_context: str
       chr: str
+      end: int
+      start: int
 relationships:
   gene to transcription binding site association:
     url: https://genome.ucsc.edu/cgi-bin/hgTables
@@ -39,6 +36,13 @@ relationships:
     target: tfbs
     properties:
       score: float
+  enhancer to gene association:
+    url: https://screen.wenglab.org/downloads
+    input_label: enhancer_gene
+    output_label: associated_with
+    description: An association between an enhancer and a gene
+    source: enhancer
+    target: gene
   promoter to gene association:
     url: https://screen.wenglab.org/downloads
     input_label: promoter_gene
@@ -48,10 +52,3 @@ relationships:
     target: gene
     properties:
       biological_context: str
-  enhancer to gene association:
-    url: https://screen.wenglab.org/downloads
-    input_label: enhancer_gene
-    output_label: associated_with
-    description: An association between an enhancer and a gene
-    source: enhancer
-    target: gene

--- a/data_source_schemas/hsa/ENCODE_rE2G.yaml
+++ b/data_source_schemas/hsa/ENCODE_rE2G.yaml
@@ -4,18 +4,23 @@ nodes:
   enhancer:
     url: https://www.encodeproject.org/
     input_label: enhancer
-    output_label: enhancer
     properties:
+      biological_context: str
+      chr: str
       end: int
       start: int
-      chr: str
+      taxon_id: str
 relationships:
   enhancer activity by contact:
     url: https://www.encodeproject.org/
     input_label: enhancer_activity_by_contact
     output_label: activity_by_contact
-    description: An enhancer-to-gene association predicted by ENCODE rE2G
+    description: An association between an enhancer cCRE and a gene predicted by the
+      ABC model (Activity-By-Contact, Fulco et al. 2019) using CATLAS single-cell
+      chromatin accessibility data, or by ENCODE rE2G.
     source: enhancer
     target: gene
     properties:
+      biological_context: str
       score: float
+      taxon_id: str

--- a/data_source_schemas/hsa/EPD.yaml
+++ b/data_source_schemas/hsa/EPD.yaml
@@ -4,12 +4,11 @@ nodes:
   promoter:
     url: https://epd.expasy.org/ftp/epdnew/H_sapiens/
     input_label: promoter
-    output_label: promoter
     properties:
-      end: int
-      taxon_id: str
-      start: int
       chr: str
+      end: int
+      start: int
+      taxon_id: str
 relationships:
   promoter to gene association:
     url: https://epd.expasy.org/ftp/epdnew/H_sapiens/

--- a/data_source_schemas/hsa/EPD.yaml
+++ b/data_source_schemas/hsa/EPD.yaml
@@ -6,8 +6,8 @@ nodes:
     input_label: promoter
     output_label: promoter
     properties:
-      taxon_id: int
       end: int
+      taxon_id: str
       start: int
       chr: str
 relationships:

--- a/data_source_schemas/hsa/Enhancer_Atlas.yaml
+++ b/data_source_schemas/hsa/Enhancer_Atlas.yaml
@@ -6,10 +6,10 @@ nodes:
     input_label: enhancer
     output_label: enhancer
     properties:
-      biological_context: str
       end: int
       start: int
       chr: str
+      biological_context: str
 relationships:
   enhancer to gene association:
     url: http://enhanceratlas.org/downloadv2.php

--- a/data_source_schemas/hsa/Enhancer_Atlas.yaml
+++ b/data_source_schemas/hsa/Enhancer_Atlas.yaml
@@ -1,23 +1,22 @@
 name: Enhancer Atlas
-website: http://enhanceratlas.org
+website: http://singlecelldb.com
 nodes:
   enhancer:
-    url: http://enhanceratlas.org/downloadv2.php
+    url: http://singlecelldb.com/downloadv2.php
     input_label: enhancer
-    output_label: enhancer
     properties:
+      biological_context: str
+      chr: str
       end: int
       start: int
-      chr: str
-      biological_context: str
 relationships:
   enhancer to gene association:
-    url: http://enhanceratlas.org/downloadv2.php
+    url: http://singlecelldb.com/downloadv2.php
     input_label: enhancer_gene
     output_label: associated_with
     description: An association between an enhancer and a gene
     source: enhancer
     target: gene
     properties:
-      score: float
       biological_context: str
+      score: float

--- a/data_source_schemas/hsa/FAVOR.yaml
+++ b/data_source_schemas/hsa/FAVOR.yaml
@@ -4,14 +4,11 @@ nodes:
   snp:
     url: http://favor.genohub.org/
     input_label: snp
-    output_label: snp
-    description: >-
-      A variant annotated with FAVOR (Functional Annotation of Variants - Online Resource)
-      including APC scores, allele frequencies, CADD scores, and functional predictions.
+    description: A single nucleotide polymorphism (SNP) is a variation in a single
+      nucleotide that occurs at a specific position in the genome
     properties:
+      alt: str
       chr: str
-      start: int
       end: int
       ref: str
-      alt: str
-      annotation: dict
+      start: int

--- a/data_source_schemas/hsa/GENCODE.yaml
+++ b/data_source_schemas/hsa/GENCODE.yaml
@@ -6,11 +6,11 @@ nodes:
     input_label: gene
     output_label: gene
     properties:
+      gene_type: str
       synonym: str[]
       end: int
-      gene_type: str
-      start: int
       gene_name: str
+      start: int
       chr: str
   transcript:
     url: https://www.gencodegenes.org/
@@ -18,27 +18,27 @@ nodes:
     output_label: transcript
     description: An RNA synthesized on a DNA or RNA template by an RNA polymerase.
     properties:
-      transcript_type: str
-      transcript_name: str
-      gene_name: str
       transcript_id: str
+      transcript_type: str
+      gene_name: str
+      transcript_name: str
   exon:
     url: https://www.gencodegenes.org/
     input_label: exon
     output_label: exon
     properties:
-      gene_id: str
-      exon_id: str
-      end: int
-      start: int
-      exon_number: int
-      chr: str
       transcript_id: str
+      exon_number: int
+      end: int
+      gene_id: str
+      start: int
+      exon_id: str
+      chr: str
 relationships:
   transcribes to:
     url: https://www.gencodegenes.org/
     input_label: transcribes_to
-    output_label: transcribes_to
+    output_label: transcribes to
     description: inverse of transcribed from
     source: gene
     target: transcript

--- a/data_source_schemas/hsa/GENCODE.yaml
+++ b/data_source_schemas/hsa/GENCODE.yaml
@@ -4,41 +4,33 @@ nodes:
   gene:
     url: https://www.gencodegenes.org/
     input_label: gene
-    output_label: gene
     properties:
-      gene_type: str
-      synonym: str[]
+      chr: str
       end: int
       gene_name: str
+      gene_type: str
       start: int
-      chr: str
+      synonym: str[]
   transcript:
     url: https://www.gencodegenes.org/
     input_label: transcript
-    output_label: transcript
     description: An RNA synthesized on a DNA or RNA template by an RNA polymerase.
     properties:
       transcript_id: str
-      transcript_type: str
-      gene_name: str
       transcript_name: str
+      transcript_type: str
   exon:
     url: https://www.gencodegenes.org/
     input_label: exon
-    output_label: exon
     properties:
-      transcript_id: str
-      exon_number: int
-      end: int
-      gene_id: str
-      start: int
-      exon_id: str
       chr: str
+      end: int
+      exon_number: int
+      start: int
 relationships:
   transcribes to:
     url: https://www.gencodegenes.org/
     input_label: transcribes_to
-    output_label: transcribes to
     description: inverse of transcribed from
     source: gene
     target: transcript

--- a/data_source_schemas/hsa/GOA.yaml
+++ b/data_source_schemas/hsa/GOA.yaml
@@ -8,9 +8,10 @@ relationships:
     source: protein
     target: biological_process
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str
   molecular function gene product:
     url: http://geneontology.org/gene-associations/goa_human.gaf.gz
     input_label: molecular_function_gene_product
@@ -18,9 +19,10 @@ relationships:
     source: protein
     target: molecular_function
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str
   cellular component gene product part of:
     url: http://geneontology.org/gene-associations/goa_human.gaf.gz
     input_label: cellular_component_gene_product_part_of
@@ -28,9 +30,10 @@ relationships:
     source: protein
     target: cellular_component
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str
   cellular component gene product located in:
     url: http://geneontology.org/gene-associations/goa_human.gaf.gz
     input_label: cellular_component_gene_product_located_in
@@ -38,9 +41,10 @@ relationships:
     source: protein
     target: cellular_component
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str
   biological process gene:
     url: http://geneontology.org/gene-associations/goa_human.gaf.gz
     input_label: biological_process_gene
@@ -48,9 +52,10 @@ relationships:
     source: gene
     target: biological_process
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str
   molecular function gene:
     url: http://geneontology.org/gene-associations/goa_human.gaf.gz
     input_label: molecular_function_gene
@@ -58,9 +63,10 @@ relationships:
     source: gene
     target: molecular_function
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str
   cellular component gene part of:
     url: http://geneontology.org/gene-associations/goa_human.gaf.gz
     input_label: cellular_component_gene_part_of
@@ -68,9 +74,10 @@ relationships:
     source: gene
     target: cellular_component
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str
   cellular component gene located in:
     url: http://geneontology.org/gene-associations/goa_human.gaf.gz
     input_label: cellular_component_gene_located_in
@@ -78,6 +85,7 @@ relationships:
     source: gene
     target: cellular_component
     properties:
-      db_reference: str
-      evidence: str
+      db_reference: str[]
       qualifier: str
+      evidence: str
+      taxon_id: str

--- a/data_source_schemas/hsa/GOA.yaml
+++ b/data_source_schemas/hsa/GOA.yaml
@@ -6,10 +6,9 @@ relationships:
     input_label: biological_process_gene_product
     output_label: involved_in
     source: protein
-    target: biological_process
+    target: biological process
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str
   molecular function gene product:
@@ -17,10 +16,9 @@ relationships:
     input_label: molecular_function_gene_product
     output_label: enables
     source: protein
-    target: molecular_function
+    target: molecular function
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str
   cellular component gene product part of:
@@ -28,10 +26,9 @@ relationships:
     input_label: cellular_component_gene_product_part_of
     output_label: part_of
     source: protein
-    target: cellular_component
+    target: cellular component
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str
   cellular component gene product located in:
@@ -39,10 +36,9 @@ relationships:
     input_label: cellular_component_gene_product_located_in
     output_label: located_in
     source: protein
-    target: cellular_component
+    target: cellular component
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str
   biological process gene:
@@ -50,10 +46,9 @@ relationships:
     input_label: biological_process_gene
     output_label: involved_in
     source: gene
-    target: biological_process
+    target: biological process
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str
   molecular function gene:
@@ -61,10 +56,9 @@ relationships:
     input_label: molecular_function_gene
     output_label: enables
     source: gene
-    target: molecular_function
+    target: molecular function
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str
   cellular component gene part of:
@@ -72,10 +66,9 @@ relationships:
     input_label: cellular_component_gene_part_of
     output_label: part_of
     source: gene
-    target: cellular_component
+    target: cellular component
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str
   cellular component gene located in:
@@ -83,9 +76,8 @@ relationships:
     input_label: cellular_component_gene_located_in
     output_label: located_in
     source: gene
-    target: cellular_component
+    target: cellular component
     properties:
       db_reference: str[]
-      qualifier: str
       evidence: str
       taxon_id: str

--- a/data_source_schemas/hsa/GTEx.yaml
+++ b/data_source_schemas/hsa/GTEx.yaml
@@ -17,7 +17,8 @@ relationships:
     url: https://forgedb.cancer.gov/api/gtex/v1.0/gtex.forgedb.csv.gz
     input_label: gene_expressed_in_anatomy
     output_label: expressed_in
-    description: holds between a gene and an anatomy ontology term in which it is expressed
+    description: holds between a gene and an anatomy ontology term in which it is
+      expressed
     source: gene
     target: anatomy
     properties:

--- a/data_source_schemas/hsa/GTEx.yaml
+++ b/data_source_schemas/hsa/GTEx.yaml
@@ -9,16 +9,15 @@ relationships:
     source: snp
     target: gene
     properties:
-      p_value: str
-      maf: str
       biological_context: str
+      maf: str
+      p_value: str
       slope: str
   gene expressed in anatomy:
     url: https://forgedb.cancer.gov/api/gtex/v1.0/gtex.forgedb.csv.gz
     input_label: gene_expressed_in_anatomy
     output_label: expressed_in
-    description: holds between a gene and an anatomy ontology term in which it is
-      expressed
+    description: holds between a gene and an anatomical entity in which it is expressed
     source: gene
     target: anatomy
     properties:

--- a/data_source_schemas/hsa/GWAS.yaml
+++ b/data_source_schemas/hsa/GWAS.yaml
@@ -10,8 +10,8 @@ relationships:
     source: snp
     target: gene
     properties:
-      p_value: float
       distance: int
+      p_value: float
   downstream gene to variant association:
     url: https://ftp.ebi.ac.uk/pub/databases/gwas/releases/2024/07/29/gwas-catalog-associations_ontology-annotated.tsv
     input_label: snp_downstream_gene
@@ -21,8 +21,8 @@ relationships:
     source: snp
     target: gene
     properties:
-      p_value: float
       distance: int
+      p_value: float
   in gene to variant association:
     url: https://ftp.ebi.ac.uk/pub/databases/gwas/releases/2024/07/29/gwas-catalog-associations_ontology-annotated.tsv
     input_label: snp_in_gene
@@ -32,5 +32,5 @@ relationships:
     source: snp
     target: gene
     properties:
-      p_value: float
       distance: int
+      p_value: float

--- a/data_source_schemas/hsa/HOCOMOCO.yaml
+++ b/data_source_schemas/hsa/HOCOMOCO.yaml
@@ -4,12 +4,11 @@ nodes:
   motif:
     url: https://hocomoco11.autosome.org/downloads_v11
     input_label: motif
-    output_label: motif
     properties:
-      pwm_G: float[]
-      taxon_id: int
+      length: int
       pwm_A: float[]
       pwm_C: float[]
-      length: int
-      tf_name: str
+      pwm_G: float[]
       pwm_T: float[]
+      taxon_id: int
+      tf_name: str

--- a/data_source_schemas/hsa/HOCOMOCO.yaml
+++ b/data_source_schemas/hsa/HOCOMOCO.yaml
@@ -6,10 +6,10 @@ nodes:
     input_label: motif
     output_label: motif
     properties:
+      pwm_G: float[]
       taxon_id: int
+      pwm_A: float[]
       pwm_C: float[]
       length: int
-      pwm_T: float[]
       tf_name: str
-      pwm_G: float[]
-      pwm_A: float[]
+      pwm_T: float[]

--- a/data_source_schemas/hsa/Human_Phenotype_Ontology.yaml
+++ b/data_source_schemas/hsa/Human_Phenotype_Ontology.yaml
@@ -9,10 +9,10 @@ relationships:
     source: gene
     target: phenotype
     properties:
-      gene_symbol: str
-      phenotype_name: str
       frequency: str
       disease_id: str
+      gene_symbol: str
+      phenotype_name: str
   gene to disease association:
     url: https://hpo.jax.org/
     input_label: gene_disease
@@ -22,6 +22,6 @@ relationships:
     source: gene
     target: disease
     properties:
-      association_type: str
       gene_symbol: str
       source_ref: str
+      association_type: str

--- a/data_source_schemas/hsa/Human_Phenotype_Ontology.yaml
+++ b/data_source_schemas/hsa/Human_Phenotype_Ontology.yaml
@@ -9,8 +9,8 @@ relationships:
     source: gene
     target: phenotype
     properties:
-      frequency: str
       disease_id: str
+      frequency: str
       gene_symbol: str
       phenotype_name: str
   gene to disease association:
@@ -22,6 +22,6 @@ relationships:
     source: gene
     target: disease
     properties:
+      association_type: str
       gene_symbol: str
       source_ref: str
-      association_type: str

--- a/data_source_schemas/hsa/MotifDiff.yaml
+++ b/data_source_schemas/hsa/MotifDiff.yaml
@@ -5,8 +5,7 @@ relationships:
     url: https://github.com/rezwanhosseini/MotifDiff
     input_label: tf_snp
     output_label: alters_binding
-    description: >-
-      holds between a SNP and a HOCOMOCO motif where the SNP causes a gain
+    description: holds between a SNP and a HOCOMOCO motif where the SNP causes a gain
       or loss of transcription factor binding affinity at that motif site
     source: snp
     target: motif

--- a/data_source_schemas/hsa/MotifDiff.yaml
+++ b/data_source_schemas/hsa/MotifDiff.yaml
@@ -1,15 +1,14 @@
 name: MotifDiff
-website: https://github.com/rezwanhosseini/MotifDiff
+website: https://github.com
 relationships:
   snp to motif association:
     url: https://github.com/rezwanhosseini/MotifDiff
     input_label: tf_snp
     output_label: alters_binding
-    description: holds between a SNP and a HOCOMOCO motif where the SNP causes a gain
+    description: holds between a snp and a HOCOMOCO motif where the snp causes a gain
       or loss of transcription factor binding affinity at that motif site
     source: snp
     target: motif
     properties:
       effect: str
       score: float
-      motif_id: str

--- a/data_source_schemas/hsa/OBO_Foundry.yaml
+++ b/data_source_schemas/hsa/OBO_Foundry.yaml
@@ -4,213 +4,122 @@ nodes:
   biological process:
     url: http://www.obofoundry.org/
     input_label: biological_process
-    output_label: biological process
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
   molecular function:
     url: http://www.obofoundry.org/
     input_label: molecular_function
-    output_label: molecular function
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
   cellular component:
     url: http://www.obofoundry.org/
     input_label: cellular_component
-    output_label: cellular component
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
   anatomy:
     url: http://www.obofoundry.org/
     input_label: anatomy
-    output_label: anatomy
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
   cell line:
     url: http://www.obofoundry.org/
     input_label: cell_line
-    output_label: cell line
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
   cell type:
     url: http://www.obofoundry.org/
     input_label: cell_type
-    output_label: cell type
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
   experimental factor:
     url: http://www.obofoundry.org/
     input_label: experimental_factor
-    output_label: experimental factor
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
   tissue:
     url: http://www.obofoundry.org/
     input_label: tissue
-    output_label: tissue
     properties:
+      alternative_ids: str[]
+      description: str
       synonym: str[]
       term_name: str
-      description: str
-      alternative_ids: str[]
-  small molecule:
-    url: http://www.obofoundry.org/
-    input_label: small_molecule
-    output_label: small molecule
-    properties:
-      synonym: str[]
-      term_name: str
-      description: str
-      alternative_ids: str[]
   phenotype:
     url: http://www.obofoundry.org/
     input_label: phenotype
-    output_label: phenotype
     properties:
-      description: str
-      term_name: str
-      synonym: str[]
       alternative_ids: str[]
+      description: str
+      synonym: str[]
+      term_name: str
+  small molecule:
+    url: http://www.obofoundry.org/
+    input_label: small_molecule
+    properties:
+      alternative_ids: str[]
+      description: str
+      synonym: str[]
+      term_name: str
   disease:
     url: http://www.obofoundry.org/
     input_label: disease
-    output_label: disease
     properties:
-      synonym: str[]
-      term_name: str
-      description: str
       alternative_ids: str[]
-  developmental_stage:
-    url: http://www.obofoundry.org/
-    input_label: developmental_stage
-    output_label: developmental_stage
-    properties:
+      description: str
       synonym: str[]
       term_name: str
-      description: str
 relationships:
   biological process subclass:
     url: http://www.obofoundry.org/
     input_label: biological_process_subclass_of
     output_label: is_a
-    source: biological_process
-    target: biological_process
-    properties:
-      rel_type: str
-  molecular function subclass:
-    url: http://www.obofoundry.org/
-    input_label: molecular_function_subclass_of
-    output_label: is_a
-    source: molecular_function
-    target: molecular_function
-    properties:
-      rel_type: str
+    source: biological process
+    target: biological process
   cellular component subclass:
     url: http://www.obofoundry.org/
     input_label: cellular_component_subclass_of
     output_label: is_a
-    source: cellular_component
-    target: cellular_component
-    properties:
-      rel_type: str
+    source: cellular component
+    target: cellular component
+  molecular function subclass:
+    url: http://www.obofoundry.org/
+    input_label: molecular_function_subclass_of
+    output_label: is_a
+    source: molecular function
+    target: molecular function
   uberon subclass of:
     url: http://www.obofoundry.org/
     input_label: uberon_subclass_of
     output_label: is_a
     source: anatomy
     target: anatomy
-    properties:
-      rel_type: str
   clo subclass of:
     url: http://www.obofoundry.org/
     input_label: clo_subclass_of
     output_label: is_a
-    source: cell_line
-    target: cell_line
-    properties:
-      rel_type: str
-  cl subclass of:
-    url: http://www.obofoundry.org/
-    input_label: cl_subclass_of
-    output_label: is_a
-    source: cell_type
-    target: cell_type
-    properties:
-      rel_type: str
-  cl capable of:
-    url: http://www.obofoundry.org/
-    input_label: cl_capable_of
-    output_label: capable_of
-    description: Represents the capability of a cell type (CL term) to carry out or
-      be involved in a specific biological process.
-    source: cell_type
-    target: biological_process
-  cl part of:
-    url: http://www.obofoundry.org/
-    input_label: cl_part_of
-    output_label: part_of
-    description: Represents a part-whole relationship between a CL term and an UBERON
-      term.
-    source: cell_type
-    target: anatomy
-  efo subclass of:
-    url: http://www.obofoundry.org/
-    input_label: efo_subclass_of
-    output_label: is_a
-    source: experimental_factor
-    target: experimental_factor
-    properties:
-      rel_type: str
-  bto subclass of:
-    url: http://www.obofoundry.org/
-    input_label: bto_subclass_of
-    output_label: is_a
-    source: tissue
-    target: tissue
-    properties:
-      rel_type: str
-  chebi subclass of:
-    url: http://www.obofoundry.org/
-    input_label: chebi_subclass_of
-    output_label: is_a
-    source: small_molecule
-    target: small_molecule
-    properties:
-      rel_type: str
-  hpo subclass of:
-    url: http://www.obofoundry.org/
-    input_label: hpo_subclass_of
-    output_label: is_a
-    source: phenotype
-    target: phenotype
-  do subclass of:
-    url: http://www.obofoundry.org/
-    input_label: do_subclass_of
-    output_label: is_a
-    source: disease
-    target: disease
-    properties:
-      rel_type: str
+    source: cell line
+    target: cell line
   cell line is a cell type:
     url: http://www.obofoundry.org/
     input_label: cell_line_is_a_cell_type
@@ -219,12 +128,46 @@ relationships:
       a Cell Ontology (CL) term.
     source: cell line
     target: cell type
+  cl subclass of:
+    url: http://www.obofoundry.org/
+    input_label: cl_subclass_of
+    output_label: is_a
+    source: cell type
+    target: cell type
+  cl capable of:
+    url: http://www.obofoundry.org/
+    input_label: cl_capable_of
+    output_label: capable_of
+    description: Represents the capability of a cell type (CL term) to carry out or
+      be involved in a specific biological process.
+    source: cell type
+    target: biological process
+  cl part of:
+    url: http://www.obofoundry.org/
+    input_label: cl_part_of
+    output_label: part_of
+    description: Represents a part-whole relationship between a CL term and an UBERON
+      term.
+    source: cell type
+    target: anatomy
   cell type part of tissue:
     url: http://www.obofoundry.org/
     input_label: cell_type_part_of_tissue
     output_label: part_of
     description: Cross-ontology relation linking a CL cell type to a BTO tissue term.
     source: cell type
+    target: tissue
+  efo subclass of:
+    url: http://www.obofoundry.org/
+    input_label: efo_subclass_of
+    output_label: is_a
+    source: experimental factor
+    target: experimental factor
+  bto subclass of:
+    url: http://www.obofoundry.org/
+    input_label: bto_subclass_of
+    output_label: is_a
+    source: tissue
     target: tissue
   tissue part of anatomy:
     url: http://www.obofoundry.org/
@@ -234,3 +177,21 @@ relationships:
       to an UBERON anatomy term.
     source: tissue
     target: anatomy
+  hpo subclass of:
+    url: http://www.obofoundry.org/
+    input_label: hpo_subclass_of
+    output_label: is_a
+    source: phenotype
+    target: phenotype
+  chebi subclass of:
+    url: http://www.obofoundry.org/
+    input_label: chebi_subclass_of
+    output_label: is_a
+    source: small molecule
+    target: small molecule
+  do subclass of:
+    url: http://www.obofoundry.org/
+    input_label: do_subclass_of
+    output_label: is_a
+    source: disease
+    target: disease

--- a/data_source_schemas/hsa/OBO_Foundry.yaml
+++ b/data_source_schemas/hsa/OBO_Foundry.yaml
@@ -4,27 +4,30 @@ nodes:
   biological process:
     url: http://www.obofoundry.org/
     input_label: biological_process
-    output_label: biological_process
+    output_label: biological process
     properties:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   molecular function:
     url: http://www.obofoundry.org/
     input_label: molecular_function
-    output_label: molecular_function
+    output_label: molecular function
     properties:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   cellular component:
     url: http://www.obofoundry.org/
     input_label: cellular_component
-    output_label: cellular_component
+    output_label: cellular component
     properties:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   anatomy:
     url: http://www.obofoundry.org/
     input_label: anatomy
@@ -33,30 +36,34 @@ nodes:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   cell line:
     url: http://www.obofoundry.org/
     input_label: cell_line
-    output_label: cell_line
+    output_label: cell line
     properties:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   cell type:
     url: http://www.obofoundry.org/
     input_label: cell_type
-    output_label: cell_type
+    output_label: cell type
     properties:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   experimental factor:
     url: http://www.obofoundry.org/
     input_label: experimental_factor
-    output_label: experimental_factor
+    output_label: experimental factor
     properties:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   tissue:
     url: http://www.obofoundry.org/
     input_label: tissue
@@ -65,20 +72,25 @@ nodes:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   small molecule:
     url: http://www.obofoundry.org/
     input_label: small_molecule
-    output_label: small_molecule
+    output_label: small molecule
     properties:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   phenotype:
     url: http://www.obofoundry.org/
     input_label: phenotype
     output_label: phenotype
     properties:
       description: str
+      term_name: str
+      synonym: str[]
+      alternative_ids: str[]
   disease:
     url: http://www.obofoundry.org/
     input_label: disease
@@ -87,6 +99,7 @@ nodes:
       synonym: str[]
       term_name: str
       description: str
+      alternative_ids: str[]
   developmental_stage:
     url: http://www.obofoundry.org/
     input_label: developmental_stage
@@ -198,3 +211,26 @@ relationships:
     target: disease
     properties:
       rel_type: str
+  cell line is a cell type:
+    url: http://www.obofoundry.org/
+    input_label: cell_line_is_a_cell_type
+    output_label: is_a
+    description: Cross-ontology relation linking a Cell Line Ontology (CLO) term to
+      a Cell Ontology (CL) term.
+    source: cell line
+    target: cell type
+  cell type part of tissue:
+    url: http://www.obofoundry.org/
+    input_label: cell_type_part_of_tissue
+    output_label: part_of
+    description: Cross-ontology relation linking a CL cell type to a BTO tissue term.
+    source: cell type
+    target: tissue
+  tissue part of anatomy:
+    url: http://www.obofoundry.org/
+    input_label: tissue_part_of_anatomy
+    output_label: part_of
+    description: Cross-ontology relation linking a BRENDA Tissue Ontology (BTO) term
+      to an UBERON anatomy term.
+    source: tissue
+    target: anatomy

--- a/data_source_schemas/hsa/PEREGRINE.yaml
+++ b/data_source_schemas/hsa/PEREGRINE.yaml
@@ -6,12 +6,12 @@ nodes:
     input_label: enhancer
     output_label: enhancer
     properties:
-      enhancer_id: str
       end: int
-      data_source: str
       biological_context: str
+      enhancer_id: str
       start: int
       chr: str
+      data_source: str
 relationships:
   enhancer to gene association:
     url: https://www.peregrineproj.org/

--- a/data_source_schemas/hsa/PEREGRINE.yaml
+++ b/data_source_schemas/hsa/PEREGRINE.yaml
@@ -4,14 +4,13 @@ nodes:
   enhancer:
     url: https://www.peregrineproj.org/
     input_label: enhancer
-    output_label: enhancer
     properties:
-      end: int
       biological_context: str
-      enhancer_id: str
-      start: int
       chr: str
       data_source: str
+      end: int
+      enhancer_id: str
+      start: int
 relationships:
   enhancer to gene association:
     url: https://www.peregrineproj.org/
@@ -21,5 +20,5 @@ relationships:
     source: enhancer
     target: gene
     properties:
-      score: float
       biological_context: str
+      score: float

--- a/data_source_schemas/hsa/PolyPhen_2.yaml
+++ b/data_source_schemas/hsa/PolyPhen_2.yaml
@@ -9,8 +9,8 @@ nodes:
       substitutions on protein structure and function
     properties:
       polyphen2_humdiv_score: float
-      polyphen2_humdiv_prediction: str
       alt: str
+      polyphen2_humvar_score: float
+      polyphen2_humdiv_prediction: str
       ref: str
       polyphen2_humvar_prediction: str
-      polyphen2_humvar_score: float

--- a/data_source_schemas/hsa/PolyPhen_2.yaml
+++ b/data_source_schemas/hsa/PolyPhen_2.yaml
@@ -4,13 +4,12 @@ nodes:
   snp:
     url: https://hgdownload.soe.ucsc.edu/gbdb/hg38/dbNsfp/dbNsfpPolyPhen2.bb
     input_label: snp
-    output_label: snp
-    description: A variant with PolyPhen-2 predictions for the impact of amino acid
-      substitutions on protein structure and function
+    description: A single nucleotide polymorphism (SNP) is a variation in a single
+      nucleotide that occurs at a specific position in the genome
     properties:
-      polyphen2_humdiv_score: float
       alt: str
-      polyphen2_humvar_score: float
       polyphen2_humdiv_prediction: str
-      ref: str
+      polyphen2_humdiv_score: float
       polyphen2_humvar_prediction: str
+      polyphen2_humvar_score: float
+      ref: str

--- a/data_source_schemas/hsa/REACTOME.yaml
+++ b/data_source_schemas/hsa/REACTOME.yaml
@@ -4,23 +4,118 @@ nodes:
   pathway:
     url: https://reactome.org
     input_label: pathway
-    output_label: pathway
     properties:
-      pathway_name: str
-      taxon_id: str
       evidence: str
+      pathway_name: str
       pathway_url: str
+      taxon_id: str
   reaction:
     url: https://reactome.org
     input_label: reaction
-    output_label: reaction
     properties:
-      taxon_id: str
       evidence: str
-      reaction_url: str
       pubmed_url: str
       reaction_name: str
+      reaction_url: str
+      taxon_id: str
 relationships:
+  reaction to pathway association:
+    url: https://reactome.org
+    input_label: reaction_to_pathway
+    output_label: part_of
+    description: holds between a reaction and a pathway
+    source: reaction
+    target: pathway
+  input role protein to pathway association:
+    url: https://reactome.org
+    input_label: protein_enables_pathway
+    output_label: enables
+    description: holds between a protein playing an input role in a pathway
+    source: protein
+    target: pathway
+    properties:
+      relation_ontology_term: str
+  input role protein to reaction association:
+    url: https://reactome.org
+    input_label: protein_enables_reaction
+    output_label: enables
+    description: holds between a protein playing an input role in a reaction
+    source: protein
+    target: reaction
+    properties:
+      relation_ontology_term: str
+  output role protein to pathway association:
+    url: https://reactome.org
+    input_label: protein_produced_by_pathway
+    output_label: produced_by
+    description: holds between a protein produced by a pathway
+    source: protein
+    target: pathway
+    properties:
+      relation_ontology_term: str
+  output role protein to reaction association:
+    url: https://reactome.org
+    input_label: protein_produced_by_reaction
+    output_label: produced_by
+    description: holds between a protein produced by a reaction
+    source: protein
+    target: reaction
+    properties:
+      relation_ontology_term: str
+  catalyst protein to pathway association:
+    url: https://reactome.org
+    input_label: protein_regulates_pathway
+    output_label: regulates
+    description: holds between a protein playing a catalyst role in a pathway
+    source: protein
+    target: pathway
+    properties:
+      relation_ontology_term: str
+  catalyst protein to reaction association:
+    url: https://reactome.org
+    input_label: protein_regulates_reaction
+    output_label: regulates
+    description: holds between a protein playing a catalyst role in a reaction
+    source: protein
+    target: reaction
+    properties:
+      relation_ontology_term: str
+  negative role protein to pathway association:
+    url: https://reactome.org
+    input_label: protein_negatively_regulates_pathway
+    output_label: negatively_regulates
+    description: holds between a protein negatively regulating a pathway
+    source: protein
+    target: pathway
+    properties:
+      relation_ontology_term: str
+  negative role protein to reaction association:
+    url: https://reactome.org
+    input_label: protein_negatively_regulates_reaction
+    output_label: negatively_regulates
+    description: holds between a protein negatively regulating a reaction
+    source: protein
+    target: reaction
+    properties:
+      relation_ontology_term: str
+  positive role protein to pathway association:
+    url: https://reactome.org
+    input_label: protein_positively_regulates_pathway
+    output_label: positively_regulates
+    description: holds between a protein positively regulating a pathway
+    source: protein
+    target: pathway
+    properties:
+      relation_ontology_term: str
+  positive role protein to reaction association:
+    url: https://reactome.org
+    input_label: protein_positively_regulates_reaction
+    output_label: positively_regulates
+    description: holds between a protein positively regulating a reaction
+    source: protein
+    target: reaction
+    properties:
+      relation_ontology_term: str
   gene to pathway association:
     url: https://reactome.org
     input_label: genes_pathways
@@ -46,66 +141,23 @@ relationships:
     url: https://reactome.org
     input_label: gene_or_gene_product_reaction
     output_label: involved_in
-    description: An interaction between a gene and a molecular activity.
+    description: An interaction between a gene and a reaction (Reactome).
     source: gene
     target: reaction
   protein to reaction association:
     url: https://reactome.org
     input_label: protein_reaction
     output_label: involved_in
-    description: An interaction between a protein and a molecular activity.
+    description: An interaction between a protein and a reaction (Reactome).
     source: protein
     target: reaction
   transcript to reaction association:
     url: https://reactome.org
     input_label: transcript_reaction
     output_label: involved_in
-    description: An interaction between a transcript and a molecular activity.
+    description: An interaction between a transcript and a reaction (Reactome).
     source: transcript
     target: reaction
-  parent pathway of:
-    url: https://reactome.org
-    input_label: parent_pathway_of
-    output_label: parent pathway of
-    description: holds between two pathways where the domain class is a parent pathway
-      of the range class
-    source: pathway
-    target: pathway
-  child pathway of:
-    url: https://reactome.org
-    input_label: child_pathway_of
-    output_label: child pathway of
-    description: holds between two pathways where the domain class is a child pathway
-      of the range class
-    source: pathway
-    target: pathway
-  pathway_to_biological_process:
-    url: https://reactome.org
-    input_label: pathway_to_biological_process
-    output_label: equivalent_to
-    description: An association between a pathway and a biological process, indicating
-      that the pathway is involved in the process.
-    source: pathway
-    target: biological_process
-    properties:
-      pathway_name: str
-      go_term_id: str
-  post translational interaction:
-    url: https://reactome.org/
-    input_label: interacts_with
-    output_label: post translational interaction
-    source: protein
-    target: protein
-    properties:
-      interaction_type: str
-      reactome_pathway: str
-  reaction to pathway association:
-    url: https://reactome.org
-    input_label: reaction_to_pathway
-    output_label: part_of
-    description: holds between a reaction and a pathway
-    source: reaction
-    target: pathway
   small molecule to pathway association:
     url: https://reactome.org
     input_label: small_molecule_to_pathway
@@ -120,3 +172,46 @@ relationships:
     description: An interaction between a small molecule (ChEBI) and a reaction (Reactome).
     source: small molecule
     target: reaction
+  parent pathway of:
+    url: https://reactome.org
+    input_label: parent_pathway_of
+    description: holds between two pathways where the domain class is a parent pathway
+      of the range class
+    source: pathway
+    target: pathway
+  child pathway of:
+    url: https://reactome.org
+    input_label: child_pathway_of
+    description: holds between two pathways where the domain class is a child pathway
+      of the range class
+    source: pathway
+    target: pathway
+  pathway_to_biological_process:
+    url: https://reactome.org
+    input_label: pathway_to_biological_process
+    output_label: equivalent_to
+    description: An association between a pathway and a biological process, indicating
+      that the pathway is involved in the process.
+    source: pathway
+    target: biological process
+  post translational interaction:
+    url: https://reactome.org/
+    input_label: interacts_with
+    source: protein
+    target: protein
+    properties:
+      interaction_type: str
+  pathway_to_molecular_function:
+    url: https://reactome.org
+    input_label: pathway_to_molecular_function
+    description: An association between a pathway and a molecular function, indicating
+      that the pathway is involved in the function.
+    source: pathway
+    target: molecular function
+  pathway_to_cellular_component:
+    url: https://reactome.org
+    input_label: pathway_to_cellular_component
+    description: An association between a pathway and a cellular component, indicating
+      that the pathway is associated with the component.
+    source: pathway
+    target: cellular component

--- a/data_source_schemas/hsa/REACTOME.yaml
+++ b/data_source_schemas/hsa/REACTOME.yaml
@@ -9,6 +9,7 @@ nodes:
       pathway_name: str
       taxon_id: str
       evidence: str
+      pathway_url: str
   reaction:
     url: https://reactome.org
     input_label: reaction
@@ -17,6 +18,8 @@ nodes:
       taxon_id: str
       evidence: str
       reaction_url: str
+      pubmed_url: str
+      reaction_name: str
 relationships:
   gene to pathway association:
     url: https://reactome.org
@@ -63,7 +66,7 @@ relationships:
   parent pathway of:
     url: https://reactome.org
     input_label: parent_pathway_of
-    output_label: parent_pathway_of
+    output_label: parent pathway of
     description: holds between two pathways where the domain class is a parent pathway
       of the range class
     source: pathway
@@ -71,7 +74,7 @@ relationships:
   child pathway of:
     url: https://reactome.org
     input_label: child_pathway_of
-    output_label: child_pathway_of
+    output_label: child pathway of
     description: holds between two pathways where the domain class is a child pathway
       of the range class
     source: pathway
@@ -90,9 +93,30 @@ relationships:
   post translational interaction:
     url: https://reactome.org/
     input_label: interacts_with
-    output_label: interacts_with
+    output_label: post translational interaction
     source: protein
     target: protein
     properties:
       interaction_type: str
       reactome_pathway: str
+  reaction to pathway association:
+    url: https://reactome.org
+    input_label: reaction_to_pathway
+    output_label: part_of
+    description: holds between a reaction and a pathway
+    source: reaction
+    target: pathway
+  small molecule to pathway association:
+    url: https://reactome.org
+    input_label: small_molecule_to_pathway
+    output_label: participates_in
+    description: An interaction between a small molecule (ChEBI) and a pathway (Reactome).
+    source: small molecule
+    target: pathway
+  small molecule to reaction association:
+    url: https://reactome.org
+    input_label: small_molecule_to_reaction
+    output_label: participates_in
+    description: An interaction between a small molecule (ChEBI) and a reaction (Reactome).
+    source: small molecule
+    target: reaction

--- a/data_source_schemas/hsa/RNAcentral.yaml
+++ b/data_source_schemas/hsa/RNAcentral.yaml
@@ -4,29 +4,28 @@ nodes:
   non coding rna:
     url: https://rnacentral.org/downloads
     input_label: non_coding_rna
-    output_label: non coding rna
     properties:
-      end: int
-      taxon_id: int
-      start: int
       chr: str
+      end: int
       rna_type: str
+      start: int
+      taxon_id: int
 relationships:
   biological process rna:
     url: https://rnacentral.org/downloads
     input_label: biological_process_rna
     output_label: participates_in
-    source: non_coding_rna
-    target: biological_process
+    source: non coding rna
+    target: biological process
   molecular function rna:
     url: https://rnacentral.org/downloads
     input_label: molecular_function_rna
     output_label: enables
-    source: non_coding_rna
-    target: molecular_function
+    source: non coding rna
+    target: molecular function
   cellular component rna:
     url: https://rnacentral.org/downloads
     input_label: cellular_component_rna
     output_label: located_in
-    source: non_coding_rna
-    target: cellular_component
+    source: non coding rna
+    target: cellular component

--- a/data_source_schemas/hsa/RNAcentral.yaml
+++ b/data_source_schemas/hsa/RNAcentral.yaml
@@ -1,16 +1,16 @@
 name: RNAcentral
 website: https://rnacentral.org
 nodes:
-  non_coding_rna:
+  non coding rna:
     url: https://rnacentral.org/downloads
     input_label: non_coding_rna
-    output_label: non_coding_rna
+    output_label: non coding rna
     properties:
-      taxon_id: int
-      rna_type: str
       end: int
+      taxon_id: int
       start: int
       chr: str
+      rna_type: str
 relationships:
   biological process rna:
     url: https://rnacentral.org/downloads

--- a/data_source_schemas/hsa/RefSeq_Closest_Gene.yaml
+++ b/data_source_schemas/hsa/RefSeq_Closest_Gene.yaml
@@ -4,12 +4,11 @@ relationships:
   closest gene to variant association:
     url: https://forgedb.cancer.gov/api/closest_gene/v1.0/closest_gene.forgedb.csv.gz
     input_label: closest_gene
-    output_label: closest gene to variant association
     description: holds between a sequence variant and a gene that is closest to the
       variant
     source: snp
     target: gene
     properties:
+      chr: str
       distance: int
       pos: int
-      chr: str

--- a/data_source_schemas/hsa/RefSeq_Closest_Gene.yaml
+++ b/data_source_schemas/hsa/RefSeq_Closest_Gene.yaml
@@ -4,12 +4,12 @@ relationships:
   closest gene to variant association:
     url: https://forgedb.cancer.gov/api/closest_gene/v1.0/closest_gene.forgedb.csv.gz
     input_label: closest_gene
-    output_label: closest_gene
+    output_label: closest gene to variant association
     description: holds between a sequence variant and a gene that is closest to the
       variant
     source: snp
     target: gene
     properties:
-      chr: str
-      pos: int
       distance: int
+      pos: int
+      chr: str

--- a/data_source_schemas/hsa/Roadmap_Epigenomics_Project.yaml
+++ b/data_source_schemas/hsa/Roadmap_Epigenomics_Project.yaml
@@ -4,7 +4,7 @@ relationships:
   chromatin state snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
     input_label: chromatin_state
-    output_label: chromatin_state
+    output_label: chromatin state snp to anatomy
     description: Association between a SNP and a chromatin state in an anatomy context
     source: snp
     target: anatomy
@@ -32,7 +32,8 @@ relationships:
     url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
     input_label: chromatin_state
     output_label: chromatin_state
-    description: Association between a SNP and a chromatin state in an experimental factor context
+    description: Association between a SNP and a chromatin state in an experimental
+      factor context
     source: snp
     target: experimental_factor
     properties:
@@ -49,8 +50,9 @@ relationships:
   histone modification snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
     input_label: histone_modification
-    output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation, acetylation, phosphorylation in an anatomy context
+    output_label: histone modification snp to anatomy
+    description: A post-translational modification of histone proteins e.g methylation,
+      acetylation, phosphorylation in an anatomy context
     source: snp
     target: anatomy
     properties:
@@ -59,7 +61,8 @@ relationships:
     url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
     input_label: histone_modification
     output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation, acetylation, phosphorylation in a cell type context
+    description: A post-translational modification of histone proteins e.g methylation,
+      acetylation, phosphorylation in a cell type context
     source: snp
     target: cell_type
     properties:
@@ -68,7 +71,8 @@ relationships:
     url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
     input_label: histone_modification
     output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation, acetylation, phosphorylation in a cell line context
+    description: A post-translational modification of histone proteins e.g methylation,
+      acetylation, phosphorylation in a cell line context
     source: snp
     target: cell_line
     properties:
@@ -77,7 +81,8 @@ relationships:
     url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
     input_label: histone_modification
     output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation, acetylation, phosphorylation in an experimental factor context
+    description: A post-translational modification of histone proteins e.g methylation,
+      acetylation, phosphorylation in an experimental factor context
     source: snp
     target: experimental_factor
     properties:
@@ -86,7 +91,8 @@ relationships:
     url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
     input_label: histone_modification
     output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation, acetylation, phosphorylation in a tissue context
+    description: A post-translational modification of histone proteins e.g methylation,
+      acetylation, phosphorylation in a tissue context
     source: snp
     target: tissue
     properties:
@@ -94,35 +100,40 @@ relationships:
   dnase I hotspot snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
     input_label: in_dnase_I_hotspot
-    output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme DNase I in an anatomy context
+    output_label: dnase I hotspot snp to anatomy
+    description: A region of chromatin that is sensitive to cleavage by the enzyme
+      DNase I in an anatomy context
     source: snp
     target: anatomy
   dnase I hotspot snp to cell type:
     url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
     input_label: in_dnase_I_hotspot
     output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme DNase I in a cell type context
+    description: A region of chromatin that is sensitive to cleavage by the enzyme
+      DNase I in a cell type context
     source: snp
     target: cell_type
   dnase I hotspot snp to cell line:
     url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
     input_label: in_dnase_I_hotspot
     output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme DNase I in a cell line context
+    description: A region of chromatin that is sensitive to cleavage by the enzyme
+      DNase I in a cell line context
     source: snp
     target: cell_line
   dnase I hotspot snp to experimental factor:
     url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
     input_label: in_dnase_I_hotspot
     output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme DNase I in an experimental factor context
+    description: A region of chromatin that is sensitive to cleavage by the enzyme
+      DNase I in an experimental factor context
     source: snp
     target: experimental_factor
   dnase I hotspot snp to tissue:
     url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
     input_label: in_dnase_I_hotspot
     output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme DNase I in a tissue context
+    description: A region of chromatin that is sensitive to cleavage by the enzyme
+      DNase I in a tissue context
     source: snp
     target: tissue

--- a/data_source_schemas/hsa/Roadmap_Epigenomics_Project.yaml
+++ b/data_source_schemas/hsa/Roadmap_Epigenomics_Project.yaml
@@ -4,136 +4,21 @@ relationships:
   chromatin state snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
     input_label: chromatin_state
-    output_label: chromatin state snp to anatomy
-    description: Association between a SNP and a chromatin state in an anatomy context
     source: snp
     target: anatomy
-    properties:
-      state: str
-  chromatin state snp to cell type:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
-    input_label: chromatin_state
-    output_label: chromatin_state
-    description: Association between a SNP and a chromatin state in a cell type context
-    source: snp
-    target: cell_type
-    properties:
-      state: str
-  chromatin state snp to cell line:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
-    input_label: chromatin_state
-    output_label: chromatin_state
-    description: Association between a SNP and a chromatin state in a cell line context
-    source: snp
-    target: cell_line
-    properties:
-      state: str
-  chromatin state snp to experimental factor:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
-    input_label: chromatin_state
-    output_label: chromatin_state
-    description: Association between a SNP and a chromatin state in an experimental
-      factor context
-    source: snp
-    target: experimental_factor
-    properties:
-      state: str
-  chromatin state snp to tissue:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
-    input_label: chromatin_state
-    output_label: chromatin_state
-    description: Association between a SNP and a chromatin state in a tissue context
-    source: snp
-    target: tissue
     properties:
       state: str
   histone modification snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
     input_label: histone_modification
-    output_label: histone modification snp to anatomy
     description: A post-translational modification of histone proteins e.g methylation,
-      acetylation, phosphorylation in an anatomy context
+      acetylation, phosphorylation
     source: snp
     target: anatomy
-    properties:
-      modification: str
-  histone modification snp to cell type:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
-    input_label: histone_modification
-    output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation,
-      acetylation, phosphorylation in a cell type context
-    source: snp
-    target: cell_type
-    properties:
-      modification: str
-  histone modification snp to cell line:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
-    input_label: histone_modification
-    output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation,
-      acetylation, phosphorylation in a cell line context
-    source: snp
-    target: cell_line
-    properties:
-      modification: str
-  histone modification snp to experimental factor:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
-    input_label: histone_modification
-    output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation,
-      acetylation, phosphorylation in an experimental factor context
-    source: snp
-    target: experimental_factor
-    properties:
-      modification: str
-  histone modification snp to tissue:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
-    input_label: histone_modification
-    output_label: histone_modification
-    description: A post-translational modification of histone proteins e.g methylation,
-      acetylation, phosphorylation in a tissue context
-    source: snp
-    target: tissue
-    properties:
-      modification: str
   dnase I hotspot snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
     input_label: in_dnase_I_hotspot
-    output_label: dnase I hotspot snp to anatomy
     description: A region of chromatin that is sensitive to cleavage by the enzyme
-      DNase I in an anatomy context
+      DNase I
     source: snp
     target: anatomy
-  dnase I hotspot snp to cell type:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
-    input_label: in_dnase_I_hotspot
-    output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme
-      DNase I in a cell type context
-    source: snp
-    target: cell_type
-  dnase I hotspot snp to cell line:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
-    input_label: in_dnase_I_hotspot
-    output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme
-      DNase I in a cell line context
-    source: snp
-    target: cell_line
-  dnase I hotspot snp to experimental factor:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
-    input_label: in_dnase_I_hotspot
-    output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme
-      DNase I in an experimental factor context
-    source: snp
-    target: experimental_factor
-  dnase I hotspot snp to tissue:
-    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
-    input_label: in_dnase_I_hotspot
-    output_label: in_dnase_I_hotspot
-    description: A region of chromatin that is sensitive to cleavage by the enzyme
-      DNase I in a tissue context
-    source: snp
-    target: tissue

--- a/data_source_schemas/hsa/Roadmap_Epigenomics_Project.yaml
+++ b/data_source_schemas/hsa/Roadmap_Epigenomics_Project.yaml
@@ -8,6 +8,34 @@ relationships:
     target: anatomy
     properties:
       state: str
+  chromatin state snp to cell type:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
+    input_label: chromatin_state
+    source: snp
+    target: cell type
+    properties:
+      state: str
+  chromatin state snp to cell line:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
+    input_label: chromatin_state
+    source: snp
+    target: cell line
+    properties:
+      state: str
+  chromatin state snp to experimental factor:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
+    input_label: chromatin_state
+    source: snp
+    target: experimental factor
+    properties:
+      state: str
+  chromatin state snp to tissue:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-chromatin15state-all/v1.0/forge2.erc2-chromatin15state-all.{0-9}.forgedb.csv.gz
+    input_label: chromatin_state
+    source: snp
+    target: tissue
+    properties:
+      state: str
   histone modification snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
     input_label: histone_modification
@@ -15,6 +43,26 @@ relationships:
       acetylation, phosphorylation
     source: snp
     target: anatomy
+  histone modification snp to cell type:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
+    input_label: histone_modification
+    source: snp
+    target: cell type
+  histone modification snp to cell line:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
+    input_label: histone_modification
+    source: snp
+    target: cell line
+  histone modification snp to experimental factor:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
+    input_label: histone_modification
+    source: snp
+    target: experimental factor
+  histone modification snp to tissue:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-H3-all/v1.0/forge2.erc2-H3-all.{0-9}.forgedb.csv.gz
+    input_label: histone_modification
+    source: snp
+    target: tissue
   dnase I hotspot snp to anatomy:
     url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
     input_label: in_dnase_I_hotspot
@@ -22,3 +70,23 @@ relationships:
       DNase I
     source: snp
     target: anatomy
+  dnase I hotspot snp to cell type:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
+    input_label: in_dnase_I_hotspot
+    source: snp
+    target: cell type
+  dnase I hotspot snp to cell line:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
+    input_label: in_dnase_I_hotspot
+    source: snp
+    target: cell line
+  dnase I hotspot snp to experimental factor:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
+    input_label: in_dnase_I_hotspot
+    source: snp
+    target: experimental factor
+  dnase I hotspot snp to tissue:
+    url: https://forgedb.cancer.gov/api/forge2.erc2-DHS/v1.0/forge2.erc2-DHS.forgedb.csv.gz
+    input_label: in_dnase_I_hotspot
+    source: snp
+    target: tissue

--- a/data_source_schemas/hsa/STRING.yaml
+++ b/data_source_schemas/hsa/STRING.yaml
@@ -4,7 +4,7 @@ relationships:
   post translational interaction:
     url: https://string-db.org/
     input_label: interacts_with
-    output_label: interacts_with
+    output_label: post translational interaction
     source: protein
     target: protein
     properties:
@@ -13,7 +13,19 @@ relationships:
     url: https://string-db.org/
     input_label: protein_coexpressed_with
     output_label: coexpressed_with
-    description: Proteins whose genes are co-expressed according to STRING coexpression scores.
+    description: Proteins whose genes are co-expressed according to STRING coexpression
+      scores.
+    source: protein
+    target: protein
+    properties:
+      coexpression_score: float
+  protein to protein coexpression association:
+    url: https://string-db.org/
+    input_label: protein_coexpressed_with
+    output_label: coexpressed_with
+    description: Indicates that two proteins are co-expressed, generally under the
+      same conditions, as measured at the protein/transcript level (e.g. STRING coexpression
+      channel).
     source: protein
     target: protein
     properties:

--- a/data_source_schemas/hsa/STRING.yaml
+++ b/data_source_schemas/hsa/STRING.yaml
@@ -4,21 +4,10 @@ relationships:
   post translational interaction:
     url: https://string-db.org/
     input_label: interacts_with
-    output_label: post translational interaction
     source: protein
     target: protein
     properties:
       score: float
-  protein coexpression:
-    url: https://string-db.org/
-    input_label: protein_coexpressed_with
-    output_label: coexpressed_with
-    description: Proteins whose genes are co-expressed according to STRING coexpression
-      scores.
-    source: protein
-    target: protein
-    properties:
-      coexpression_score: float
   protein to protein coexpression association:
     url: https://string-db.org/
     input_label: protein_coexpressed_with

--- a/data_source_schemas/hsa/TADMap.yaml
+++ b/data_source_schemas/hsa/TADMap.yaml
@@ -4,17 +4,15 @@ nodes:
   tad:
     url: https://cb.csail.mit.edu/cb/tadmap/
     input_label: tad
-    output_label: tad
     properties:
-      end: int
-      taxon_id: int
-      start: int
       chr: str
+      end: int
+      start: int
+      taxon_id: int
 relationships:
   gene in tad region:
     url: https://cb.csail.mit.edu/cb/tadmap/
     input_label: in_tad_region
-    output_label: gene in tad region
     description: holds between a tad and a gene that is in the tad region
     source: gene
     target: tad

--- a/data_source_schemas/hsa/TADMap.yaml
+++ b/data_source_schemas/hsa/TADMap.yaml
@@ -6,15 +6,15 @@ nodes:
     input_label: tad
     output_label: tad
     properties:
-      taxon_id: int
       end: int
+      taxon_id: int
       start: int
       chr: str
 relationships:
   gene in tad region:
     url: https://cb.csail.mit.edu/cb/tadmap/
     input_label: in_tad_region
-    output_label: in_tad_region
+    output_label: gene in tad region
     description: holds between a tad and a gene that is in the tad region
     source: gene
     target: tad

--- a/data_source_schemas/hsa/TFLink.yaml
+++ b/data_source_schemas/hsa/TFLink.yaml
@@ -10,7 +10,13 @@ relationships:
     source: gene
     target: gene
     properties:
-      evidence: str
+      detection_method: str
       evidence_type: str
       database: str
-      detection_method: str
+      evidence: str
+  post translational interaction:
+    url: tflink.net
+    input_label: interacts_with
+    output_label: interacts_with
+    source: protein
+    target: protein

--- a/data_source_schemas/hsa/TFLink.yaml
+++ b/data_source_schemas/hsa/TFLink.yaml
@@ -10,13 +10,7 @@ relationships:
     source: gene
     target: gene
     properties:
-      detection_method: str
-      evidence_type: str
       database: str
+      detection_method: str
       evidence: str
-  post translational interaction:
-    url: tflink.net
-    input_label: interacts_with
-    output_label: interacts_with
-    source: protein
-    target: protein
+      evidence_type: str

--- a/data_source_schemas/hsa/TopLD.yaml
+++ b/data_source_schemas/hsa/TopLD.yaml
@@ -4,12 +4,11 @@ relationships:
   topld in linkage disequilibrium with:
     url: http://topld.genetics.unc.edu/
     input_label: in_linkage_disequilibrium_with
-    output_label: topld in linkage disequilibrium with
     description: holds between two sequence variants, the presence of which are correlated
       in a population
     source: snp
     target: snp
     properties:
-      d_prime: float
       ancestry: str
+      d_prime: float
       r2: float

--- a/data_source_schemas/hsa/TopLD.yaml
+++ b/data_source_schemas/hsa/TopLD.yaml
@@ -4,12 +4,12 @@ relationships:
   topld in linkage disequilibrium with:
     url: http://topld.genetics.unc.edu/
     input_label: in_linkage_disequilibrium_with
-    output_label: in_linkage_disequilibrium_with
+    output_label: topld in linkage disequilibrium with
     description: holds between two sequence variants, the presence of which are correlated
       in a population
     source: snp
     target: snp
     properties:
-      r2: float
-      ancestry: str
       d_prime: float
+      ancestry: str
+      r2: float

--- a/data_source_schemas/hsa/UniProt.yaml
+++ b/data_source_schemas/hsa/UniProt.yaml
@@ -7,11 +7,16 @@ nodes:
     output_label: protein
     properties:
       protein_name: str
+      canonical_accession: str
+      accessions: str[]
+      isoform_name: str
+      is_canonical: bool
+      is_isoform: bool
 relationships:
   translates to:
     url: https://www.uniprot.org/
     input_label: translates_to
-    output_label: translates_to
+    output_label: translates to
     description: x (amino acid chain/polypeptide) is the ribosomal translation of
       y (transcript) if and only if a ribosome reads y (transcript) through a series
       of triplet codon-amino acid adaptor activities (GO:0030533) and produces x (amino
@@ -24,33 +29,77 @@ relationships:
     output_label: has_xref
     source: protein
     target: gene
+    properties:
+      evidence: str[]
   protein has_xref transcript:
     url: https://www.uniprot.org/
     input_label: protein_has_xref_transcript
     output_label: has_xref
     source: protein
     target: transcript
+    properties:
+      evidence: str[]
   protein has_xref protein:
     url: https://www.uniprot.org/
     input_label: protein_has_xref_protein
     output_label: has_xref
     source: protein
     target: protein
+    properties:
+      evidence: str[]
   protein has_xref biological_process:
     url: https://www.uniprot.org/
     input_label: protein_has_xref_biological_process
     output_label: has_xref
     source: protein
     target: biological_process
+    properties:
+      evidence: str[]
   protein has_xref cellular_component:
     url: https://www.uniprot.org/
     input_label: protein_has_xref_cellular_component
     output_label: has_xref
     source: protein
     target: cellular_component
+    properties:
+      evidence: str[]
   protein has_xref molecular_function:
     url: https://www.uniprot.org/
     input_label: protein_has_xref_molecular_function
     output_label: has_xref
     source: protein
     target: molecular_function
+    properties:
+      evidence: str[]
+  protein has_xref catalytic_activity:
+    url: https://www.uniprot.org/
+    input_label: protein_has_xref_catalytic_activity
+    output_label: has_xref
+    source: protein
+    target: small molecule
+    properties:
+      evidence: str[]
+  protein has_xref cofactor:
+    url: https://www.uniprot.org/
+    input_label: protein_has_xref_cofactor
+    output_label: has_xref
+    source: protein
+    target: small molecule
+    properties:
+      evidence: str[]
+  protein has_xref binding_site_ligand:
+    url: https://www.uniprot.org/
+    input_label: protein_has_xref_binding_site_ligand
+    output_label: has_xref
+    source: protein
+    target: small molecule
+    properties:
+      evidence: str[]
+  chemical_substance part_of chemical_substance:
+    url: https://www.uniprot.org/
+    input_label: chemical_substance_part_of_chemical_substance
+    output_label: part_of
+    source: small molecule
+    target: small molecule
+    properties:
+      evidence: str[]

--- a/data_source_schemas/hsa/UniProt.yaml
+++ b/data_source_schemas/hsa/UniProt.yaml
@@ -4,19 +4,17 @@ nodes:
   protein:
     url: https://www.uniprot.org/
     input_label: protein
-    output_label: protein
     properties:
-      protein_name: str
-      canonical_accession: str
       accessions: str[]
-      isoform_name: str
+      canonical_accession: str
       is_canonical: bool
       is_isoform: bool
+      isoform_name: str
+      protein_name: str
 relationships:
   translates to:
     url: https://www.uniprot.org/
     input_label: translates_to
-    output_label: translates to
     description: x (amino acid chain/polypeptide) is the ribosomal translation of
       y (transcript) if and only if a ribosome reads y (transcript) through a series
       of triplet codon-amino acid adaptor activities (GO:0030533) and produces x (amino
@@ -52,7 +50,7 @@ relationships:
     input_label: protein_has_xref_biological_process
     output_label: has_xref
     source: protein
-    target: biological_process
+    target: biological process
     properties:
       evidence: str[]
   protein has_xref cellular_component:
@@ -60,7 +58,7 @@ relationships:
     input_label: protein_has_xref_cellular_component
     output_label: has_xref
     source: protein
-    target: cellular_component
+    target: cellular component
     properties:
       evidence: str[]
   protein has_xref molecular_function:
@@ -68,7 +66,7 @@ relationships:
     input_label: protein_has_xref_molecular_function
     output_label: has_xref
     source: protein
-    target: molecular_function
+    target: molecular function
     properties:
       evidence: str[]
   protein has_xref catalytic_activity:

--- a/data_source_schemas/hsa/dbSNP.yaml
+++ b/data_source_schemas/hsa/dbSNP.yaml
@@ -4,14 +4,13 @@ nodes:
   snp:
     url: https://ftp.ncbi.nih.gov/snp/organisms/human_9606_b151_GRCh38p7/VCF/
     input_label: snp
-    output_label: snp
     description: A single nucleotide polymorphism (SNP) is a variation in a single
       nucleotide that occurs at a specific position in the genome
     properties:
+      alt: str
       caf_alt: str
       caf_ref: str
+      chr: str
       end: int
-      alt: str
       ref: str
       start: int
-      chr: str

--- a/data_source_schemas/hsa/dbSNP.yaml
+++ b/data_source_schemas/hsa/dbSNP.yaml
@@ -8,10 +8,10 @@ nodes:
     description: A single nucleotide polymorphism (SNP) is a variation in a single
       nucleotide that occurs at a specific position in the genome
     properties:
+      caf_alt: str
+      caf_ref: str
       end: int
+      alt: str
+      ref: str
       start: int
       chr: str
-      alt: str
-      caf_ref: str
-      caf_alt: str
-      ref: str

--- a/data_source_schemas/hsa/dbSuper.yaml
+++ b/data_source_schemas/hsa/dbSuper.yaml
@@ -1,16 +1,16 @@
 name: dbSuper
 website: https://asntech.org
 nodes:
-  super_enhancer:
+  super enhancer:
     url: https://asntech.org/dbsuper/download.php
     input_label: super_enhancer
-    output_label: super_enhancer
+    output_label: super enhancer
     properties:
       end: int
-      biological_context: str
       start: int
-      chr: str
       se_id: str
+      chr: str
+      biological_context: str
 relationships:
   super enhancer to gene association:
     url: https://asntech.org/dbsuper/download.php

--- a/data_source_schemas/hsa/dbSuper.yaml
+++ b/data_source_schemas/hsa/dbSuper.yaml
@@ -4,20 +4,19 @@ nodes:
   super enhancer:
     url: https://asntech.org/dbsuper/download.php
     input_label: super_enhancer
-    output_label: super enhancer
     properties:
-      end: int
-      start: int
-      se_id: str
-      chr: str
       biological_context: str
+      chr: str
+      end: int
+      se_id: str
+      start: int
 relationships:
   super enhancer to gene association:
     url: https://asntech.org/dbsuper/download.php
     input_label: super_enhancer_gene
     output_label: associated_with
     description: An association between a super enhancer and a gene
-    source: super_enhancer
+    source: super enhancer
     target: gene
     properties:
       biological_context: str

--- a/data_source_schemas/hsa/dbVar.yaml
+++ b/data_source_schemas/hsa/dbVar.yaml
@@ -11,5 +11,5 @@ nodes:
     properties:
       end: int
       start: int
-      chr: str
       variant_type: str
+      chr: str

--- a/data_source_schemas/hsa/dbVar.yaml
+++ b/data_source_schemas/hsa/dbVar.yaml
@@ -4,12 +4,48 @@ nodes:
   structural variant:
     url: https://www.ncbi.nlm.nih.gov/dbvar/content/ftp_manifest/
     input_label: structural_variant
-    output_label: structural_variant
     description: A structural variant is a larger scale genomic alteration that affects
       the structure of chromosomes, such as deletions, duplications, inversions, and
       translocations.
     properties:
+      chr: str
       end: int
       start: int
       variant_type: str
-      chr: str
+relationships:
+  gene overlaps structural_variant:
+    url: https://www.ncbi.nlm.nih.gov/dbvar/content/ftp_manifest/
+    input_label: gene_overlaps_structural_variant
+    output_label: overlaps
+    source: gene
+    target: structural variant
+  structural_variant overlaps gene:
+    url: https://www.ncbi.nlm.nih.gov/dbvar/content/ftp_manifest/
+    input_label: structural_variant_overlaps_gene
+    output_label: overlaps
+    source: structural variant
+    target: gene
+  non_coding_rna overlaps structural_variant:
+    url: https://www.ncbi.nlm.nih.gov/dbvar/content/ftp_manifest/
+    input_label: non_coding_rna_overlaps_structural_variant
+    output_label: overlaps
+    source: non_coding_rna
+    target: structural variant
+  structural_variant overlaps non_coding_rna:
+    url: https://www.ncbi.nlm.nih.gov/dbvar/content/ftp_manifest/
+    input_label: structural_variant_overlaps_non_coding_rna
+    output_label: overlaps
+    source: structural variant
+    target: non_coding_rna
+  promoter overlaps structural_variant:
+    url: https://www.ncbi.nlm.nih.gov/dbvar/content/ftp_manifest/
+    input_label: promoter_overlaps_structural_variant
+    output_label: overlaps
+    source: promoter
+    target: structural variant
+  structural_variant overlaps promoter:
+    url: https://www.ncbi.nlm.nih.gov/dbvar/content/ftp_manifest/
+    input_label: structural_variant_overlaps_promoter
+    output_label: overlaps
+    source: structural variant
+    target: promoter

--- a/data_source_schemas/hsa/dgv.yaml
+++ b/data_source_schemas/hsa/dgv.yaml
@@ -4,14 +4,50 @@ nodes:
   structural variant:
     url: http://dgv.tcag.ca/dgv/app/downloads
     input_label: structural_variant
-    output_label: structural_variant
     description: A structural variant is a larger scale genomic alteration that affects
       the structure of chromosomes, such as deletions, duplications, inversions, and
       translocations.
     properties:
-      end: int
-      start: int
-      variant_type: str
-      variant_accession: str
       chr: str
+      end: int
       evidence: str
+      start: int
+      variant_accession: str
+      variant_type: str
+relationships:
+  gene overlaps structural_variant:
+    url: http://dgv.tcag.ca/dgv/app/downloads
+    input_label: gene_overlaps_structural_variant
+    output_label: overlaps
+    source: gene
+    target: structural variant
+  structural_variant overlaps gene:
+    url: http://dgv.tcag.ca/dgv/app/downloads
+    input_label: structural_variant_overlaps_gene
+    output_label: overlaps
+    source: structural variant
+    target: gene
+  non_coding_rna overlaps structural_variant:
+    url: http://dgv.tcag.ca/dgv/app/downloads
+    input_label: non_coding_rna_overlaps_structural_variant
+    output_label: overlaps
+    source: non_coding_rna
+    target: structural variant
+  structural_variant overlaps non_coding_rna:
+    url: http://dgv.tcag.ca/dgv/app/downloads
+    input_label: structural_variant_overlaps_non_coding_rna
+    output_label: overlaps
+    source: structural variant
+    target: non_coding_rna
+  promoter overlaps structural_variant:
+    url: http://dgv.tcag.ca/dgv/app/downloads
+    input_label: promoter_overlaps_structural_variant
+    output_label: overlaps
+    source: promoter
+    target: structural variant
+  structural_variant overlaps promoter:
+    url: http://dgv.tcag.ca/dgv/app/downloads
+    input_label: structural_variant_overlaps_promoter
+    output_label: overlaps
+    source: structural variant
+    target: promoter

--- a/data_source_schemas/hsa/dgv.yaml
+++ b/data_source_schemas/hsa/dgv.yaml
@@ -10,8 +10,8 @@ nodes:
       translocations.
     properties:
       end: int
-      evidence: str
       start: int
-      chr: str
-      variant_accession: str
       variant_type: str
+      variant_accession: str
+      chr: str
+      evidence: str

--- a/schema_generator/README.md
+++ b/schema_generator/README.md
@@ -71,6 +71,11 @@ uv run python create_knowledge_graph.py \
   --data-source-schema-output-dir data_source_schemas/hsa
 ```
 
+When `--data-source-schema-output-dir` is provided for a single species, the path is
+used directly. With `--species all`, each species is written under that directory
+as `<data-source-schema-output-dir>/<species>`. The default species-mode path
+remains `data_source_schemas/<species>`.
+
 To disable automatic schema generation:
 
 ```bash
@@ -83,7 +88,8 @@ uv run python create_knowledge_graph.py \
 
 Checkpointing is still responsible for the expensive KG adapter work. Datasource schema
 generation is a final post-processing step. If an adapter fails, schemas are not generated.
-If schema generation fails, the checkpoint remains available so the KG run can be resumed.
+If schema generation fails after the KG has been written, the failure is logged and the
+KG run is still allowed to complete.
 
 ### Standalone Script
 
@@ -178,6 +184,7 @@ uv run python schema_generator/generate_data_source_schemas.py \
 - New nodes are appended to the `nodes` section
 - New relationships are appended to the `relationships` section
 - If a node/relationship already exists, its properties are merged (not overwritten)
+- Existing property types are preserved when an entry is regenerated
 - Existing entries remain in place
 
 ### Generate Schema for Specific Data Source(s)
@@ -229,8 +236,8 @@ relationships:
   relationship_type:
     url: https://datasource.org/download
     input_label: edge_label
-    description: Edge description
     output_label: biolink_predicate
+    description: Edge description
     source: source_node_type
     target: target_node_type
     properties:
@@ -264,7 +271,7 @@ Labels are resolved in the following order:
 3. **Init Assignment**: `self.label = 'value'` in `__init__`
 4. **Dynamic Label Candidates**: Schema-valid string values from adapter args
 5. **Adapter Label Maps**: String values from class-level dictionaries used as label maps
-6. **Adapter Literals**: Schema-valid string literals in adapter code
+6. **Label Assignments**: Schema-valid strings assigned to label-like variables or attributes
 7. **Yielded Labels**: Literal string labels yielded from `get_nodes()` or `get_edges()`
 8. **Adapter Name**: Falls back to adapter name as last resort
 
@@ -278,6 +285,9 @@ schema entries when the adapter emits several labels from a map or branch logic.
 All extracted properties are validated against schema_config.yaml:
 - Properties defined in schema → Use schema type (int, float, str, etc.)
 - Properties not in schema → **Excluded** (strict validation)
+
+`output_label` is included only when the schema configuration explicitly defines it.
+If a schema element has no `output_label`, the datasource schema omits that field.
 - Inherited properties → Included via schema inheritance chain
 
 ### 4. Data Source Grouping

--- a/schema_generator/README.md
+++ b/schema_generator/README.md
@@ -18,14 +18,86 @@ This tool analyzes adapter Python files to extract metadata and properties, cros
 
 ## Usage
 
+### Automatic Generation During KG Creation
+
+Datasource schemas are generated automatically when you run `create_knowledge_graph.py`.
+The KG pipeline calls this generator after all selected adapters finish successfully and
+after `graph_info.json` is written.
+
+```bash
+uv run python create_knowledge_graph.py \
+  --species hsa \
+  --dataset sample \
+  --output-dir output/hsa_sample
+```
+
+For a full run:
+
+```bash
+uv run python create_knowledge_graph.py \
+  --species hsa \
+  --dataset full \
+  --output-dir output/hsa_full \
+  --dbsnp-cache-root /path/to/dbsnp \
+  --dbsnp-variant common
+```
+
+The datasource schema generator uses the same adapter config selected by the KG run:
+
+- `--dataset sample` uses `config/<species>/<species>_adapters_config_sample.yaml`
+- `--dataset full` uses `config/<species>/<species>_adapters_config.yaml`
+- `--include-adapters` narrows both the KG generation and datasource schema generation
+- If no `--include-adapters` filter is passed, all adapters in the selected dataset config are analyzed
+
+By default, species-mode output is written to:
+
+```text
+data_source_schemas/<species>
+```
+
+Manual mode writes to:
+
+```text
+<output-dir>/data_source_schemas
+```
+
+To override the schema output directory:
+
+```bash
+uv run python create_knowledge_graph.py \
+  --species hsa \
+  --dataset sample \
+  --output-dir output/hsa_sample \
+  --data-source-schema-output-dir data_source_schemas/hsa
+```
+
+To disable automatic schema generation:
+
+```bash
+uv run python create_knowledge_graph.py \
+  --species hsa \
+  --dataset sample \
+  --output-dir output/hsa_sample \
+  --no-generate-data-source-schemas
+```
+
+Checkpointing is still responsible for the expensive KG adapter work. Datasource schema
+generation is a final post-processing step. If an adapter fails, schemas are not generated.
+If schema generation fails, the checkpoint remains available so the KG run can be resumed.
+
+### Standalone Script
+
+You can still run the generator directly when you want to regenerate schemas without
+building a KG.
+
 ### Generate All Schemas
 
 ```bash
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated
+  --output-dir data_source_schemas/hsa
 ```
 
 ### Generate Schema for Specific Adapter(s)
@@ -34,19 +106,19 @@ Filter by adapter config name (only generates schema for that specific config en
 
 ```bash
 # Single adapter
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --adapter promoter_ccre
 
 # Multiple adapters
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --adapter promoter_ccre \
   --adapter proximal_enhancer_ccre
 ```
@@ -57,19 +129,19 @@ Filter by Python adapter module (generates schema for ALL configs using that ada
 
 ```bash
 # Single module - includes all nodes and edges
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --module candidate_cis_regulatory_promoter_adapter
 
 # Multiple modules
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --module candidate_cis_regulatory_promoter_adapter \
   --module uniprot_protein_adapter
 ```
@@ -82,21 +154,21 @@ The generator supports **incremental/append mode**. If a schema file already exi
 
 ```bash
 # Step 1: Generate schema for promoter adapter
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --module candidate_cis_regulatory_promoter_adapter
 
 # Result: ENCODE.yaml with 1 node (promoter) + 1 relationship
 
 # Step 2: Add enhancer adapter to existing ENCODE.yaml
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --module candidate_cis_regulatory_enhancer_adapter
 
 # Result: ENCODE.yaml now has 2 nodes (promoter, enhancer) + 2 relationships
@@ -112,19 +184,19 @@ python schema_generator/generate_data_source_schemas.py \
 
 ```bash
 # Single data source
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --source "REACTOME"
 
 # Multiple data sources
-python schema_generator/generate_data_source_schemas.py \
-  --schema-config config/schema_config.yaml \
-  --adapter-config config/adapters_config.yaml \
+uv run python schema_generator/generate_data_source_schemas.py \
+  --schema-config config/hsa/hsa_schema_config.yaml \
+  --adapter-config config/hsa/hsa_adapters_config.yaml \
   --adapters-dir biocypher_metta/adapters \
-  --output-dir data_source_schemas_generated \
+  --output-dir data_source_schemas/hsa \
   --source "REACTOME" \
   --source "UniProt"
 ```
@@ -167,6 +239,11 @@ relationships:
 
 ## How It Works
 
+When invoked by `create_knowledge_graph.py`, the generator receives the already-loaded
+adapter dictionary from the KG pipeline. This ensures it analyzes the same adapters that
+were used to build the graph. When run as a standalone script, it loads `--adapter-config`
+from disk.
+
 ### 1. Adapter Analysis
 
 The tool uses AST (Abstract Syntax Tree) parsing to analyze adapter Python files:
@@ -185,7 +262,16 @@ Labels are resolved in the following order:
 1. **Config Args**: `adapter.args.label` in adapters_config.yaml
 2. **Init Signature**: Default parameter values in `__init__`
 3. **Init Assignment**: `self.label = 'value'` in `__init__`
-4. **Adapter Name**: Falls back to adapter name as last resort
+4. **Dynamic Label Candidates**: Schema-valid string values from adapter args
+5. **Adapter Label Maps**: String values from class-level dictionaries used as label maps
+6. **Adapter Literals**: Schema-valid string literals in adapter code
+7. **Yielded Labels**: Literal string labels yielded from `get_nodes()` or `get_edges()`
+8. **Adapter Name**: Falls back to adapter name as last resort
+
+Dynamic candidates are filtered against `schema_config.yaml` and the adapter mode. Node
+adapters only keep schema entries represented as nodes, and edge adapters only keep
+schema entries represented as edges. This lets one adapter config produce multiple
+schema entries when the adapter emits several labels from a map or branch logic.
 
 ### 3. Property Validation
 
@@ -199,6 +285,10 @@ All extracted properties are validated against schema_config.yaml:
 Adapters are grouped by their `source` metadata:
 - Most adapters → Grouped by `self.source` value
 - Ontology adapters → Grouped under "OBO Foundry"
+
+Adapter modules in subpackages, such as `biocypher_metta.adapters.hsa.gwas_adapter`
+or `biocypher_metta.adapters.dmel.gene_group_adapter`, are resolved relative to
+`--adapters-dir`.
 
 ## Special Cases
 
@@ -249,8 +339,8 @@ _props = {'property1': value1}
 
 ## Requirements
 
-- Python 3.7+
-- PyYAML
+- Python 3.10+
+- Project dependencies installed with `uv sync`
 - BioCypher adapters with standard structure
 
 ## Example Output

--- a/schema_generator/README.md
+++ b/schema_generator/README.md
@@ -96,7 +96,29 @@ KG run is still allowed to complete.
 You can still run the generator directly when you want to regenerate schemas without
 building a KG.
 
-### Generate All Schemas
+### Generate All Schemas for a Species
+
+Use `--species` for exhaustive generation from the repo's full species adapter
+configuration. This also merges `config/primer_schema_config.yaml`, matching the KG
+pipeline's schema view.
+Species mode also includes commented-out adapter blocks from the adapter config and
+discovers adapter implementations under `biocypher_metta/adapters/<species>`, so it
+can regenerate schemas for species adapters that are not active in the KG build.
+
+```bash
+uv run python schema_generator/generate_data_source_schemas.py --species hsa
+```
+
+```bash
+uv run python schema_generator/generate_data_source_schemas.py --species dmel
+```
+
+The default output directories are:
+
+- `data_source_schemas/hsa`
+- `data_source_schemas/dmel`
+
+### Generate with Explicit Configs
 
 ```bash
 uv run python schema_generator/generate_data_source_schemas.py \
@@ -212,11 +234,13 @@ uv run python schema_generator/generate_data_source_schemas.py \
 
 - `--schema-config`: Path to schema configuration YAML file
 - `--adapter-config`: Path to adapters configuration YAML file
-- `--adapters-dir`: Directory containing adapter Python files
-- `--output-dir`: Output directory for generated schema files
+- `--species`: (Optional) Generate all configured schemas for `hsa` or `dmel` using repo defaults
+- `--adapters-dir`: Directory containing adapter Python files. Defaults to `biocypher_metta/adapters`
+- `--output-dir`: Output directory for generated schema files. Defaults to `data_source_schemas/<species>` when `--species` is used
 - `--adapter`: (Optional) Generate schema only for specific adapter config name(s). Can be used multiple times.
 - `--module`: (Optional) Generate schema for all adapters using specific Python module(s). Recommended for complete schemas with all nodes and edges. Can be used multiple times.
 - `--source`: (Optional) Generate schema only for specific data source(s). Can be used multiple times.
+- `--include-inactive-adapters` / `--no-include-inactive-adapters`: Include commented-out adapter config blocks and discoverable species adapter files. Defaults to enabled with `--species`.
 
 ## Output
 

--- a/schema_generator/generate_data_source_schemas.py
+++ b/schema_generator/generate_data_source_schemas.py
@@ -17,6 +17,7 @@ Key features:
 import argparse
 import ast
 import sys
+import warnings
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Set, Any, Optional
@@ -26,7 +27,12 @@ import yaml
 
 try:
     from config.yaml_loader import load_yaml_with_includes
-except ImportError:  # pragma: no cover
+except ImportError as exc:  # pragma: no cover
+    warnings.warn(
+        f"Falling back to yaml.safe_load because config.yaml_loader could not be imported: {exc}",
+        RuntimeWarning,
+        stacklevel=2,
+    )
     load_yaml_with_includes = yaml.safe_load
 
 
@@ -102,13 +108,24 @@ class AdapterAnalyzer:
                                 labels.add(label_node.value)
         return labels
 
-    def get_string_literals(self) -> Set[str]:
-        """Return string literals from executable adapter code."""
-        literals = set()
+    def get_label_literals(self) -> Set[str]:
+        """Return strings assigned to variables or attributes that are explicitly label-like."""
+        label_names = {'label', 'input_label', 'node_label', 'edge_label', 'relationship_label'}
+        labels = set()
         for node in ast.walk(self.tree):
-            if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                literals.add(node.value)
-        return literals
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+                continue
+            if not isinstance(node.value.value, str):
+                continue
+            for target in node.targets:
+                target_name = None
+                if isinstance(target, ast.Name):
+                    target_name = target.id
+                elif isinstance(target, ast.Attribute):
+                    target_name = target.attr
+                if target_name in label_names or (target_name and target_name.endswith('_label')):
+                    labels.add(node.value.value)
+        return labels
 
     def inherits_from_ontology_adapter(self) -> bool:
         for node in ast.walk(self.tree):
@@ -357,7 +374,26 @@ class SchemaGenerator:
         adapter_prefix = 'biocypher_metta.adapters.'
         if module.startswith(adapter_prefix):
             return module.removeprefix(adapter_prefix).replace('.', '/') + '.py'
-        return module.split('.')[-1] + '.py'
+
+        module_path = module.replace('.', '/') + '.py'
+        if (self.adapters_dir / module_path).exists():
+            return module_path
+
+        adapter_file = module.split('.')[-1] + '.py'
+        matches = sorted(self.adapters_dir.rglob(adapter_file))
+        if len(matches) == 1:
+            return str(matches[0].relative_to(self.adapters_dir))
+        if len(matches) > 1:
+            print(
+                f"Warning: Adapter module '{module}' matched multiple files; "
+                f"using top-level fallback '{adapter_file}'"
+            )
+        elif '.' in module:
+            print(
+                f"Warning: Adapter module '{module}' does not use the expected "
+                f"'{adapter_prefix}' prefix and no matching subpackage file was found"
+            )
+        return adapter_file
 
     def get_labels_for_adapter_config(
         self,
@@ -377,28 +413,38 @@ class SchemaGenerator:
             return [label]
 
         candidates = []
+        seen_candidates = set()
+
+        def add_candidate(value):
+            if isinstance(value, str) and value not in seen_candidates:
+                candidates.append(value)
+                seen_candidates.add(value)
 
         metadata_label = adapter_data['metadata'].get('label')
         if metadata_label:
-            candidates.append(metadata_label)
+            add_candidate(metadata_label)
 
         for value in adapter_args.values():
-            if isinstance(value, str):
-                candidates.append(value)
+            add_candidate(value)
 
-        candidates.extend(analyzer.get_class_dict_string_values())
-        candidates.extend(analyzer.get_string_literals())
+        for value in sorted(analyzer.get_class_dict_string_values()):
+            add_candidate(value)
+        for value in sorted(analyzer.get_label_literals()):
+            add_candidate(value)
 
         if writes_nodes:
-            candidates.extend(analyzer.get_yield_string_labels('get_nodes', 1))
+            for value in sorted(analyzer.get_yield_string_labels('get_nodes', 1)):
+                add_candidate(value)
         if writes_edges:
-            candidates.extend(analyzer.get_yield_string_labels('get_edges', 2))
+            for value in sorted(analyzer.get_yield_string_labels('get_edges', 2)):
+                add_candidate(value)
 
-        candidates.append(adapter_name)
+        add_candidate(adapter_name)
 
         labels = []
+        seen_labels = set()
         for candidate in candidates:
-            if candidate in labels:
+            if candidate in seen_labels:
                 continue
 
             type_info = self.get_schema_type_info(candidate)
@@ -408,8 +454,10 @@ class SchemaGenerator:
             represented_as = type_info['config'].get('represented_as')
             if writes_nodes and represented_as == 'node':
                 labels.append(candidate)
+                seen_labels.add(candidate)
             elif writes_edges and represented_as == 'edge':
                 labels.append(candidate)
+                seen_labels.add(candidate)
 
         return labels or [adapter_name]
 
@@ -417,7 +465,8 @@ class SchemaGenerator:
         for type_name, type_config in self.schema_config.items():
             if not isinstance(type_config, dict):
                 continue
-            if type_config.get('input_label') == input_label:
+            labels = type_config.get('input_label')
+            if labels == input_label or (isinstance(labels, list) and input_label in labels):
                 return {
                     'name': type_name,
                     'config': type_config
@@ -471,16 +520,28 @@ class SchemaGenerator:
         schema_props = self.get_all_properties_for_type(type_name)
         valid_props = {}
 
-        for prop in adapter_props:
+        for prop in sorted(adapter_props):
             if prop in schema_props:
                 prop_config = schema_props[prop]
                 if isinstance(prop_config, dict):
                     prop_type = prop_config.get('type', 'str')
                 else:
                     prop_type = 'str'
-                valid_props[prop] = prop_type
+                valid_props[prop] = self.normalize_property_type(prop_type)
 
         return valid_props
+
+    @staticmethod
+    def normalize_property_type(prop_type: Any) -> str:
+        """Normalize BioCypher property types to the shorthand used in datasource schemas."""
+        if not isinstance(prop_type, str):
+            return 'str'
+        return {
+            'string': 'str',
+            'integer': 'int',
+            'double': 'float',
+            'boolean': 'bool',
+        }.get(prop_type, prop_type)
 
     def extract_base_url(self, url: str) -> str:
         if not url:
@@ -632,7 +693,7 @@ class SchemaGenerator:
 
                 type_config = type_info['config']
                 type_name = type_info['name']
-                output_label = type_config.get('output_label') or type_name
+                output_label = type_config.get('output_label')
                 is_edge = type_config.get('represented_as') == 'edge'
 
                 # Process nodes
@@ -654,19 +715,24 @@ class SchemaGenerator:
                         nodes[type_name] = {
                             'url': adapter_source_url,
                             'input_label': label,
-                            'output_label': output_label,
                         }
+                        if output_label:
+                            nodes[type_name]['output_label'] = output_label
                         if description:
                             nodes[type_name]['description'] = description.strip()
                         if valid_props:
                             nodes[type_name]['properties'] = valid_props
                     else:
-                        nodes[type_name]['output_label'] = output_label
+                        if output_label:
+                            nodes[type_name]['output_label'] = output_label
+                        else:
+                            nodes[type_name].pop('output_label', None)
                         # Merge properties if node already exists
                         if valid_props:
                             if 'properties' not in nodes[type_name]:
                                 nodes[type_name]['properties'] = {}
-                            nodes[type_name]['properties'].update(valid_props)
+                            for prop, prop_type in valid_props.items():
+                                nodes[type_name]['properties'].setdefault(prop, prop_type)
 
                 # Process edges
                 elif writes_edges and is_edge:
@@ -689,8 +755,9 @@ class SchemaGenerator:
                         relationships[type_name] = {
                             'url': adapter_source_url,
                             'input_label': label,
-                            'output_label': output_label,
                         }
+                        if output_label:
+                            relationships[type_name]['output_label'] = output_label
                         if description:
                             relationships[type_name]['description'] = description.strip()
                         if source:
@@ -700,12 +767,16 @@ class SchemaGenerator:
                         if valid_props:
                             relationships[type_name]['properties'] = valid_props
                     else:
-                        relationships[type_name]['output_label'] = output_label
+                        if output_label:
+                            relationships[type_name]['output_label'] = output_label
+                        else:
+                            relationships[type_name].pop('output_label', None)
                         # Merge properties if relationship already exists
                         if valid_props:
                             if 'properties' not in relationships[type_name]:
                                 relationships[type_name]['properties'] = {}
-                            relationships[type_name]['properties'].update(valid_props)
+                            for prop, prop_type in valid_props.items():
+                                relationships[type_name]['properties'].setdefault(prop, prop_type)
 
         if nodes:
             schema['nodes'] = nodes

--- a/schema_generator/generate_data_source_schemas.py
+++ b/schema_generator/generate_data_source_schemas.py
@@ -15,13 +15,19 @@ Key features:
 """
 
 import argparse
-import yaml
 import ast
 import sys
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Set, Any, Optional
 import urllib.parse
+
+import yaml
+
+try:
+    from config.yaml_loader import load_yaml_with_includes
+except ImportError:  # pragma: no cover
+    load_yaml_with_includes = yaml.safe_load
 
 
 class FlowStyleListDumper(yaml.SafeDumper):
@@ -55,13 +61,54 @@ class AdapterAnalyzer:
                                 if isinstance(item.value, ast.Dict):
                                     dict_value = {}
                                     for key, value in zip(item.value.keys, item.value.values):
-                                        if isinstance(key, ast.Constant) and isinstance(value, ast.Constant):
+                                        if not isinstance(value, ast.Constant):
+                                            continue
+                                        if isinstance(key, ast.Constant):
                                             dict_value[key.value] = value.value
+                                        elif isinstance(key, ast.Tuple):
+                                            key_parts = []
+                                            for elt in key.elts:
+                                                if isinstance(elt, ast.Constant):
+                                                    key_parts.append(elt.value)
+                                            if len(key_parts) == len(key.elts):
+                                                dict_value[tuple(key_parts)] = value.value
                                     if dict_value:
                                         class_attrs[target.id] = dict_value
                                 elif isinstance(item.value, ast.Constant):
                                     class_attrs[target.id] = item.value.value
         return class_attrs
+
+    def get_class_dict_string_values(self) -> Set[str]:
+        """Return string values from class-level dictionaries used as label maps."""
+        values = set()
+        for attr_value in self.class_attributes.values():
+            if isinstance(attr_value, dict):
+                for value in attr_value.values():
+                    if isinstance(value, str):
+                        values.add(value)
+        return values
+
+    def get_yield_string_labels(self, method_name: str, tuple_index: int) -> Set[str]:
+        """Extract constant string labels yielded at a tuple position in a method."""
+        labels = set()
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.FunctionDef) and node.name == method_name:
+                for stmt in ast.walk(node):
+                    if isinstance(stmt, (ast.Yield, ast.YieldFrom)):
+                        value = stmt.value
+                        if isinstance(value, ast.Tuple) and len(value.elts) > tuple_index:
+                            label_node = value.elts[tuple_index]
+                            if isinstance(label_node, ast.Constant) and isinstance(label_node.value, str):
+                                labels.add(label_node.value)
+        return labels
+
+    def get_string_literals(self) -> Set[str]:
+        """Return string literals from executable adapter code."""
+        literals = set()
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                literals.add(node.value)
+        return literals
 
     def inherits_from_ontology_adapter(self) -> bool:
         for node in ast.walk(self.tree):
@@ -123,37 +170,101 @@ class AdapterAnalyzer:
                     properties.add(key.value)
         return properties
 
-    def get_properties_from_method(self, method_name: str) -> Set[str]:
+    @staticmethod
+    def _is_property_var_name(name: str) -> bool:
+        return name in ['props', '_props', 'properties'] or name.endswith('_props')
+
+    def get_property_variables_from_method(self, method_node: ast.FunctionDef, tuple_index: int) -> Set[str]:
+        property_vars = set()
+        for stmt in ast.walk(method_node):
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and self._is_property_var_name(target.id):
+                        property_vars.add(target.id)
+
+            if isinstance(stmt, (ast.Yield, ast.YieldFrom)):
+                value = stmt.value
+                if isinstance(value, ast.Tuple) and len(value.elts) > tuple_index:
+                    props_node = value.elts[tuple_index]
+                    if isinstance(props_node, ast.Name):
+                        property_vars.add(props_node.id)
+
+        return property_vars
+
+    def extract_properties_for_vars_from_method(
+        self,
+        method_node: ast.FunctionDef,
+        property_vars: Set[str],
+    ) -> Set[str]:
+        properties = set()
+        for stmt in ast.walk(method_node):
+            # Pattern 1: props = {...}
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id in property_vars:
+                        if isinstance(stmt.value, ast.Dict):
+                            properties.update(self.extract_properties_from_dict(stmt.value))
+
+            # Pattern 2: props['key'] = value
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Subscript):
+                        if isinstance(target.value, ast.Name) and target.value.id in property_vars:
+                            if isinstance(target.slice, ast.Constant):
+                                prop_name = target.slice.value
+                                if prop_name not in ['source', 'source_url']:
+                                    properties.add(prop_name)
+
+            # Pattern 3: props.update({...})
+            if isinstance(stmt, ast.Expr):
+                if isinstance(stmt.value, ast.Call):
+                    if isinstance(stmt.value.func, ast.Attribute):
+                        if (stmt.value.func.attr == 'update' and
+                            isinstance(stmt.value.func.value, ast.Name) and
+                            stmt.value.func.value.id in property_vars):
+                            if stmt.value.args and isinstance(stmt.value.args[0], ast.Dict):
+                                properties.update(self.extract_properties_from_dict(stmt.value.args[0]))
+        return properties
+
+    def get_properties_from_method(self, method_name: str, tuple_index: int) -> Set[str]:
         properties = set()
         for node in ast.walk(self.tree):
             if isinstance(node, ast.FunctionDef) and node.name == method_name:
-                for stmt in ast.walk(node):
-                    # Pattern 1: props = {...}
-                    if isinstance(stmt, ast.Assign):
-                        for target in stmt.targets:
-                            if isinstance(target, ast.Name) and target.id in ['props', '_props', 'properties']:
-                                if isinstance(stmt.value, ast.Dict):
-                                    properties.update(self.extract_properties_from_dict(stmt.value))
+                property_vars = self.get_property_variables_from_method(node, tuple_index)
+                properties.update(self.extract_properties_for_vars_from_method(node, property_vars))
+        return properties
 
-                    # Pattern 2: props['key'] = value
-                    if isinstance(stmt, ast.Assign):
-                        for target in stmt.targets:
-                            if isinstance(target, ast.Subscript):
-                                if isinstance(target.value, ast.Name) and target.value.id in ['props', '_props', 'properties']:
-                                    if isinstance(target.slice, ast.Constant):
-                                        prop_name = target.slice.value
-                                        if prop_name not in ['source', 'source_url']:
-                                            properties.add(prop_name)
+    def get_properties_for_label(
+        self,
+        method_name: str,
+        label: str,
+        label_index: int,
+        props_index: int,
+    ) -> Set[str]:
+        properties = set()
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.FunctionDef) or node.name != method_name:
+                continue
 
-                    # Pattern 3: props.update({...})
-                    if isinstance(stmt, ast.Expr):
-                        if isinstance(stmt.value, ast.Call):
-                            if isinstance(stmt.value.func, ast.Attribute):
-                                if (stmt.value.func.attr == 'update' and
-                                    isinstance(stmt.value.func.value, ast.Name) and
-                                    stmt.value.func.value.id in ['props', '_props', 'properties']):
-                                    if stmt.value.args and isinstance(stmt.value.args[0], ast.Dict):
-                                        properties.update(self.extract_properties_from_dict(stmt.value.args[0]))
+            property_vars = set()
+            for stmt in ast.walk(node):
+                if not isinstance(stmt, (ast.Yield, ast.YieldFrom)):
+                    continue
+                value = stmt.value
+                if not isinstance(value, ast.Tuple) or len(value.elts) <= max(label_index, props_index):
+                    continue
+                label_node = value.elts[label_index]
+                props_node = value.elts[props_index]
+                if (
+                    isinstance(label_node, ast.Constant)
+                    and label_node.value == label
+                    and isinstance(props_node, ast.Name)
+                ):
+                    property_vars.add(props_node.id)
+
+            if property_vars:
+                properties.update(self.extract_properties_for_vars_from_method(node, property_vars))
+
         return properties
 
     def get_all_class_properties(self) -> Set[str]:
@@ -167,7 +278,7 @@ class AdapterAnalyzer:
                             # Pattern 1: props = {...}
                             if isinstance(stmt, ast.Assign):
                                 for target in stmt.targets:
-                                    if isinstance(target, ast.Name) and target.id in ['props', '_props', 'properties']:
+                                    if isinstance(target, ast.Name) and self._is_property_var_name(target.id):
                                         if isinstance(stmt.value, ast.Dict):
                                             properties.update(self.extract_properties_from_dict(stmt.value))
 
@@ -175,7 +286,7 @@ class AdapterAnalyzer:
                             if isinstance(stmt, ast.Assign):
                                 for target in stmt.targets:
                                     if isinstance(target, ast.Subscript):
-                                        if isinstance(target.value, ast.Name) and target.value.id in ['props', '_props', 'properties']:
+                                        if isinstance(target.value, ast.Name) and self._is_property_var_name(target.value.id):
                                             if isinstance(target.slice, ast.Constant):
                                                 prop_name = target.slice.value
                                                 if prop_name not in ['source', 'source_url']:
@@ -187,20 +298,20 @@ class AdapterAnalyzer:
                                     if isinstance(stmt.value.func, ast.Attribute):
                                         if (stmt.value.func.attr == 'update' and
                                             isinstance(stmt.value.func.value, ast.Name) and
-                                            stmt.value.func.value.id in ['props', '_props', 'properties']):
+                                            self._is_property_var_name(stmt.value.func.value.id)):
                                             if stmt.value.args and isinstance(stmt.value.args[0], ast.Dict):
                                                 properties.update(self.extract_properties_from_dict(stmt.value.args[0]))
         return properties
 
     def get_node_properties(self) -> Set[str]:
         """Get properties from get_nodes method and all helper methods."""
-        main_props = self.get_properties_from_method('get_nodes')
+        main_props = self.get_properties_from_method('get_nodes', 2)
         all_props = self.get_all_class_properties()
         return main_props.union(all_props)
 
     def get_edge_properties(self) -> Set[str]:
         """Get properties from get_edges method and all helper methods."""
-        main_props = self.get_properties_from_method('get_edges')
+        main_props = self.get_properties_from_method('get_edges', 3)
         all_props = self.get_all_class_properties()
         return main_props.union(all_props)
 
@@ -209,27 +320,98 @@ class AdapterAnalyzer:
             return set()
         try:
             parent_analyzer = AdapterAnalyzer(parent_adapter_path)
-            return parent_analyzer.get_properties_from_method(method_name)
+            tuple_index = 2 if method_name == 'get_nodes' else 3
+            return parent_analyzer.get_properties_from_method(method_name, tuple_index)
         except Exception as e:
             print(f"Warning: Could not analyze parent class {parent_adapter_path}: {e}")
             return set()
 
 
 class SchemaGenerator:
-    def __init__(self, schema_config_path: str, adapter_config_path: str,
-                 adapters_dir: str, output_dir: str):
+    def __init__(
+        self,
+        schema_config_path: str,
+        adapter_config_path: str,
+        adapters_dir: str,
+        output_dir: str,
+        adapter_config_data: Optional[Dict] = None,
+    ):
         self.schema_config_path = Path(schema_config_path)
         self.adapter_config_path = Path(adapter_config_path)
         self.adapters_dir = Path(adapters_dir)
         self.output_dir = Path(output_dir)
 
         with open(self.schema_config_path) as f:
-            self.schema_config = yaml.safe_load(f)
-        with open(self.adapter_config_path) as f:
-            self.adapter_config = yaml.safe_load(f)
+            self.schema_config = load_yaml_with_includes(f)
+        if adapter_config_data is not None:
+            self.adapter_config = adapter_config_data
+        else:
+            with open(self.adapter_config_path) as f:
+                self.adapter_config = load_yaml_with_includes(f)
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.adapter_cache = {}
+
+    def get_adapter_file_from_module(self, module: str) -> str:
+        """Resolve a configured adapter module to a path relative to adapters_dir."""
+        adapter_prefix = 'biocypher_metta.adapters.'
+        if module.startswith(adapter_prefix):
+            return module.removeprefix(adapter_prefix).replace('.', '/') + '.py'
+        return module.split('.')[-1] + '.py'
+
+    def get_labels_for_adapter_config(
+        self,
+        adapter_name: str,
+        adapter_cfg: Dict,
+        adapter_data: Dict,
+    ) -> List[str]:
+        """Resolve schema input labels represented by one adapter config entry."""
+        adapter_info = adapter_cfg.get('adapter', {})
+        adapter_args = adapter_info.get('args', {})
+        writes_nodes = adapter_cfg.get('nodes', False)
+        writes_edges = adapter_cfg.get('edges', False)
+        analyzer = adapter_data['analyzer']
+
+        label = adapter_args.get('label')
+        if label:
+            return [label]
+
+        candidates = []
+
+        metadata_label = adapter_data['metadata'].get('label')
+        if metadata_label:
+            candidates.append(metadata_label)
+
+        for value in adapter_args.values():
+            if isinstance(value, str):
+                candidates.append(value)
+
+        candidates.extend(analyzer.get_class_dict_string_values())
+        candidates.extend(analyzer.get_string_literals())
+
+        if writes_nodes:
+            candidates.extend(analyzer.get_yield_string_labels('get_nodes', 1))
+        if writes_edges:
+            candidates.extend(analyzer.get_yield_string_labels('get_edges', 2))
+
+        candidates.append(adapter_name)
+
+        labels = []
+        for candidate in candidates:
+            if candidate in labels:
+                continue
+
+            type_info = self.get_schema_type_info(candidate)
+            if not type_info:
+                continue
+
+            represented_as = type_info['config'].get('represented_as')
+            if writes_nodes and represented_as == 'node':
+                labels.append(candidate)
+            elif writes_edges and represented_as == 'edge':
+                labels.append(candidate)
+
+        return labels or [adapter_name]
 
     def get_schema_type_info(self, input_label: str) -> Optional[Dict]:
         for type_name, type_config in self.schema_config.items():
@@ -368,7 +550,7 @@ class SchemaGenerator:
             if filter_modules and module_name not in filter_modules:
                 continue
 
-            adapter_file = module_name + '.py'
+            adapter_file = self.get_adapter_file_from_module(module)
             adapter_data = self.analyze_adapter_file(adapter_file)
             if not adapter_data:
                 continue
@@ -435,89 +617,95 @@ class SchemaGenerator:
             is_ontology_adapter = analyzer.inherits_from_ontology_adapter()
             adapter_args = adapter_cfg.get('adapter', {}).get('args', {})
 
-            label = adapter_args.get('label')
-            if not label:
-                label = adapter_data['metadata'].get('label', adapter_name)
-
             if is_ontology_adapter:
                 ontology_type = adapter_args.get('type', '')
                 if ontology_type == 'node':
                     pass
 
-            type_info = self.get_schema_type_info(label)
-            if not type_info:
-                print(f"  Warning: No schema config found for label: {label} (adapter: {adapter_name})")
-                continue
-
-            type_config = type_info['config']
-            type_name = type_info['name']
-            is_edge = type_config.get('represented_as') == 'edge'
-
             adapter_source_url = adapter_data['source_url'] if adapter_data['source_url'] else ''
 
-            # Process nodes
-            if writes_nodes and not is_edge:
-                node_props = analyzer.get_node_properties()
+            for label in self.get_labels_for_adapter_config(adapter_name, adapter_cfg, adapter_data):
+                type_info = self.get_schema_type_info(label)
+                if not type_info:
+                    print(f"  Warning: No schema config found for label: {label} (adapter: {adapter_name})")
+                    continue
 
-                if is_ontology_adapter:
-                    ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
-                    parent_props = analyzer.get_parent_class_properties('get_nodes', ontology_adapter_path)
-                    node_props = node_props.union(parent_props)
+                type_config = type_info['config']
+                type_name = type_info['name']
+                output_label = type_config.get('output_label') or type_name
+                is_edge = type_config.get('represented_as') == 'edge'
 
-                valid_props = self.get_valid_properties(label, node_props)
-                description = type_config.get('description', '')
+                # Process nodes
+                if writes_nodes and not is_edge:
+                    node_props = analyzer.get_properties_for_label('get_nodes', label, 1, 2)
+                    if not node_props:
+                        node_props = analyzer.get_node_properties()
 
-                # Add or update node
-                if type_name not in nodes:
-                    nodes[type_name] = {
-                        'url': adapter_source_url,
-                        'input_label': label,
-                    }
-                    if description:
-                        nodes[type_name]['description'] = description.strip()
-                    if valid_props:
-                        nodes[type_name]['properties'] = valid_props
-                else:
-                    # Merge properties if node already exists
-                    if valid_props:
-                        if 'properties' not in nodes[type_name]:
-                            nodes[type_name]['properties'] = {}
-                        nodes[type_name]['properties'].update(valid_props)
+                    if is_ontology_adapter:
+                        ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
+                        parent_props = analyzer.get_parent_class_properties('get_nodes', ontology_adapter_path)
+                        node_props = node_props.union(parent_props)
 
-            # Process edges
-            elif writes_edges and is_edge:
-                edge_props = analyzer.get_edge_properties()
+                    valid_props = self.get_valid_properties(label, node_props)
+                    description = type_config.get('description', '')
 
-                if is_ontology_adapter:
-                    ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
-                    parent_props = analyzer.get_parent_class_properties('get_edges', ontology_adapter_path)
-                    edge_props = edge_props.union(parent_props)
+                    # Add or update node
+                    if type_name not in nodes:
+                        nodes[type_name] = {
+                            'url': adapter_source_url,
+                            'input_label': label,
+                            'output_label': output_label,
+                        }
+                        if description:
+                            nodes[type_name]['description'] = description.strip()
+                        if valid_props:
+                            nodes[type_name]['properties'] = valid_props
+                    else:
+                        nodes[type_name]['output_label'] = output_label
+                        # Merge properties if node already exists
+                        if valid_props:
+                            if 'properties' not in nodes[type_name]:
+                                nodes[type_name]['properties'] = {}
+                            nodes[type_name]['properties'].update(valid_props)
 
-                valid_props = self.get_valid_properties(label, edge_props)
-                description = type_config.get('description', '')
-                source = type_config.get('source')
-                target = type_config.get('target')
+                # Process edges
+                elif writes_edges and is_edge:
+                    edge_props = analyzer.get_properties_for_label('get_edges', label, 2, 3)
+                    if not edge_props:
+                        edge_props = analyzer.get_edge_properties()
 
-                # Add or update relationship
-                if type_name not in relationships:
-                    relationships[type_name] = {
-                        'url': adapter_source_url,
-                        'input_label': label,
-                    }
-                    if description:
-                        relationships[type_name]['description'] = description.strip()
-                    if source:
-                        relationships[type_name]['source'] = source
-                    if target:
-                        relationships[type_name]['target'] = target
-                    if valid_props:
-                        relationships[type_name]['properties'] = valid_props
-                else:
-                    # Merge properties if relationship already exists
-                    if valid_props:
-                        if 'properties' not in relationships[type_name]:
-                            relationships[type_name]['properties'] = {}
-                        relationships[type_name]['properties'].update(valid_props)
+                    if is_ontology_adapter:
+                        ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
+                        parent_props = analyzer.get_parent_class_properties('get_edges', ontology_adapter_path)
+                        edge_props = edge_props.union(parent_props)
+
+                    valid_props = self.get_valid_properties(label, edge_props)
+                    description = type_config.get('description', '')
+                    source = type_config.get('source')
+                    target = type_config.get('target')
+
+                    # Add or update relationship
+                    if type_name not in relationships:
+                        relationships[type_name] = {
+                            'url': adapter_source_url,
+                            'input_label': label,
+                            'output_label': output_label,
+                        }
+                        if description:
+                            relationships[type_name]['description'] = description.strip()
+                        if source:
+                            relationships[type_name]['source'] = source
+                        if target:
+                            relationships[type_name]['target'] = target
+                        if valid_props:
+                            relationships[type_name]['properties'] = valid_props
+                    else:
+                        relationships[type_name]['output_label'] = output_label
+                        # Merge properties if relationship already exists
+                        if valid_props:
+                            if 'properties' not in relationships[type_name]:
+                                relationships[type_name]['properties'] = {}
+                            relationships[type_name]['properties'].update(valid_props)
 
         if nodes:
             schema['nodes'] = nodes

--- a/schema_generator/generate_data_source_schemas.py
+++ b/schema_generator/generate_data_source_schemas.py
@@ -684,16 +684,21 @@ class SchemaGenerator:
         return 1 + max((self.get_type_depth(parent, visited) for parent in parents), default=0)
 
     def get_schema_type_info(self, input_label: str) -> Optional[Dict]:
+        matches = self.get_schema_type_infos(input_label)
+        return matches[0] if matches else None
+
+    def get_schema_type_infos(self, input_label: str) -> List[Dict]:
+        matches = []
         for type_name, type_config in self.schema_config.items():
             if not isinstance(type_config, dict):
                 continue
             labels = type_config.get('input_label')
             if labels == input_label or (isinstance(labels, list) and input_label in labels):
-                return {
+                matches.append({
                     'name': type_name,
                     'config': type_config
-                }
-        return None
+                })
+        return matches
 
     def get_type_by_name(self, type_name: str) -> Optional[Dict]:
         if type_name in self.schema_config:
@@ -733,8 +738,13 @@ class SchemaGenerator:
         all_props.update(direct_props)
         return all_props
 
-    def get_valid_properties(self, input_label: str, adapter_props: Set[str]) -> Dict[str, str]:
-        type_info = self.get_schema_type_info(input_label)
+    def get_valid_properties(
+        self,
+        input_label: str,
+        adapter_props: Set[str],
+        type_info: Optional[Dict] = None,
+    ) -> Dict[str, str]:
+        type_info = type_info or self.get_schema_type_info(input_label)
         if not type_info:
             return {}
 
@@ -965,97 +975,98 @@ class SchemaGenerator:
             adapter_source_url = adapter_data['source_url'] if adapter_data['source_url'] else ''
 
             for label in self.get_labels_for_adapter_config(adapter_name, adapter_cfg, adapter_data):
-                type_info = self.get_schema_type_info(label)
-                if not type_info:
+                type_infos = self.get_schema_type_infos(label)
+                if not type_infos:
                     print(f"  Warning: No schema config found for label: {label} (adapter: {adapter_name})")
                     continue
 
-                type_config = type_info['config']
-                type_name = type_info['name']
-                output_label = type_config.get('output_label')
-                is_edge = type_config.get('represented_as') == 'edge'
+                for type_info in type_infos:
+                    type_config = type_info['config']
+                    type_name = type_info['name']
+                    output_label = type_config.get('output_label')
+                    is_edge = type_config.get('represented_as') == 'edge'
 
-                # Process nodes
-                if writes_nodes and not is_edge:
-                    node_props = analyzer.get_properties_for_label('get_nodes', label, 1, 2)
-                    if not node_props:
-                        node_props = analyzer.get_node_properties()
+                    # Process nodes
+                    if writes_nodes and not is_edge:
+                        node_props = analyzer.get_properties_for_label('get_nodes', label, 1, 2)
+                        if not node_props:
+                            node_props = analyzer.get_node_properties()
 
-                    if is_ontology_adapter:
-                        ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
-                        parent_props = analyzer.get_parent_class_properties('get_nodes', ontology_adapter_path)
-                        node_props = node_props.union(parent_props)
+                        if is_ontology_adapter:
+                            ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
+                            parent_props = analyzer.get_parent_class_properties('get_nodes', ontology_adapter_path)
+                            node_props = node_props.union(parent_props)
 
-                    valid_props = self.get_valid_properties(label, node_props)
-                    description = type_config.get('description', '')
+                        valid_props = self.get_valid_properties(label, node_props, type_info=type_info)
+                        description = type_config.get('description', '')
 
-                    # Add or update node
-                    if type_name not in nodes:
-                        nodes[type_name] = {
-                            'url': adapter_source_url,
-                            'input_label': label,
-                        }
-                        if output_label:
-                            nodes[type_name]['output_label'] = output_label
-                        if description:
-                            nodes[type_name]['description'] = description.strip()
-                        if valid_props:
-                            nodes[type_name]['properties'] = valid_props
-                    else:
-                        if output_label:
-                            nodes[type_name]['output_label'] = output_label
+                        # Add or update node
+                        if type_name not in nodes:
+                            nodes[type_name] = {
+                                'url': adapter_source_url,
+                                'input_label': label,
+                            }
+                            if output_label:
+                                nodes[type_name]['output_label'] = output_label
+                            if description:
+                                nodes[type_name]['description'] = description.strip()
+                            if valid_props:
+                                nodes[type_name]['properties'] = valid_props
                         else:
-                            nodes[type_name].pop('output_label', None)
-                        # Merge properties if node already exists
-                        if valid_props:
-                            if 'properties' not in nodes[type_name]:
-                                nodes[type_name]['properties'] = {}
-                            for prop, prop_type in valid_props.items():
-                                nodes[type_name]['properties'].setdefault(prop, prop_type)
+                            if output_label:
+                                nodes[type_name]['output_label'] = output_label
+                            else:
+                                nodes[type_name].pop('output_label', None)
+                            # Merge properties if node already exists
+                            if valid_props:
+                                if 'properties' not in nodes[type_name]:
+                                    nodes[type_name]['properties'] = {}
+                                for prop, prop_type in valid_props.items():
+                                    nodes[type_name]['properties'].setdefault(prop, prop_type)
 
-                # Process edges
-                elif writes_edges and is_edge:
-                    edge_props = analyzer.get_properties_for_label('get_edges', label, 2, 3)
-                    if not edge_props:
-                        edge_props = analyzer.get_edge_properties()
+                    # Process edges
+                    elif writes_edges and is_edge:
+                        edge_props = analyzer.get_properties_for_label('get_edges', label, 2, 3)
+                        if not edge_props:
+                            edge_props = analyzer.get_edge_properties()
 
-                    if is_ontology_adapter:
-                        ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
-                        parent_props = analyzer.get_parent_class_properties('get_edges', ontology_adapter_path)
-                        edge_props = edge_props.union(parent_props)
+                        if is_ontology_adapter:
+                            ontology_adapter_path = self.adapters_dir / 'ontologies_adapter.py'
+                            parent_props = analyzer.get_parent_class_properties('get_edges', ontology_adapter_path)
+                            edge_props = edge_props.union(parent_props)
 
-                    valid_props = self.get_valid_properties(label, edge_props)
-                    description = type_config.get('description', '')
-                    source = type_config.get('source')
-                    target = type_config.get('target')
+                        valid_props = self.get_valid_properties(label, edge_props, type_info=type_info)
+                        description = type_config.get('description', '')
+                        source = type_config.get('source')
+                        target = type_config.get('target')
 
-                    # Add or update relationship
-                    if type_name not in relationships:
-                        relationships[type_name] = {
-                            'url': adapter_source_url,
-                            'input_label': label,
-                        }
-                        if output_label:
-                            relationships[type_name]['output_label'] = output_label
-                        if description:
-                            relationships[type_name]['description'] = description.strip()
-                        if source:
-                            relationships[type_name]['source'] = source
-                        if target:
-                            relationships[type_name]['target'] = target
-                        if valid_props:
-                            relationships[type_name]['properties'] = valid_props
-                    else:
-                        if output_label:
-                            relationships[type_name]['output_label'] = output_label
+                        # Add or update relationship
+                        if type_name not in relationships:
+                            relationships[type_name] = {
+                                'url': adapter_source_url,
+                                'input_label': label,
+                            }
+                            if output_label:
+                                relationships[type_name]['output_label'] = output_label
+                            if description:
+                                relationships[type_name]['description'] = description.strip()
+                            if source:
+                                relationships[type_name]['source'] = source
+                            if target:
+                                relationships[type_name]['target'] = target
+                            if valid_props:
+                                relationships[type_name]['properties'] = valid_props
                         else:
-                            relationships[type_name].pop('output_label', None)
-                        # Merge properties if relationship already exists
-                        if valid_props:
-                            if 'properties' not in relationships[type_name]:
-                                relationships[type_name]['properties'] = {}
-                            for prop, prop_type in valid_props.items():
-                                relationships[type_name]['properties'].setdefault(prop, prop_type)
+                            if output_label:
+                                relationships[type_name]['output_label'] = output_label
+                            else:
+                                relationships[type_name].pop('output_label', None)
+                            # Merge properties if relationship already exists
+                            if valid_props:
+                                if 'properties' not in relationships[type_name]:
+                                    relationships[type_name]['properties'] = {}
+                                for prop, prop_type in valid_props.items():
+                                    relationships[type_name]['properties'].setdefault(prop, prop_type)
 
         if nodes:
             schema['nodes'] = nodes

--- a/schema_generator/generate_data_source_schemas.py
+++ b/schema_generator/generate_data_source_schemas.py
@@ -25,6 +25,10 @@ import urllib.parse
 
 import yaml
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 try:
     from config.yaml_loader import load_yaml_with_includes
 except ImportError as exc:  # pragma: no cover
@@ -55,6 +59,25 @@ class AdapterAnalyzer:
         self.source_code = adapter_path.read_text()
         self.tree = ast.parse(self.source_code)
         self.class_attributes = self._extract_class_attributes()
+        self.label_attributes = self._extract_label_attributes()
+
+    @staticmethod
+    def _is_label_name(name: str) -> bool:
+        label_names = {'label', 'input_label', 'node_label', 'edge_label', 'relationship_label'}
+        return name in label_names or name.endswith('_label')
+
+    @classmethod
+    def _extract_string_values(cls, node: ast.AST) -> Set[str]:
+        values = set()
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            values.add(node.value)
+        elif isinstance(node, ast.BoolOp):
+            for value in node.values:
+                values.update(cls._extract_string_values(value))
+        elif isinstance(node, ast.IfExp):
+            values.update(cls._extract_string_values(node.body))
+            values.update(cls._extract_string_values(node.orelse))
+        return values
 
     def _extract_class_attributes(self) -> Dict[str, Any]:
         class_attrs = {}
@@ -84,6 +107,30 @@ class AdapterAnalyzer:
                                     class_attrs[target.id] = item.value.value
         return class_attrs
 
+    def get_adapter_class_name(self) -> str:
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ClassDef):
+                return node.name
+        return self.adapter_path.stem
+
+    def _extract_label_attributes(self) -> Dict[str, Set[str]]:
+        label_attrs = defaultdict(set)
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            values = self._extract_string_values(node.value)
+            if not values:
+                continue
+            for target in node.targets:
+                target_name = None
+                if isinstance(target, ast.Name):
+                    target_name = target.id
+                elif isinstance(target, ast.Attribute):
+                    target_name = target.attr
+                if target_name and self._is_label_name(target_name):
+                    label_attrs[target_name].update(values)
+        return dict(label_attrs)
+
     def get_class_dict_string_values(self) -> Set[str]:
         """Return string values from class-level dictionaries used as label maps."""
         values = set()
@@ -106,16 +153,18 @@ class AdapterAnalyzer:
                             label_node = value.elts[tuple_index]
                             if isinstance(label_node, ast.Constant) and isinstance(label_node.value, str):
                                 labels.add(label_node.value)
+                            elif isinstance(label_node, ast.Attribute):
+                                labels.update(self.label_attributes.get(label_node.attr, set()))
         return labels
 
     def get_label_literals(self) -> Set[str]:
         """Return strings assigned to variables or attributes that are explicitly label-like."""
-        label_names = {'label', 'input_label', 'node_label', 'edge_label', 'relationship_label'}
         labels = set()
         for node in ast.walk(self.tree):
-            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            if not isinstance(node, ast.Assign):
                 continue
-            if not isinstance(node.value.value, str):
+            values = self._extract_string_values(node.value)
+            if not values:
                 continue
             for target in node.targets:
                 target_name = None
@@ -123,8 +172,22 @@ class AdapterAnalyzer:
                     target_name = target.id
                 elif isinstance(target, ast.Attribute):
                     target_name = target.attr
-                if target_name in label_names or (target_name and target_name.endswith('_label')):
-                    labels.add(node.value.value)
+                if target_name and self._is_label_name(target_name):
+                    labels.update(values)
+        return labels
+
+    def get_feature_overlap_labels(self, feature_labels: List[str], variant_label: str) -> List[str]:
+        """Resolve labels generated from feature overlap templates in the adapter."""
+        labels = []
+        source = self.source_code
+        has_feature_to_variant = "_overlaps_" in source and f"_overlaps_{variant_label}" in source
+        has_variant_to_feature = "_overlaps_{" in source or f"{variant_label}_overlaps_" in source
+
+        for feature_label in feature_labels:
+            if has_feature_to_variant:
+                labels.append(f"{feature_label}_overlaps_{variant_label}")
+            if has_variant_to_feature:
+                labels.append(f"{variant_label}_overlaps_{feature_label}")
         return labels
 
     def inherits_from_ontology_adapter(self) -> bool:
@@ -345,6 +408,85 @@ class AdapterAnalyzer:
 
 
 class SchemaGenerator:
+    SPECIES_CONFIGS = {
+        'hsa': {
+            'schema_config': 'config/hsa/hsa_schema_config.yaml',
+            'adapter_config': 'config/hsa/hsa_adapters_config.yaml',
+            'output_dir': 'data_source_schemas/hsa',
+        },
+        'dmel': {
+            'schema_config': 'config/dmel/dmel_schema_config.yaml',
+            'adapter_config': 'config/dmel/dmel_adapters_config.yaml',
+            'output_dir': 'data_source_schemas/dmel',
+        },
+    }
+    SOURCE_FILENAME_ALIASES = {
+        'HOCOMOCOv11': 'HOCOMOCO',
+        'Reactome': 'REACTOME',
+    }
+    SOURCE_NAME_ALIASES = {
+        'Reactome': 'REACTOME',
+    }
+
+    @staticmethod
+    def load_schema_config(schema_config_path: str, include_primer: bool = False) -> Dict:
+        schema_config = {}
+        if include_primer:
+            primer_path = Path('config/primer_schema_config.yaml')
+            with open(primer_path) as f:
+                primer_config = load_yaml_with_includes(f) or {}
+            schema_config.update(primer_config)
+
+        with open(schema_config_path) as f:
+            species_config = load_yaml_with_includes(f) or {}
+        schema_config.update(species_config)
+        return schema_config
+
+    @staticmethod
+    def load_commented_adapter_config(adapter_config_path: str) -> Dict:
+        """Load adapter entries that are commented out as YAML blocks.
+
+        Species-level schema generation should document all configured human/fly
+        sources, including adapters that are temporarily disabled in the KG build
+        config. This keeps those entries generated from adapter code/config rather
+        than maintaining datasource YAMLs by hand.
+        """
+        inactive_adapters = {}
+        current_block = []
+
+        def flush_block():
+            if not current_block:
+                return
+            text = '\n'.join(current_block)
+            current_block.clear()
+            try:
+                parsed = yaml.safe_load(text)
+            except yaml.YAMLError:
+                return
+            if not isinstance(parsed, dict):
+                return
+            for name, config in parsed.items():
+                if (
+                    isinstance(name, str)
+                    and isinstance(config, dict)
+                    and isinstance(config.get('adapter'), dict)
+                    and ('nodes' in config or 'edges' in config)
+                ):
+                    inactive_adapters[name] = config
+
+        for line in Path(adapter_config_path).read_text().splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith('#'):
+                content = stripped[1:]
+                if content.startswith(' '):
+                    content = content[1:]
+                current_block.append(content)
+            else:
+                flush_block()
+        flush_block()
+
+        return inactive_adapters
+
     def __init__(
         self,
         schema_config_path: str,
@@ -352,14 +494,18 @@ class SchemaGenerator:
         adapters_dir: str,
         output_dir: str,
         adapter_config_data: Optional[Dict] = None,
+        schema_config_data: Optional[Dict] = None,
     ):
         self.schema_config_path = Path(schema_config_path)
         self.adapter_config_path = Path(adapter_config_path)
         self.adapters_dir = Path(adapters_dir)
         self.output_dir = Path(output_dir)
 
-        with open(self.schema_config_path) as f:
-            self.schema_config = load_yaml_with_includes(f)
+        if schema_config_data is not None:
+            self.schema_config = schema_config_data
+        else:
+            with open(self.schema_config_path) as f:
+                self.schema_config = load_yaml_with_includes(f)
         if adapter_config_data is not None:
             self.adapter_config = adapter_config_data
         else:
@@ -408,10 +554,6 @@ class SchemaGenerator:
         writes_edges = adapter_cfg.get('edges', False)
         analyzer = adapter_data['analyzer']
 
-        label = adapter_args.get('label')
-        if label:
-            return [label]
-
         candidates = []
         seen_candidates = set()
 
@@ -419,6 +561,8 @@ class SchemaGenerator:
             if isinstance(value, str) and value not in seen_candidates:
                 candidates.append(value)
                 seen_candidates.add(value)
+
+        add_candidate(adapter_args.get('label'))
 
         metadata_label = adapter_data['metadata'].get('label')
         if metadata_label:
@@ -431,6 +575,16 @@ class SchemaGenerator:
             add_candidate(value)
         for value in sorted(analyzer.get_label_literals()):
             add_candidate(value)
+
+        feature_labels = [
+            feature_config.get('label')
+            for feature_config in adapter_args.get('feature_files', [])
+            if isinstance(feature_config, dict)
+        ]
+        variant_label = adapter_args.get('label')
+        if writes_edges and feature_labels and variant_label:
+            for value in analyzer.get_feature_overlap_labels(feature_labels, variant_label):
+                add_candidate(value)
 
         if writes_nodes:
             for value in sorted(analyzer.get_yield_string_labels('get_nodes', 1)):
@@ -459,7 +613,75 @@ class SchemaGenerator:
                 labels.append(candidate)
                 seen_labels.add(candidate)
 
+        if not labels:
+            labels.extend(self.infer_labels_from_adapter_properties(adapter_cfg, analyzer))
+
         return labels or [adapter_name]
+
+    def infer_labels_from_adapter_properties(self, adapter_cfg: Dict, analyzer: AdapterAnalyzer) -> List[str]:
+        """Infer schema labels when config labels are absent/stale but properties are distinctive."""
+        candidates = []
+        modes = []
+        if adapter_cfg.get('nodes', False):
+            modes.append(('node', analyzer.get_node_properties()))
+
+        for represented_as, adapter_props in modes:
+            if not adapter_props:
+                continue
+            scored = []
+            for type_name, type_config in self.schema_config.items():
+                if not isinstance(type_config, dict):
+                    continue
+                if type_config.get('represented_as') != represented_as:
+                    continue
+                labels = type_config.get('input_label')
+                if labels is None:
+                    continue
+                schema_props = set(self.get_all_properties_for_type(type_name))
+                overlap = adapter_props.intersection(schema_props)
+                if overlap:
+                    label_values = labels if isinstance(labels, list) else [labels]
+                    scored.append((
+                        len(overlap),
+                        self.get_type_depth(type_name),
+                        len(schema_props),
+                        type_name,
+                        label_values,
+                    ))
+            if not scored:
+                continue
+            best_score = max(score for score, _, _, _, _ in scored)
+            best_depth = max(depth for score, depth, _, _, _ in scored if score == best_score)
+            best_schema_size = max(
+                schema_size
+                for score, depth, schema_size, _, _ in scored
+                if score == best_score and depth == best_depth
+            )
+            for score, depth, schema_size, _, label_values in sorted(scored, key=lambda item: item[3]):
+                if score == best_score and depth == best_depth and schema_size == best_schema_size:
+                    for label in label_values:
+                        if label not in candidates:
+                            candidates.append(label)
+
+        return candidates
+
+    def get_type_depth(self, type_name: str, visited: Set[str] = None) -> int:
+        if visited is None:
+            visited = set()
+        if type_name in visited:
+            return 0
+        visited.add(type_name)
+        type_info = self.get_type_by_name(type_name)
+        if not type_info:
+            return 0
+        parents = type_info['config'].get('is_a')
+        if not parents:
+            return 0
+        if isinstance(parents, str):
+            parents = [parents]
+        if not isinstance(parents, list):
+            return 0
+        return 1 + max((self.get_type_depth(parent, visited) for parent in parents), default=0)
 
     def get_schema_type_info(self, input_label: str) -> Optional[Dict]:
         for type_name, type_config in self.schema_config.items():
@@ -582,6 +804,59 @@ class SchemaGenerator:
         self.adapter_cache[adapter_file] = result
         return result
 
+    def discover_species_adapters(
+        self,
+        species: str,
+        existing_adapter_config: Dict,
+    ) -> Dict:
+        existing_modules = {
+            (config.get('adapter') or {}).get('module')
+            for config in existing_adapter_config.values()
+            if isinstance(config, dict)
+        }
+        discovered = {}
+        species_adapter_dir = self.adapters_dir / species
+        if not species_adapter_dir.exists():
+            return discovered
+
+        for adapter_path in sorted(species_adapter_dir.rglob('*_adapter.py')):
+            adapter_file = str(adapter_path.relative_to(self.adapters_dir))
+            module = (
+                'biocypher_metta.adapters.'
+                + adapter_path.relative_to(self.adapters_dir).with_suffix('').as_posix().replace('/', '.')
+            )
+            if module in existing_modules:
+                continue
+
+            adapter_data = self.analyze_adapter_file(adapter_file)
+            if not adapter_data:
+                continue
+
+            analyzer = adapter_data['analyzer']
+            has_nodes = any(
+                isinstance(node, ast.FunctionDef) and node.name == 'get_nodes'
+                for node in ast.walk(analyzer.tree)
+            )
+            has_edges = any(
+                isinstance(node, ast.FunctionDef) and node.name == 'get_edges'
+                for node in ast.walk(analyzer.tree)
+            )
+            if not has_nodes and not has_edges:
+                continue
+
+            adapter_name = adapter_path.stem.removesuffix('_adapter')
+            discovered[adapter_name] = {
+                'adapter': {
+                    'module': module,
+                    'cls': analyzer.get_adapter_class_name(),
+                    'args': {},
+                },
+                'nodes': has_nodes,
+                'edges': has_edges,
+            }
+
+        return discovered
+
     def generate_all_schemas(self, filter_adapters: Optional[List[str]] = None, filter_modules: Optional[List[str]] = None, filter_sources: Optional[List[str]] = None):
         if filter_adapters:
             print(f"Analyzing specific adapters: {', '.join(filter_adapters)}")
@@ -616,7 +891,10 @@ class SchemaGenerator:
             if not adapter_data:
                 continue
 
-            source_name = adapter_data['source_name']
+            source_name = self.SOURCE_NAME_ALIASES.get(
+                adapter_data['source_name'],
+                adapter_data['source_name'],
+            )
 
             # Filter by source name if specified
             if filter_sources and source_name not in filter_sources:
@@ -645,7 +923,8 @@ class SchemaGenerator:
         website = self.extract_base_url(source_urls[0]) if source_urls else ''
 
         # Check if output file already exists
-        output_filename = source_name.replace(' ', '_').replace('-', '_').replace('/', '_') + '.yaml'
+        filename_source = self.SOURCE_FILENAME_ALIASES.get(source_name, source_name)
+        output_filename = filename_source.replace(' ', '_').replace('-', '_').replace('/', '_') + '.yaml'
         output_path = self.output_dir / output_filename
 
         # Load existing schema if it exists
@@ -800,15 +1079,43 @@ def main():
         epilog=__doc__
     )
 
-    parser.add_argument('--schema-config', required=True, help='Path to schema configuration YAML file')
-    parser.add_argument('--adapter-config', required=True, help='Path to adapter configuration YAML file')
-    parser.add_argument('--adapters-dir', required=True, help='Directory containing adapter Python files')
-    parser.add_argument('--output-dir', required=True, help='Output directory for generated schema files')
+    parser.add_argument(
+        '--species',
+        choices=sorted(SchemaGenerator.SPECIES_CONFIGS),
+        help='Generate all configured data source schemas for a species using repo defaults.',
+    )
+    parser.add_argument('--schema-config', help='Path to schema configuration YAML file')
+    parser.add_argument('--adapter-config', help='Path to adapter configuration YAML file')
+    parser.add_argument('--adapters-dir', default='biocypher_metta/adapters', help='Directory containing adapter Python files')
+    parser.add_argument('--output-dir', help='Output directory for generated schema files')
     parser.add_argument('--adapter', action='append', help='Generate schema only for specific adapter(s). Can be used multiple times.')
     parser.add_argument('--module', action='append', help='Generate schema for all adapters using specific module(s). Example: candidate_cis_regulatory_promoter_adapter. Can be used multiple times.')
     parser.add_argument('--source', action='append', help='Generate schema only for specific data source(s). Can be used multiple times.')
+    parser.add_argument(
+        '--include-inactive-adapters',
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help='Also include commented-out adapter blocks from the adapter config. Defaults to on for --species.',
+    )
 
     args = parser.parse_args()
+
+    if args.species:
+        defaults = SchemaGenerator.SPECIES_CONFIGS[args.species]
+        args.schema_config = args.schema_config or defaults['schema_config']
+        args.adapter_config = args.adapter_config or defaults['adapter_config']
+        args.output_dir = args.output_dir or defaults['output_dir']
+
+    missing_args = [
+        name
+        for name in ('schema_config', 'adapter_config', 'adapters_dir', 'output_dir')
+        if not getattr(args, name)
+    ]
+    if missing_args:
+        parser.error(
+            "the following arguments are required unless --species is used: "
+            + ", ".join(f"--{name.replace('_', '-')}" for name in missing_args)
+        )
 
     if not Path(args.schema_config).exists():
         print(f"Error: Schema config not found: {args.schema_config}")
@@ -820,11 +1127,42 @@ def main():
         print(f"Error: Adapters directory not found: {args.adapters_dir}")
         sys.exit(1)
 
+    schema_config_data = None
+    adapter_config_data = None
+    if args.species:
+        schema_config_data = SchemaGenerator.load_schema_config(
+            args.schema_config,
+            include_primer=True,
+        )
+        include_inactive = True if args.include_inactive_adapters is None else args.include_inactive_adapters
+        if include_inactive:
+            with open(args.adapter_config) as f:
+                adapter_config_data = load_yaml_with_includes(f) or {}
+            inactive_adapters = SchemaGenerator.load_commented_adapter_config(args.adapter_config)
+            for adapter_name, adapter_cfg in inactive_adapters.items():
+                adapter_config_data.setdefault(adapter_name, adapter_cfg)
+            discovery_generator = SchemaGenerator(
+                args.schema_config,
+                args.adapter_config,
+                args.adapters_dir,
+                args.output_dir,
+                adapter_config_data=adapter_config_data,
+                schema_config_data=schema_config_data,
+            )
+            discovered_adapters = discovery_generator.discover_species_adapters(
+                args.species,
+                adapter_config_data,
+            )
+            for adapter_name, adapter_cfg in discovered_adapters.items():
+                adapter_config_data.setdefault(adapter_name, adapter_cfg)
+
     generator = SchemaGenerator(
         args.schema_config,
         args.adapter_config,
         args.adapters_dir,
-        args.output_dir
+        args.output_dir,
+        adapter_config_data=adapter_config_data,
+        schema_config_data=schema_config_data,
     )
 
     generator.generate_all_schemas(


### PR DESCRIPTION
## Type of change

- [ ] New adapter
- [ ] Adapter fix / update
- [ ] New processor / Processor fix
- [X] Schema change
- [ ] Adapters config change
- [ ] Writer fix / update
- [ ] CI / workflow change
- [ ] Bug fix / Refactor

---

## Summary

Integrates datasource schema generation into KG creation, improves the schema generator, and updates generated datasource schema files.

## Changes

- Generate datasource schemas automatically after successful KG builds
- Use the same adapter set selected for the KG run, including filtered adapter runs
- Add CLI options to disable schema generation or set a custom output directory
- Improve dynamic label and property extraction for adapters
- Support adapter modules in subpackages
- Update schema generator documentation
- Regenerate and update HSA datasource schema YAML files


---

## Checklist

### General
- [X] PR targets `main` and branch is up to date
- [X] No hardcoded absolute paths; paths are repo-relative or under `aux_files/` when persistent generated assets are expected
- [X] No credentials, tokens, or real patient data committed

### New adapter
- [ ] Entry added to `config/hsa/hsa_adapters_config_sample.yaml` with correct `module`, `cls`, and `args`
- [ ] Entry added to `config/hsa/hsa_data_source_config.yaml` with the correct `name` and `url`
- [ ] Sample inputs are committed under `samples/` when tests must run offline; generated/cache assets are under `aux_files/` only when appropriate
- [ ] `nodes` / `edges` flags are correct; dbSNP-related config uses the current mapping-based inputs if needed
- [ ] If this is a heavy ontology adapter, the relevant skip/detection lists used by CI and tests are updated consistently

### Schema changes
- [ ] New labels are validated against BioCypher / Biolink expectations
- [ ] `input_label`, `output_label`, `source`, and `target` match what the adapter actually yields
- [ ] Breaking label, schema, or adapter-arg changes are called out below

### Testing
- [ ] `uv run pytest test/test.py --adapter-test-mode=smoke` passes
- [ ] Ran additional focused checks relevant to the change
- [ ] `uv run pytest test/test.py` passes if heavy ontology, schema-wide, or cache/update behavior changed
- [ ] Spot-checked output node / edge labels and counts where relevant


