### PR TITLE
Change biocypher_metta/processors/* to get parameters for other species #284

### DIFF
--- a/biocypher_metta/processors/ensembl_uniprot_processor.py
+++ b/biocypher_metta/processors/ensembl_uniprot_processor.py
@@ -17,16 +17,17 @@ from .base_mapping_processor import BaseMappingProcessor
 
 
 class EnsemblUniProtProcessor(BaseMappingProcessor):
-    UNIPROT_IDMAPPING_URL = (
-        "https://ftp.uniprot.org/pub/databases/uniprot/current_release/"
-        "knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping.dat.gz"
-    )
-
     def __init__(
         self,
+        organism: str = 'HUMAN_9606',
         cache_dir: str = 'aux_files/hsa/ensembl_uniprot',
         update_interval_hours: Optional[int] = None
     ):
+        self.organism = organism
+        self.UNIPROT_IDMAPPING_URL = (
+            "https://ftp.uniprot.org/pub/databases/uniprot/current_release/"
+            f"knowledgebase/idmapping/by_organism/{self.organism}_idmapping.dat.gz"
+        )
         super().__init__(
             name='ensembl_uniprot',
             cache_dir=cache_dir,

--- a/biocypher_metta/processors/entrez_ensembl_processor.py
+++ b/biocypher_metta/processors/entrez_ensembl_processor.py
@@ -24,20 +24,17 @@ from .base_mapping_processor import BaseMappingProcessor
 
 class EntrezEnsemblProcessor(BaseMappingProcessor):
 
-    NCBI_GENE_INFO_URL = (
-        "https://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz"
-    )
-
-    GENCODE_URL = (
-        "https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_46/"
-        "gencode.v46.chr_patch_hapl_scaff.annotation.gtf.gz"
-    )
-
     def __init__(
         self,
+        ncbi_gene_info_url: str = "https://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz",
+        gencode_url: str = "https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_46/gencode.v46.chr_patch_hapl_scaff.annotation.gtf.gz",
+        tax_id: str = '9606',
         cache_dir: str = 'aux_files/hsa/entrez_ensembl',
         update_interval_hours: int = 168
     ):
+        self.NCBI_GENE_INFO_URL = ncbi_gene_info_url
+        self.GENCODE_URL = gencode_url
+        self.tax_id = tax_id
         super().__init__(
             name='entrez_ensembl',
             cache_dir=cache_dir,
@@ -148,7 +145,7 @@ class EntrezEnsemblProcessor(BaseMappingProcessor):
                         continue
 
                     tax_id = fields[0]
-                    if tax_id != '9606':
+                    if tax_id != self.tax_id:
                         continue
 
                     entrez_id = fields[1]

--- a/biocypher_metta/processors/hgnc_processor.py
+++ b/biocypher_metta/processors/hgnc_processor.py
@@ -20,18 +20,17 @@ from .base_mapping_processor import BaseMappingProcessor
 
 
 class HGNCProcessor(BaseMappingProcessor):
+    HGNC_API_URL = (
+        "https://www.genenames.org/cgi-bin/download/custom?"
+        "col=gd_hgnc_id&col=gd_app_sym&col=gd_prev_sym&col=gd_aliases&col=gd_pub_ensembl_id"
+        "&status=Approved&hgnc_dbtag=on&order_by=gd_app_sym_sort&format=text&submit=submit"
+    )
 
     def __init__(
         self,
-        hgnc_api_url: str = (
-            "https://www.genenames.org/cgi-bin/download/custom?"
-            "col=gd_hgnc_id&col=gd_app_sym&col=gd_prev_sym&col=gd_aliases&col=gd_pub_ensembl_id"
-            "&status=Approved&hgnc_dbtag=on&order_by=gd_app_sym_sort&format=text&submit=submit"
-        ),
         cache_dir: str = 'aux_files/hsa/hgnc',
         update_interval_hours: Optional[int] = 48  # HGNC needs time-based (no remote metadata)
     ):
-        self.HGNC_API_URL = hgnc_api_url
         super().__init__(
             name='hgnc',
             cache_dir=cache_dir,

--- a/biocypher_metta/processors/hgnc_processor.py
+++ b/biocypher_metta/processors/hgnc_processor.py
@@ -20,17 +20,18 @@ from .base_mapping_processor import BaseMappingProcessor
 
 
 class HGNCProcessor(BaseMappingProcessor):
-    HGNC_API_URL = (
-        "https://www.genenames.org/cgi-bin/download/custom?"
-        "col=gd_hgnc_id&col=gd_app_sym&col=gd_prev_sym&col=gd_aliases&col=gd_pub_ensembl_id"
-        "&status=Approved&hgnc_dbtag=on&order_by=gd_app_sym_sort&format=text&submit=submit"
-    )
 
     def __init__(
         self,
+        hgnc_api_url: str = (
+            "https://www.genenames.org/cgi-bin/download/custom?"
+            "col=gd_hgnc_id&col=gd_app_sym&col=gd_prev_sym&col=gd_aliases&col=gd_pub_ensembl_id"
+            "&status=Approved&hgnc_dbtag=on&order_by=gd_app_sym_sort&format=text&submit=submit"
+        ),
         cache_dir: str = 'aux_files/hsa/hgnc',
         update_interval_hours: Optional[int] = 48  # HGNC needs time-based (no remote metadata)
     ):
+        self.HGNC_API_URL = hgnc_api_url
         super().__init__(
             name='hgnc',
             cache_dir=cache_dir,


### PR DESCRIPTION
Summary

#284 

This update removes hardcoded human-specific configurations from multiple processors and makes them configurable to support multi-species workflows.

Changes

Updated the following processors to accept dynamic parameters instead of fixed human-only values:

EntrezEnsemblProcessor
- Added tax_id
- Added ncbi_gene_info_url
- Added gencode_url
- Replaces hardcoded Homo sapiens references

EnsemblUniProtProcessor
- Added organism parameter
- Enables dynamic UniProt endpoint construction per species

