### PR TITLE
feat: declarative dataset versioning & provenance tracking

### DIFF
--- a/.github/workflows/check-dataset-versions.yml
+++ b/.github/workflows/check-dataset-versions.yml
@@ -35,7 +35,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Set up Python
-        run: uv python install 3.9
+        run: uv python install 3.10
 
       - name: Run dataset version check
         id: check

--- a/.github/workflows/check-dataset-versions.yml
+++ b/.github/workflows/check-dataset-versions.yml
@@ -1,0 +1,71 @@
+name: Check Dataset Versions
+
+# Bioversions-style staleness check: resolves each input dataset's current version
+# (from its data_source_config) and compares to a committed baseline, flagging sources
+# whose ETag/Last-Modified changed (CHANGED) or whose pinned config URL drifted from the
+# recorded download (drift). Pinned sources with no baseline report 'unknown' (no noise).
+#
+# Baselines are optional and live in versioning/baselines/<species>/versions.json. Seed
+# them by copying a download run's versions.json there; until then the job is a no-op pass.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      species:
+        description: "Species to check (hsa/dmel/cel/mmu/rno or 'all')"
+        default: "all"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.9
+
+      - name: Run dataset version check
+        id: check
+        run: |
+          set +e
+          uv run python -m biocypher_dataset_downloader.versioning.cli \
+            --species "${{ github.event.inputs.species || 'all' }}" \
+            --config-dir config \
+            --versions-root versioning/baselines \
+            --json > version_report.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          echo "----- version report -----"
+          cat version_report.json
+
+      - name: Upload version report
+        uses: actions/upload-artifact@v4
+        with:
+          name: dataset-version-report
+          path: version_report.json
+
+      - name: Open issue on staleness
+        if: steps.check.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "Dataset version drift detected ($(date +%Y-%m-%d))" \
+            --body "$(printf 'The scheduled dataset version check found CHANGED or drifted sources.\n\nReport (also attached as an artifact):\n\n```json\n%s\n```\n' "$(cat version_report.json)")" \
+            --label "data-versioning" || echo "Could not create issue (label or permissions); see artifact."
+
+      - name: Fail if stale
+        if: steps.check.outputs.exit_code != '0'
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ output_human/
 aux_files/hsa/catlas/*.pkl
 samples/hsa/catlasv1/cCRE_hg38.tsv.gz
 samples/reactome/interactors/reactome.all_species.interactions.tab-delimited.txt
+doc/plans

--- a/README.md
+++ b/README.md
@@ -345,10 +345,15 @@ python kg-service/neo4j_loader.py \
 **Notes:**
 - The loader detects changed files via hash comparison and only reloads what changed.
 - Edges use `CREATE` (not `MERGE`) — the loader surgically deletes changed edges before reloading, so the existence check is unnecessary and very slow on large files.
+- Each `KGVersion` node records `source_provenance_json` — the upstream version, URL, and checksums of every dataset it was built from. See [Dataset Versioning & Provenance](#-dataset-versioning--provenance).
 
 ## ⬇ Downloading data
 The `biocypher_dataset_downloader` directory contains code for downloading data from various sources.
 Data source URLs and metadata are configured in the species-specific config files under `config/` (e.g. `config/hsa/hsa_data_source_config.yaml`).
+
+Each download also writes a provenance record into the output directory — `download_manifest.json`
+(per-source version, sha256, and HTTP metadata) and an append-only `versions.json` history. See
+[Dataset Versioning & Provenance](#-dataset-versioning--provenance) below.
 
 ### Interactive (recommended)
 
@@ -379,6 +384,43 @@ python -m biocypher_dataset_downloader.download_data --output-dir <output_direct
 
 # Download a specific source
 python -m biocypher_dataset_downloader.download_data --output-dir <output_directory> --source <source_name>
+
+# Skip sha256 checksums in the manifest (faster on multi-GB files)
+python -m biocypher_dataset_downloader.download_data --output-dir <output_directory> --no-checksum
+```
+
+## 📌 Dataset Versioning & Provenance
+
+Every dataset's version and provenance is tracked from a single source of truth — the data-source
+config — and flows through the whole pipeline, so a build is reproducible and citable. Full guide:
+**[doc/dataset-versioning.md](doc/dataset-versioning.md)**.
+
+**Declare a version** in `config/<species>/<species>_data_source_config.yaml` (optional; defaults to
+HTTP-HEAD change tracking):
+
+```yaml
+gencode:
+  name: GENCODE v49
+  version: {strategy: url_regex, pattern: 'gencode\.(v\d+)\.', vtype: sequential}
+  source_url: https://www.gencodegenes.org/
+  url: https://ftp.ebi.ac.uk/.../gencode.v49.annotation.gtf.gz
+```
+
+Strategies: `url_regex` (version from the URL — covers most sources), `static` (`value: v11`),
+`http_head` (default — tracks `ETag`/`Last-Modified` for `current/` symlinks).
+
+**On download**, `download_manifest.json` + `versions.json` are written per species (version, sha256,
+HTTP metadata). **On build**, pass the manifest so versions flow into `graph_info.json`:
+
+```bash
+uv run python create_knowledge_graph.py ... --manifest <download_dir>/download_manifest.json
+```
+
+**Check for stale/changed sources** (exits non-zero on change; runs weekly in CI via
+`.github/workflows/check-dataset-versions.yml`):
+
+```bash
+uv run python -m biocypher_dataset_downloader.versioning.cli --species all --versions-root <dir>
 ```
 
 ## 🧬 dbSNP Cache

--- a/biocypher_dataset_downloader/download_data.py
+++ b/biocypher_dataset_downloader/download_data.py
@@ -14,16 +14,22 @@ def download_data(
     config_file: str = "config/hsa/hsa_data_source_config.yaml",
     source: str = None,
     sample_fraction: float = 0.01,
+    no_checksum: Annotated[bool, typer.Option("--no-checksum", help="Skip sha256 checksums in the provenance manifest (faster on huge files).")] = False,
 ):
     """Download data sources defined in a species config YAML.
+
+    Writes a provenance manifest (download_manifest.json) and append-only version
+    history (versions.json) under the output directory.
 
     Examples:
         python download_data.py --output-dir data/hsa
         python download_data.py --output-dir data/dmel --config-file config/dmel/dmel_data_source_config.yaml
         python download_data.py --output-dir data/hsa --source reactome
+        python download_data.py --output-dir data/hsa --no-checksum
     """
     try:
-        manager = DownloadManager(config_file, output_dir, sample_fraction=sample_fraction)
+        manager = DownloadManager(config_file, output_dir, sample_fraction=sample_fraction,
+                                  compute_checksums=not no_checksum)
         if source:
             manager.download_source(source)
         else:

--- a/biocypher_dataset_downloader/download_manager.py
+++ b/biocypher_dataset_downloader/download_manager.py
@@ -20,7 +20,7 @@ from requests.adapters import HTTPAdapter
 from tqdm import tqdm
 from urllib3.util.retry import Retry
 
-from biocypher_dataset_downloader.versioning import resolve_source
+from biocypher_dataset_downloader.versioning import resolve_source, iter_source_urls
 
 logger = logging.getLogger(__name__)
 
@@ -239,11 +239,13 @@ class DownloadManager:
                 'downloaded_at': datetime.now().isoformat(),
             })
 
-        # Attach HEAD metadata for the primary declared URL(s) (best-effort).
+        # Attach HEAD metadata for all declared URLs (best-effort). Uses iter_source_urls
+        # so every URL shape is covered — str, list, and the dict forms ({filename: url}
+        # and nested {sub_key: [urls]}) — not just the scalar/list `url` field.
         remote_metadata = {}
-        for url in list(version_info.url if isinstance(version_info.url, list) else [version_info.url]):
-            if isinstance(url, str) and url.startswith('http'):
-                meta = self._head_metadata(url.split('#')[0].strip())
+        for url in iter_source_urls(source_config):
+            if url.startswith('http'):
+                meta = self._head_metadata(url)
                 if meta:
                     remote_metadata[meta['url']] = meta
 

--- a/biocypher_dataset_downloader/download_manager.py
+++ b/biocypher_dataset_downloader/download_manager.py
@@ -1,6 +1,8 @@
 import io
 import math
 import gzip
+import hashlib
+import json
 import re
 import shutil
 import tarfile
@@ -8,6 +10,7 @@ import time
 import yaml
 import zipfile
 import logging
+from datetime import datetime
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urlparse, urljoin
@@ -17,9 +20,14 @@ from requests.adapters import HTTPAdapter
 from tqdm import tqdm
 from urllib3.util.retry import Retry
 
+from biocypher_dataset_downloader.versioning import resolve_source
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_SAMPLE_FRACTION = 0.01
+MANIFEST_FILENAME = "download_manifest.json"
+VERSIONS_FILENAME = "versions.json"
+MANIFEST_VERSION = 1
 
 
 # ---------------------------------------------------------------------------
@@ -89,12 +97,21 @@ class _LinkParser(HTMLParser):
 
 class DownloadManager:
     def __init__(self, config_path: str, output_dir: Path,
-                 sample_fraction: float = DEFAULT_SAMPLE_FRACTION):
+                 sample_fraction: float = DEFAULT_SAMPLE_FRACTION,
+                 compute_checksums: bool = True):
+        self.config_path = config_path
         self.config = self._load_config(config_path)
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.sample_fraction = sample_fraction
         self.sample_root = self.output_dir / 'sample' if sample_fraction > 0 else None
+        self.compute_checksums = compute_checksums
+
+        # Provenance manifest: source_id -> entry. Built as sources are processed.
+        self.manifest_sources: dict[str, dict] = {}
+        # Prior-run manifest (if any) lets us carry forward sha256 for unchanged files
+        # instead of re-hashing multi-GB datasets every run.
+        self._prior_manifest = self._load_prior_manifest()
 
         # Requests session with built-in retry for transient HTTP errors
         self.session = requests.Session()
@@ -114,6 +131,182 @@ class DownloadManager:
     def _load_config(self, config_path: str) -> dict:
         with open(config_path, 'r') as f:
             return yaml.safe_load(f)
+
+    # ------------------------------------------------------------------
+    # Provenance manifest
+    # ------------------------------------------------------------------
+
+    def _manifest_path(self) -> Path:
+        return self.output_dir / MANIFEST_FILENAME
+
+    def _versions_path(self) -> Path:
+        return self.output_dir / VERSIONS_FILENAME
+
+    def _load_prior_manifest(self) -> dict:
+        """Load a previous run's manifest (for sha256 carry-forward); {} if absent/invalid."""
+        path = self.output_dir / MANIFEST_FILENAME
+        try:
+            with open(path, 'r') as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    def _prior_file_hash(self, rel_path: str, size: int) -> str | None:
+        """Return the recorded sha256 for rel_path from the prior manifest iff size matches."""
+        for entry in self._prior_manifest.get('sources', {}).values():
+            for f in entry.get('files', []):
+                if f.get('rel_path') == rel_path and f.get('size_bytes') == size and f.get('sha256'):
+                    return f['sha256']
+        return None
+
+    def _sha256(self, filepath: Path) -> str:
+        """Streamed sha256 of a file (mirrors version_manager.hash_file, md5 -> sha256)."""
+        h = hashlib.sha256()
+        with open(filepath, 'rb') as f:
+            for chunk in iter(lambda: f.read(8192), b''):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def _head_metadata(self, url: str) -> dict | None:
+        """HTTP HEAD metadata for a URL (Last-Modified / ETag / Content-Length / checked_at).
+
+        Mirrors BaseMappingProcessor.check_remote_version so both sites capture the same shape.
+        """
+        try:
+            resp = self.session.head(url, timeout=10, allow_redirects=True)
+            resp.raise_for_status()
+            return {
+                'url': url,
+                'last_modified': resp.headers.get('Last-Modified'),
+                'etag': resp.headers.get('ETag'),
+                'content_length': resp.headers.get('Content-Length'),
+                'checked_at': datetime.now().isoformat(),
+            }
+        except requests.RequestException as e:
+            logger.warning(f"Could not HEAD {url} for manifest: {e}")
+            return None
+
+    def _iter_source_output_paths(self, source_id: str, source_config: dict):
+        """Yield (rel_path, absolute_path) for every file a source produced on disk.
+
+        Covers the per-source tree under output_dir/source_id plus any files relocated
+        via 'move_to' (which can land outside output_dir, e.g. ./aux_files/dmel/). The
+        sample/ subtree is excluded. rel_path is relative to output_dir where possible,
+        otherwise relative to cwd, so the manifest stays portable.
+        """
+        seen: set[Path] = set()
+        source_dir = self.output_dir / source_id
+        if source_dir.exists():
+            for fp in sorted(source_dir.rglob('*')):
+                if not fp.is_file():
+                    continue
+                if self.sample_root and self.sample_root in fp.parents:
+                    continue
+                seen.add(fp.resolve())
+                yield str(fp.relative_to(self.output_dir)), fp
+
+        # move_to destinations (normalised the same way process_download does)
+        raw_move_to = source_config.get('move_to', {})
+        if isinstance(raw_move_to, list):
+            move_to = {k: v for entry in raw_move_to for k, v in entry.items()}
+        else:
+            move_to = raw_move_to or {}
+        for filename, dest_str in move_to.items():
+            dest = (Path.cwd() / dest_str).resolve()
+            candidate = dest / filename if dest.is_dir() else dest
+            if candidate.is_file() and candidate.resolve() not in seen:
+                try:
+                    rel = str(candidate.relative_to(self.output_dir.resolve()))
+                except ValueError:
+                    rel = str(candidate.relative_to(Path.cwd())) if candidate.is_relative_to(Path.cwd()) else str(candidate)
+                yield rel, candidate
+
+    def _record_source_manifest(self, source_id: str, source_config: dict):
+        """Resolve a source's version and record its per-file provenance into the manifest."""
+        version_info = resolve_source(source_id, source_config, session=self.session)
+
+        files = []
+        for rel_path, abs_path in self._iter_source_output_paths(source_id, source_config):
+            size = abs_path.stat().st_size
+            do_checksum = self.compute_checksums and source_config.get('checksum', True)
+            sha = self._prior_file_hash(rel_path, size) if do_checksum else None
+            if do_checksum and sha is None:
+                sha = self._sha256(abs_path)
+            files.append({
+                'rel_path': rel_path,
+                'sha256': sha,
+                'size_bytes': size,
+                'downloaded_at': datetime.now().isoformat(),
+            })
+
+        # Attach HEAD metadata for the primary declared URL(s) (best-effort).
+        remote_metadata = {}
+        for url in list(version_info.url if isinstance(version_info.url, list) else [version_info.url]):
+            if isinstance(url, str) and url.startswith('http'):
+                meta = self._head_metadata(url.split('#')[0].strip())
+                if meta:
+                    remote_metadata[meta['url']] = meta
+
+        self.manifest_sources[source_id] = {
+            'name': source_config.get('name'),
+            'version': version_info.version,
+            'date': version_info.date,
+            'signature': version_info.signature,
+            'vtype': version_info.vtype,
+            'strategy': version_info.strategy,
+            'resolve_error': version_info.error,
+            'source_url': source_config.get('source_url'),
+            'citation': source_config.get('citation'),
+            'license': source_config.get('license'),
+            'declared_url': version_info.url,
+            'remote_metadata': remote_metadata,
+            'files': files,
+        }
+
+    def _write_manifest(self):
+        """Write download_manifest.json and append changed versions to versions.json."""
+        manifest = {
+            'manifest_version': MANIFEST_VERSION,
+            'config_file': str(self.config_path),
+            'generated_at': datetime.now().isoformat(),
+            'sources': self.manifest_sources,
+        }
+        with open(self._manifest_path(), 'w') as f:
+            json.dump(manifest, f, indent=2)
+        logger.info(f"Wrote provenance manifest: {self._manifest_path()}")
+
+        self._append_versions_history()
+
+    def _append_versions_history(self):
+        """Append-only per-source version history (bioversions-style).
+
+        A new release row is appended only when the resolved version/signature differs
+        from the last recorded one, so repeated runs don't bloat the history.
+        """
+        try:
+            with open(self._versions_path(), 'r') as f:
+                history = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            history = {}
+
+        now = datetime.now().isoformat()
+        for source_id, entry in self.manifest_sources.items():
+            token = entry.get('version') or entry.get('signature')
+            if token is None:
+                continue
+            rows = history.setdefault(source_id, [])
+            last = rows[-1] if rows else None
+            if not last or last.get('version') != entry.get('version') or last.get('signature') != entry.get('signature'):
+                rows.append({
+                    'retrieved': now,
+                    'version': entry.get('version'),
+                    'signature': entry.get('signature'),
+                    'date': entry.get('date'),
+                    'vtype': entry.get('vtype'),
+                })
+
+        with open(self._versions_path(), 'w') as f:
+            json.dump(history, f, indent=2)
 
     # ------------------------------------------------------------------
     # Core download primitive
@@ -756,7 +949,12 @@ class DownloadManager:
         """Download a single source by key."""
         if source_id not in self.config:
             raise ValueError(f"Source '{source_id}' not found in config")
-        self.process_download(source_id, self.config[source_id])
+        source_config = self.config[source_id]
+        self.process_download(source_id, source_config)
+        # Preserve other sources' prior manifest entries when refreshing just one.
+        self.manifest_sources = dict(self._prior_manifest.get('sources', {}))
+        self._record_source_manifest(source_id, source_config)
+        self._write_manifest()
 
     def download_all(self):
         """Download all sources defined in the config, then print a grouped error report."""
@@ -771,6 +969,12 @@ class DownloadManager:
             total_skipped    += s
             if f:
                 failed_by_source[source_id] = f
+            try:
+                self._record_source_manifest(source_id, source_config)
+            except Exception as e:
+                logger.warning(f"Could not record manifest entry for '{source_id}': {e}")
+
+        self._write_manifest()
 
         n_failed = sum(len(v) for v in failed_by_source.values())
         summary = (

--- a/biocypher_dataset_downloader/versioning/README.md
+++ b/biocypher_dataset_downloader/versioning/README.md
@@ -1,0 +1,92 @@
+# Dataset Version Resolution
+
+This package resolves the **version** of each input dataset declaratively, so versions live in one
+place (the data-source config) instead of being hardcoded across adapters. It powers the download
+provenance manifest and the `check-versions` staleness checker.
+
+For the end-to-end picture (manifest, build wiring, Neo4j lineage, CI), see
+[doc/dataset-versioning.md](../../doc/dataset-versioning.md). This README is the framework reference.
+
+## Overview
+
+A source entry in a `*_data_source_config.yaml` may carry an optional `version:` block. The
+registry turns that block into a `VersionGetter`, and the getter resolves the source to a
+`VersionInfo`. Because our URLs usually embed the version, a regex over the URL covers most sources
+with no per-source code.
+
+## Core contract
+
+- **`VersionInfo`** ([base.py](base.py)) — the result dataclass: `source_id`, `name`, `version`,
+  `date`, `url`, `signature` (opaque change token when there's no human version), `vtype`,
+  `strategy`, `resolved_at`, `error`.
+- **`VersionGetter`** ([base.py](base.py)) — abstract base. Subclasses implement `_resolve()`
+  returning a partial dict; the public `get()` wraps it. **Getters never raise** — any failure is
+  captured on `VersionInfo.error`, so one broken source can't abort a download or a staleness run.
+- **`resolve_source(source_id, source_config, session=None)`** — the one call sites use: builds the
+  configured getter and returns its `VersionInfo`.
+
+## Strategies ([strategies.py](strategies.py))
+
+| Class | `strategy` name | Resolves from | Required config |
+|---|---|---|---|
+| `UrlRegexGetter` | `url_regex` | A regex (one capture group) over the declared URL(s) | `pattern` |
+| `StaticGetter` | `static` | A declared constant | `value` |
+| `HttpHeadGetter` | `http_head` | HTTP HEAD `ETag`/`Last-Modified`/`Content-Length` → `signature` | none (the default) |
+
+The registry ([registry.py](registry.py)) selects the class from `version.strategy`; if the block
+is absent it defaults to `http_head`, and an unknown strategy name falls back to `http_head` with a
+warning (again, never raises).
+
+## Declaring a version on a source
+
+```yaml
+gencode:
+  name: GENCODE v49
+  version: {strategy: url_regex, pattern: 'gencode\.(v\d+)\.', vtype: sequential}
+  url: https://ftp.ebi.ac.uk/.../gencode.v49.annotation.gtf.gz
+```
+
+`UrlRegexGetter` matches the pattern against each declared URL until one captures (use `url_index`
+to pin which URL when several are declared). `StaticGetter` takes `value:`. `HttpHeadGetter` needs
+nothing — it's the fallback for `current/`-style URLs with no parseable version.
+
+See [doc/dataset-versioning.md](../../doc/dataset-versioning.md#declaring-a-source-version) for the
+full schema (including the `source_url` / `citation` / `license` / `checksum` provenance fields).
+
+## Using it from Python
+
+```python
+from biocypher_dataset_downloader.versioning import resolve_source
+
+info = resolve_source("gencode", source_config)   # source_config is the YAML dict for that source
+print(info.version)   # "v49"
+print(info.error)     # None, or the failure message
+```
+
+## Adding a new strategy
+
+1. Subclass `VersionGetter` in [strategies.py](strategies.py) and implement `_resolve()` returning a
+   partial dict of `{version, date, signature, vtype}`. Read your config from `self.spec` (the
+   `version:` block) and the declared URLs from `self.urls`.
+2. Set a unique `strategy` class attribute.
+3. Register it in the `STRATEGIES` dict at the bottom of `strategies.py`.
+
+```python
+class MyGetter(VersionGetter):
+    strategy = "my_strategy"
+
+    def _resolve(self) -> dict:
+        # self.spec -> the version: block; self.urls -> declared URLs; self.session -> requests session
+        return {"version": "...", "vtype": self.spec.get("vtype", "other")}
+
+STRATEGIES["my_strategy"] = MyGetter
+```
+
+Add a unit test in [test/test_versioning.py](../../test/test_versioning.py).
+
+## Planned
+
+A `LatestUrlGetter` (landing-page scraper) and/or an optional
+[bioversions](https://github.com/biopragmatics/bioversions) delegate would add true "is there a
+newer upstream release?" detection for pinned sources — the one thing a URL regex can't do. The
+framework shape above is designed to absorb it as just another strategy.

--- a/biocypher_dataset_downloader/versioning/__init__.py
+++ b/biocypher_dataset_downloader/versioning/__init__.py
@@ -1,0 +1,22 @@
+"""Dataset version resolution for biocypher-kg.
+
+Lightweight, declarative version detection for input datasets. Each source in a
+``{species}_data_source_config.yaml`` may carry an optional ``version:`` block selecting
+a resolver strategy (``url_regex`` / ``http_head`` / ``static``); the resolver turns the
+source config into a :class:`VersionInfo` recording the version, date, and a change
+signature. Used by the downloader to build a provenance manifest and by the staleness CLI.
+"""
+
+from biocypher_dataset_downloader.versioning.base import (
+    VersionInfo,
+    VersionGetter,
+    iter_source_urls,
+    resolve_source,
+)
+
+__all__ = [
+    "VersionInfo",
+    "VersionGetter",
+    "iter_source_urls",
+    "resolve_source",
+]

--- a/biocypher_dataset_downloader/versioning/base.py
+++ b/biocypher_dataset_downloader/versioning/base.py
@@ -1,0 +1,136 @@
+"""Core abstractions for dataset version resolution.
+
+A :class:`VersionGetter` turns one source entry from a data-source config into a
+:class:`VersionInfo`. Getters never raise: any failure is captured on
+``VersionInfo.error`` so a single broken source can't abort a whole download or
+staleness run.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from typing import Any, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now().isoformat()
+
+
+@dataclass
+class VersionInfo:
+    """Resolved version metadata for a single data source.
+
+    ``version`` is a human-meaningful release string when one can be determined
+    (e.g. ``v49``, ``2026_01``). When the source is pinned by URL with no parseable
+    version, or only a ``current/`` symlink is available, ``version`` may be ``None``
+    and ``signature`` carries an opaque change-detection token (ETag / Last-Modified /
+    size) instead.
+    """
+
+    source_id: str
+    name: Optional[str] = None
+    version: Optional[str] = None
+    date: Optional[str] = None
+    url: Any = None  # str | list | dict, as declared in the config
+    signature: Optional[str] = None  # opaque HEAD-derived change token
+    vtype: str = "other"  # semver | date | sequential | static | daily | other
+    strategy: str = ""
+    resolved_at: str = field(default_factory=_now_iso)
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _strip_url_comment(url: str) -> str:
+    """Drop an inline ``# comment`` from a config URL value (mirrors DownloadManager)."""
+    return url.split("#", 1)[0].strip() if isinstance(url, str) else url
+
+
+def iter_source_urls(source_config: dict) -> Iterator[str]:
+    """Yield every download URL declared in a source config, comments stripped.
+
+    Handles the same shapes DownloadManager accepts: ``url`` as str / list / dict
+    (either ``{filename: url}`` or ``{sub_key: [urls]}``), plus the specialised
+    ``bed_url`` / ``ep_base_url`` and ``zip_extract[].url`` keys.
+    """
+
+    def _walk(value: Any) -> Iterator[str]:
+        if value is None:
+            return
+        if isinstance(value, str):
+            cleaned = _strip_url_comment(value)
+            if cleaned.startswith("http") or cleaned.startswith("gs://") or cleaned.startswith("ftp"):
+                yield cleaned
+        elif isinstance(value, list):
+            for item in value:
+                yield from _walk(item)
+        elif isinstance(value, dict):
+            for item in value.values():
+                yield from _walk(item)
+
+    yield from _walk(source_config.get("url"))
+    for key in ("bed_url", "ep_base_url"):
+        if source_config.get(key):
+            yield _strip_url_comment(source_config[key])
+    for entry in source_config.get("zip_extract", []) or []:
+        if isinstance(entry, dict) and entry.get("url"):
+            yield _strip_url_comment(entry["url"])
+    for dir_url in (source_config.get("directories", {}) or {}).values():
+        if isinstance(dir_url, str):
+            yield _strip_url_comment(dir_url)
+
+
+class VersionGetter(ABC):
+    """Resolve the version of one data source. Subclasses implement :meth:`_resolve`."""
+
+    strategy: str = "base"
+
+    def __init__(self, source_id: str, source_config: dict, session: Any = None):
+        self.source_id = source_id
+        self.source_config = source_config or {}
+        self.session = session
+        self.spec = self.source_config.get("version") or {}
+
+    @property
+    def urls(self) -> list[str]:
+        return list(iter_source_urls(self.source_config))
+
+    @abstractmethod
+    def _resolve(self) -> dict:
+        """Return a partial dict of {version, date, signature, vtype}. May raise."""
+
+    def get(self) -> VersionInfo:
+        """Resolve to a :class:`VersionInfo`, capturing any error instead of raising."""
+        base = VersionInfo(
+            source_id=self.source_id,
+            name=self.source_config.get("name"),
+            url=self.source_config.get("url"),
+            strategy=self.strategy,
+            vtype=self.spec.get("vtype", "other"),
+        )
+        try:
+            resolved = self._resolve() or {}
+        except Exception as exc:  # getters must never abort the caller
+            logger.warning("Version resolution failed for '%s' (%s): %s", self.source_id, self.strategy, exc)
+            base.error = str(exc)
+            return base
+
+        base.version = resolved.get("version", base.version)
+        base.date = resolved.get("date", base.date)
+        base.signature = resolved.get("signature", base.signature)
+        base.vtype = resolved.get("vtype", base.vtype)
+        return base
+
+
+def resolve_source(source_id: str, source_config: dict, session: Any = None) -> VersionInfo:
+    """Build the configured getter for a source and resolve it to a :class:`VersionInfo`."""
+    # Imported here to avoid a circular import (registry imports from this module).
+    from biocypher_dataset_downloader.versioning.registry import build_getter
+
+    return build_getter(source_id, source_config, session=session).get()

--- a/biocypher_dataset_downloader/versioning/base.py
+++ b/biocypher_dataset_downloader/versioning/base.py
@@ -110,7 +110,10 @@ class VersionGetter(ABC):
         base = VersionInfo(
             source_id=self.source_id,
             name=self.source_config.get("name"),
-            url=self.source_config.get("url"),
+            # Keep the declared `url` structure when present; otherwise fall back to the
+            # resolved URLs so sources that use bed_url / zip_extract / directories still
+            # record a meaningful declared_url in the manifest.
+            url=self.source_config.get("url") or (self.urls or None),
             strategy=self.strategy,
             vtype=self.spec.get("vtype", "other"),
         )

--- a/biocypher_dataset_downloader/versioning/cli.py
+++ b/biocypher_dataset_downloader/versioning/cli.py
@@ -1,0 +1,164 @@
+"""``check-versions`` — report dataset staleness against recorded versions.
+
+Scope (see doc/plans/dataset-versioning-provenance.md, Stage 5): a resolver over a
+*pinned* URL cannot reveal a newer upstream release, so this checker detects only what
+is detectable from the config itself:
+
+- ``CHANGED``    — an ``http_head`` source's signature (ETag/Last-Modified/size) differs
+                   from what was last recorded (a ``current/`` file was refreshed).
+- ``drift``      — a resolved version differs from the recorded one (the config's pinned
+                   URL changed since the last download).
+- ``up-to-date`` — resolved token matches the recorded one.
+- ``unknown``    — pinned source with no recorded baseline; latest-release availability
+                   cannot be determined here (future: a LatestUrlGetter / bioversions delegate).
+- ``error``      — resolution failed.
+
+Exit code is non-zero if any source is ``CHANGED`` or ``drift`` so CI can act.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import requests
+import typer
+import yaml
+from requests.adapters import HTTPAdapter
+from typing_extensions import Annotated
+from urllib3.util.retry import Retry
+
+from biocypher_dataset_downloader.versioning.base import resolve_source
+
+logger = logging.getLogger(__name__)
+
+SPECIES = ["hsa", "dmel", "cel", "mmu", "rno"]
+STALE_STATUSES = {"CHANGED", "drift"}
+
+app = typer.Typer()
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+def _recorded_token(versions_history: dict, source_id: str) -> dict:
+    """Return the last recorded {version, signature} for a source, or {} if none."""
+    rows = (versions_history or {}).get(source_id) or []
+    return rows[-1] if rows else {}
+
+
+def evaluate_source(source_id: str, source_config: dict, recorded: dict, session=None) -> dict:
+    """Resolve a source now and classify it against its recorded baseline."""
+    info = resolve_source(source_id, source_config, session=session)
+    row = {
+        "source": source_id,
+        "strategy": info.strategy,
+        "recorded": recorded.get("version") or recorded.get("signature"),
+        "current": info.version or info.signature,
+        "date": info.date,
+        "status": "unknown",
+    }
+
+    if info.error:
+        row["status"] = "error"
+        row["error"] = info.error
+        return row
+
+    if not recorded:
+        # No baseline recorded yet. Signature sources are simply unverified; pinned
+        # sources can't have latest-availability inferred either.
+        row["status"] = "unknown"
+        return row
+
+    if info.strategy == "http_head":
+        row["status"] = "up-to-date" if info.signature == recorded.get("signature") else "CHANGED"
+    else:  # url_regex / static — version is pinned by the config URL
+        row["status"] = "up-to-date" if info.version == recorded.get("version") else "drift"
+
+    return row
+
+
+def check_versions_for_config(config_path: Path, versions_path: Optional[Path], session=None) -> list[dict]:
+    """Evaluate every source in one data_source_config against its recorded versions.json."""
+    with open(config_path, "r") as f:
+        sources = yaml.safe_load(f) or {}
+
+    history = {}
+    if versions_path and Path(versions_path).exists():
+        try:
+            with open(versions_path, "r") as f:
+                history = json.load(f)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Recorded versions file {versions_path} is invalid JSON ({e})")
+
+    rows = []
+    for source_id, source_config in sources.items():
+        if source_id == "name" or not isinstance(source_config, dict):
+            continue
+        rows.append(evaluate_source(source_id, source_config, _recorded_token(history, source_id), session=session))
+    return rows
+
+
+def _print_table(species: str, rows: list[dict]):
+    typer.echo(f"\n=== {species} ===")
+    typer.echo(f"{'source':<22} {'strategy':<10} {'recorded':<18} {'current':<18} {'status'}")
+    typer.echo("-" * 84)
+    for r in sorted(rows, key=lambda x: x["source"]):
+        typer.echo(
+            f"{r['source']:<22} {r['strategy']:<10} "
+            f"{str(r['recorded'] or '-'):<18} {str(r['current'] or '-'):<18} {r['status']}"
+        )
+
+
+@app.command()
+def check_versions(
+    species: str = typer.Option("all", help="Species to check (hsa/dmel/cel/mmu/rno) or 'all'."),
+    source: Optional[str] = typer.Option(None, help="Restrict to a single source id."),
+    config_dir: Path = typer.Option(Path("config"), help="Directory holding per-species config folders."),
+    versions_root: Optional[Path] = typer.Option(
+        None,
+        help="Base dir holding per-species recorded versions: <versions-root>/<species>/versions.json.",
+    ),
+    json_output: Annotated[bool, typer.Option("--json", help="Emit machine-readable JSON instead of a table.")] = False,
+):
+    """Compare each source's resolvable version against the last recorded one."""
+    species_list = SPECIES if species == "all" else [species]
+    session = _make_session()
+
+    all_rows: dict[str, list[dict]] = {}
+    any_stale = False
+
+    for sp in species_list:
+        config_path = config_dir / sp / f"{sp}_data_source_config.yaml"
+        if not config_path.exists():
+            logger.warning(f"No data source config for species '{sp}' at {config_path}; skipping")
+            continue
+        versions_path = (versions_root / sp / "versions.json") if versions_root else None
+
+        rows = check_versions_for_config(config_path, versions_path, session=session)
+        if source:
+            rows = [r for r in rows if r["source"] == source]
+        all_rows[sp] = rows
+        any_stale = any_stale or any(r["status"] in STALE_STATUSES for r in rows)
+
+    if json_output:
+        typer.echo(json.dumps(all_rows, indent=2))
+    else:
+        for sp, rows in all_rows.items():
+            _print_table(sp, rows)
+        n_stale = sum(1 for rows in all_rows.values() for r in rows if r["status"] in STALE_STATUSES)
+        typer.echo(f"\n{n_stale} source(s) CHANGED/drifted.")
+
+    raise typer.Exit(1 if any_stale else 0)
+
+
+if __name__ == "__main__":
+    app()

--- a/biocypher_dataset_downloader/versioning/cli.py
+++ b/biocypher_dataset_downloader/versioning/cli.py
@@ -1,8 +1,8 @@
 """``check-versions`` — report dataset staleness against recorded versions.
 
-Scope (see doc/plans/dataset-versioning-provenance.md, Stage 5): a resolver over a
-*pinned* URL cannot reveal a newer upstream release, so this checker detects only what
-is detectable from the config itself:
+Scope (see docs/knowledge-graph/dataset-versioning.md): a resolver over a *pinned* URL cannot reveal a
+newer upstream release, so this checker detects only what is detectable from the config
+itself:
 
 - ``CHANGED``    — an ``http_head`` source's signature (ETag/Last-Modified/size) differs
                    from what was last recorded (a ``current/`` file was refreshed).

--- a/biocypher_dataset_downloader/versioning/registry.py
+++ b/biocypher_dataset_downloader/versioning/registry.py
@@ -1,0 +1,38 @@
+"""Select the version-resolution strategy for a source from its config.
+
+A source's ``version:`` block names a strategy; absent a block, the default is
+``http_head`` (works for any HTTP source and detects ``current/`` refreshes).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from biocypher_dataset_downloader.versioning.base import VersionGetter
+from biocypher_dataset_downloader.versioning.strategies import STRATEGIES, HttpHeadGetter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STRATEGY = HttpHeadGetter.strategy
+
+
+def build_getter(source_id: str, source_config: dict, session: Any = None) -> VersionGetter:
+    """Return the configured :class:`VersionGetter` for a source.
+
+    The ``version.strategy`` field selects the class; an unknown strategy falls back
+    to the default with a warning rather than raising, so one bad config entry can't
+    break a whole run.
+    """
+    spec = (source_config or {}).get("version") or {}
+    strategy = spec.get("strategy", DEFAULT_STRATEGY)
+
+    cls = STRATEGIES.get(strategy)
+    if cls is None:
+        logger.warning(
+            "Unknown version strategy %r for source '%s'; falling back to %r",
+            strategy, source_id, DEFAULT_STRATEGY,
+        )
+        cls = STRATEGIES[DEFAULT_STRATEGY]
+
+    return cls(source_id, source_config, session=session)

--- a/biocypher_dataset_downloader/versioning/strategies.py
+++ b/biocypher_dataset_downloader/versioning/strategies.py
@@ -1,0 +1,121 @@
+"""Concrete version-resolution strategies.
+
+- :class:`StaticGetter`   — a declared constant version (sources with no upstream versioning).
+- :class:`UrlRegexGetter` — capture the version from the configured URL/filename via regex.
+                            Covers the common case where the version is embedded in the URL
+                            (``gencode.v49``, ``protein.links.v12.0``, ``..._fb_2026_01.tsv``).
+- :class:`HttpHeadGetter` — derive an opaque change signature from HTTP HEAD metadata
+                            (ETag / Last-Modified / Content-Length). The safe default and the
+                            only strategy that can detect a refresh of a ``current/`` symlink.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+import requests
+
+from biocypher_dataset_downloader.versioning.base import VersionGetter
+
+logger = logging.getLogger(__name__)
+
+
+class StaticGetter(VersionGetter):
+    """Return a fixed version declared in the config: ``version: {strategy: static, value: v11}``."""
+
+    strategy = "static"
+
+    def _resolve(self) -> dict:
+        value = self.spec.get("value")
+        if value is None:
+            raise ValueError("static strategy requires version.value")
+        return {"version": str(value), "vtype": self.spec.get("vtype", "static")}
+
+
+class UrlRegexGetter(VersionGetter):
+    """Extract the version from a configured URL via a regex with one capture group.
+
+    Config::
+
+        version:
+          strategy: url_regex
+          pattern: 'gencode\\.(v\\d+)\\.'
+          vtype: sequential        # optional
+          url_index: 0             # optional, which URL to match when several are declared
+
+    The pattern is matched against each declared URL (after stripping inline comments)
+    until one captures; group 1 is the version.
+    """
+
+    strategy = "url_regex"
+
+    def _resolve(self) -> dict:
+        pattern = self.spec.get("pattern")
+        if not pattern:
+            raise ValueError("url_regex strategy requires version.pattern")
+        regex = re.compile(pattern)
+
+        urls = self.urls
+        url_index = self.spec.get("url_index")
+        if url_index is not None:
+            urls = urls[url_index : url_index + 1]
+
+        for url in urls:
+            match = regex.search(url)
+            if match:
+                version = match.group(1) if match.groups() else match.group(0)
+                return {"version": version, "vtype": self.spec.get("vtype", "other")}
+
+        raise ValueError(f"pattern {pattern!r} matched none of {len(self.urls)} URL(s)")
+
+
+class HttpHeadGetter(VersionGetter):
+    """Derive a change signature from HTTP HEAD metadata of the primary URL.
+
+    This is the default when no ``version:`` block is present. It yields no human
+    version (``version`` stays ``None``) but records a ``signature`` token from
+    ETag / Last-Modified / Content-Length, which the staleness checker compares
+    across runs to detect a refreshed ``current/`` file.
+    """
+
+    strategy = "http_head"
+    timeout = 15
+
+    def _head(self, url: str) -> Optional[dict]:
+        sess = self.session or requests
+        try:
+            resp = sess.head(url, timeout=self.timeout, allow_redirects=True)
+            resp.raise_for_status()
+            return {
+                "etag": resp.headers.get("ETag"),
+                "last_modified": resp.headers.get("Last-Modified"),
+                "content_length": resp.headers.get("Content-Length"),
+            }
+        except requests.RequestException as exc:
+            logger.warning("HEAD failed for %s: %s", url, exc)
+            return None
+
+    def _resolve(self) -> dict:
+        urls = [u for u in self.urls if u.startswith("http")]
+        if not urls:
+            raise ValueError("http_head strategy needs at least one HTTP url")
+
+        meta = self._head(urls[0])
+        if not meta:
+            raise ValueError(f"could not HEAD {urls[0]}")
+
+        # Build an opaque, stable token; prefer the strongest available validator.
+        token = meta.get("etag") or meta.get("last_modified") or meta.get("content_length")
+        date = None
+        if meta.get("last_modified"):
+            date = meta["last_modified"]
+        return {"signature": token, "date": date, "vtype": self.spec.get("vtype", "daily")}
+
+
+STRATEGIES: dict[str, type[VersionGetter]] = {
+    StaticGetter.strategy: StaticGetter,
+    UrlRegexGetter.strategy: UrlRegexGetter,
+    HttpHeadGetter.strategy: HttpHeadGetter,
+}

--- a/biocypher_metta/adapters/disease_ontology_adapter.py
+++ b/biocypher_metta/adapters/disease_ontology_adapter.py
@@ -4,49 +4,52 @@ from biocypher._logger import logger
 from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
 
 class DiseaseOntologyAdapter(OntologyAdapter):
+    # Disease Ontology is fetched from OBOLibrary, which needs no API key. OBOLibrary
+    # is occasionally unreachable, so if its load fails we fall back to BioPortal —
+    # but only when a BIOPORTAL_API_KEY is available (e.g. set in your .env).
+    OBO_URL = 'https://purl.obolibrary.org/obo/doid.owl'
+
     @classmethod
     def _get_ontologies(cls):
+        return {'do': cls.OBO_URL}
+
+    @staticmethod
+    def _bioportal_url():
+        """BioPortal DO download URL, or None when no API key is configured."""
         api_key = os.getenv('BIOPORTAL_API_KEY')
         if not api_key:
-            # No key (e.g. CI without the secret, or a full sample run): disable the
-            # adapter instead of hard-failing the whole pipeline. It yields nothing in
-            # this state; set BIOPORTAL_API_KEY in your .env to ingest the Disease Ontology.
-            logger.warning(
-                "BIOPORTAL_API_KEY not set; DiseaseOntologyAdapter is disabled and will "
-                "yield no nodes/edges. Set it in your .env to ingest the Disease Ontology."
-            )
-            return {}
-        return {
-            # 'do': 'https://purl.obolibrary.org/obo/do.owl'
-            # Sometimes the above link doesn't respond. This is an alternative:
-            'do': f'https://data.bioontology.org/ontologies/DOID/submissions/654/download?apikey={api_key}'
-        }
+            return None
+        return f'https://data.bioontology.org/ontologies/DOID/submissions/654/download?apikey={api_key}'
 
     def __init__(self, write_properties, add_provenance, ontology, type, label='disease', dry_run=False, add_description=False, cache_dir=None):
         self.ONTOLOGIES = self._get_ontologies()
-        self._enabled = bool(self.ONTOLOGIES)
         super(DiseaseOntologyAdapter, self).__init__(write_properties, add_provenance, ontology, type, label, dry_run, add_description, cache_dir)
 
-    def get_nodes(self):
-        if not self._enabled:
-            return
-        yield from super().get_nodes()
-
-    def get_edges(self):
-        if not self._enabled:
-            return
-        yield from super().get_edges()
-
+    def update_graph(self):
+        """Load DO from OBOLibrary; if that fails, retry once via BioPortal (if a key is set)."""
+        try:
+            return super().update_graph()
+        except Exception as obo_error:
+            fallback_url = self._bioportal_url()
+            # No key for a fallback, or we already switched to BioPortal — surface the error.
+            if not fallback_url or self.ONTOLOGIES.get(self.ontology) == fallback_url:
+                raise
+            logger.warning(
+                f"Loading Disease Ontology from OBOLibrary failed ({obo_error}); "
+                "retrying via BioPortal (BIOPORTAL_API_KEY detected)."
+            )
+            self.ONTOLOGIES[self.ontology] = fallback_url
+            return super().update_graph()
 
     def get_ontology_source(self):
         """
         Returns the source and source URL for Disease Ontology (DO).
         """
-        return 'Disease Ontology', 'https://purl.obolibrary.org/obo/do.owl' 
+        return 'Disease Ontology', 'https://purl.obolibrary.org/obo/do.owl'
 
     def get_uri_prefixes(self):
         """Define URI prefixes for Sequence Ontology."""
         return {
             'primary': 'http://purl.obolibrary.org/obo/DOID_',
             'clo': 'http://purl.obolibrary.org/obo/CL_',
-        }                
+        }

--- a/biocypher_metta/adapters/disease_ontology_adapter.py
+++ b/biocypher_metta/adapters/disease_ontology_adapter.py
@@ -1,5 +1,6 @@
 
 import os
+from biocypher._logger import logger
 from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
 
 class DiseaseOntologyAdapter(OntologyAdapter):
@@ -7,20 +8,36 @@ class DiseaseOntologyAdapter(OntologyAdapter):
     def _get_ontologies(cls):
         api_key = os.getenv('BIOPORTAL_API_KEY')
         if not api_key:
-            raise EnvironmentError(
-                "BIOPORTAL_API_KEY environment variable is not set. "
-                "Please add it to your .env file to download the Disease Ontology."
+            # No key (e.g. CI without the secret, or a full sample run): disable the
+            # adapter instead of hard-failing the whole pipeline. It yields nothing in
+            # this state; set BIOPORTAL_API_KEY in your .env to ingest the Disease Ontology.
+            logger.warning(
+                "BIOPORTAL_API_KEY not set; DiseaseOntologyAdapter is disabled and will "
+                "yield no nodes/edges. Set it in your .env to ingest the Disease Ontology."
             )
+            return {}
         return {
             # 'do': 'https://purl.obolibrary.org/obo/do.owl'
             # Sometimes the above link doesn't respond. This is an alternative:
             'do': f'https://data.bioontology.org/ontologies/DOID/submissions/654/download?apikey={api_key}'
         }
-    
+
     def __init__(self, write_properties, add_provenance, ontology, type, label='disease', dry_run=False, add_description=False, cache_dir=None):
         self.ONTOLOGIES = self._get_ontologies()
+        self._enabled = bool(self.ONTOLOGIES)
         super(DiseaseOntologyAdapter, self).__init__(write_properties, add_provenance, ontology, type, label, dry_run, add_description, cache_dir)
-    
+
+    def get_nodes(self):
+        if not self._enabled:
+            return
+        yield from super().get_nodes()
+
+    def get_edges(self):
+        if not self._enabled:
+            return
+        yield from super().get_edges()
+
+
     def get_ontology_source(self):
         """
         Returns the source and source URL for Disease Ontology (DO).

--- a/biocypher_metta/provenance.py
+++ b/biocypher_metta/provenance.py
@@ -1,0 +1,90 @@
+"""Resolve dataset provenance for adapters from the download manifest.
+
+At build time the KG pipeline reads ``download_manifest.json`` (written by the
+downloader) so each adapter's dataset version / URL / checksum comes from a single
+authoritative record instead of drifting hardcoded ``self.version`` attributes.
+
+Provenance is keyed by **source_id**, derived from an adapter entry's ``outdir``
+first path segment (e.g. ``gencode/gene`` -> ``gencode``) or an explicit
+``source_id:`` field on the adapter entry. Keying by source_id (rather than by file
+path) is robust to sample paths, renamed files, and intermediate processor outputs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def source_id_for_adapter(adapter_entry: dict) -> Optional[str]:
+    """Derive the manifest source_id for an adapter entry.
+
+    Prefers an explicit ``source_id`` field; otherwise uses the first path segment
+    of ``outdir`` (``gencode/gene`` -> ``gencode``). Returns None if neither is set.
+    """
+    explicit = adapter_entry.get("source_id")
+    if explicit:
+        return str(explicit)
+    outdir = adapter_entry.get("outdir")
+    if isinstance(outdir, str) and outdir.strip():
+        return outdir.strip().strip("/").split("/")[0]
+    return None
+
+
+class ProvenanceLookup:
+    """Read a download manifest and resolve per-source provenance by source_id."""
+
+    def __init__(self, manifest_path: Path):
+        self.manifest_path = Path(manifest_path)
+        self.sources: dict = {}
+        try:
+            with open(self.manifest_path, "r") as f:
+                self.sources = (json.load(f) or {}).get("sources", {})
+            logger.info(f"Loaded provenance manifest ({len(self.sources)} sources): {self.manifest_path}")
+        except FileNotFoundError:
+            logger.warning(f"Provenance manifest not found at {self.manifest_path}; provenance disabled.")
+        except json.JSONDecodeError as e:
+            logger.warning(f"Provenance manifest at {self.manifest_path} is invalid JSON ({e}); provenance disabled.")
+
+    def __bool__(self) -> bool:
+        return bool(self.sources)
+
+    def for_source(self, source_id: Optional[str]) -> Optional[dict]:
+        """Return provenance for a source_id, or None if not in the manifest.
+
+        Shape: ``{version, source_url, date, citation, license, checksums}`` where
+        ``checksums`` maps each file's rel_path to its sha256.
+        """
+        if not source_id:
+            return None
+        entry = self.sources.get(source_id)
+        if not entry:
+            return None
+        return {
+            "version": entry.get("version"),
+            "source_url": entry.get("source_url"),
+            "date": entry.get("date"),
+            "citation": entry.get("citation"),
+            "license": entry.get("license"),
+            "checksums": {f["rel_path"]: f.get("sha256") for f in entry.get("files", []) if f.get("rel_path")},
+        }
+
+    def attach(self, adapters_dict: dict) -> int:
+        """Attach a ``provenance`` dict to each adapter entry it can resolve.
+
+        Returns the number of adapters matched. Adapters with no manifest match keep
+        ``provenance == None`` and fall back to their own attributes at build time.
+        """
+        matched = 0
+        for entry in adapters_dict.values():
+            if not isinstance(entry, dict):
+                continue
+            prov = self.for_source(source_id_for_adapter(entry))
+            entry["provenance"] = prov
+            if prov:
+                matched += 1
+        return matched

--- a/config/cel/cel_data_source_config.yaml
+++ b/config/cel/cel_data_source_config.yaml
@@ -1,8 +1,9 @@
 # ---
 
 # 31_0_0: https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_8/by_species/caenorhabditis_elegans/
-alliance:    
+alliance:
   name: Alliance of Genome Resources
+  version: {strategy: url_regex, pattern: 'alliancegenome\.org/(\d+\.\d+\.\d+)/', vtype: semver}
   extract: false
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
@@ -18,6 +19,7 @@ bgee:
 
 coxpressdb:
   name: Coxpress DB
+  version: {strategy: url_regex, pattern: '\.(v[\d-]+)\.', vtype: other}
   url: https://zenodo.org/record/6861444/files/Cel-u.v22-05.G14532-S7142.combat_pca.subagging.z.d.zip
 
 # enhancer_atlas:
@@ -26,7 +28,8 @@ coxpressdb:
 
 ensembl:
   name: Ensembl Assembly 235.v62
-  url: 
+  version: {strategy: url_regex, pattern: '(WBcel235\.[\d.]+)\.gtf', vtype: other}
+  url:
     - https://ftp.ebi.ac.uk/ensemblgenomes/pub/metazoa/current/gtf/caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.62.gtf.gz
     - https://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Invertebrates/Caenorhabditis_elegans.gene_info.gz
 
@@ -59,6 +62,7 @@ rna_central:
 
 string:
   name: STRING PPI
+  version: {strategy: url_regex, pattern: 'protein\.links\.(?:detailed\.)?(v[\d.]+)', vtype: semver}
   url:
     - https://stringdb-downloads.org/download/protein.links.v12.0/6239.protein.links.v12.0.txt.gz
     - https://stringdb-downloads.org/download/protein.links.detailed.v12.0/6239.protein.links.detailed.v12.0.txt.gz  # detailed version
@@ -66,6 +70,7 @@ string:
 
 tflink:
   name: TFLink
+  version: {strategy: url_regex, pattern: '_(v[\d.]+)\.tsv', vtype: semver}
   compress: gzip
   url: https://cdn.netbiol.org/tflink/download_files/TFLink_Caenorhabditis_elegans_interactions_All_simpleFormat_v1.0.tsv
 

--- a/config/dmel/dmel_adapters_config.yaml
+++ b/config/dmel/dmel_adapters_config.yaml
@@ -497,7 +497,7 @@ gencode_gene:
     module: biocypher_metta.adapters.gencode_gene_adapter
     cls: GencodeGeneAdapter
     args:
-      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.63.gtf.gz
       gene_alias_file_path: ./aux_files/dmel/Drosophila_melanogaster.gene_info.gz
       label: gene
       taxon_id: 7227
@@ -510,7 +510,7 @@ gencode_transcripts:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.63.gtf.gz
       type: transcript
       label: transcript
       taxon_id: 7227
@@ -523,7 +523,7 @@ transcribes_to:
     module: biocypher_metta.adapters.gencode_transcript_adapter
     cls: GencodeTranscriptAdapter
     args:
-      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.63.gtf.gz
       type: transcribes to
       label: transcribes_to
       taxon_id: 7227
@@ -536,7 +536,7 @@ gencode_exon:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.63.gtf.gz
       target_type: None
       label: exon
       taxon_id: 7227
@@ -549,7 +549,7 @@ exon_part_of_transcript:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.63.gtf.gz
       label: part_of_transcript
       target_type: transcript
       taxon_id: 7227
@@ -562,7 +562,7 @@ exon_part_of_gene:
     module: biocypher_metta.adapters.gencode_exon_adapter
     cls: GencodeExonAdapter
     args:
-      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+      filepath: ensembl/Drosophila_melanogaster.BDGP6.54.63.gtf.gz
       label: part_of_gene
       target_type: gene      
       taxon_id: 7227

--- a/config/dmel/dmel_data_source_config.yaml
+++ b/config/dmel/dmel_data_source_config.yaml
@@ -1,6 +1,7 @@
 # ---
 alliance:    # agr: alliance of genome resource
   name: Alliance Genome Resource
+  version: {strategy: url_regex, pattern: 'alliancegenome\.org/(\d+\.\d+\.\d+)/', vtype: semver}
   extract: false
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
@@ -17,12 +18,14 @@ bgee:
 
 coxpressdb:
   name: Coxpress DB
+  version: {strategy: url_regex, pattern: '\.(v[\d-]+)\.', vtype: other}
   url: https://zenodo.org/record/6861444/files/Dme-u.v22-05.G12209-S15610.combat_pca.subagging.z.d.zip
 
 ensembl:
   name: Ensembl Assembly 54.v62
+  version: {strategy: url_regex, pattern: '(BDGP6\.[\d.]+)\.gtf', vtype: other}
   extract: false
-  url: 
+  url:
     # - https://ftp.ebi.ac.uk/ensemblgenomes/pub/metazoa/current/gtf/drosophila_melanogaster/Drosophila_melanogaster.BDGP6.54.62.chr.gtf.gz
     - https://ftp.ebi.ac.uk/ensemblgenomes/pub/metazoa/current/gtf/drosophila_melanogaster/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
     - https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Invertebrates/Drosophila_melanogaster.gene_info.gz
@@ -34,10 +37,14 @@ epd:
   compress: gzip
   url: https://epd.expasy.org/ftp/epdnew/D_melanogaster/current/Dm_EPDnew.bed
 
-flybase: 
+flybase:
   name: Flybase 2026_01
+  # Replaces the per-adapter FlybasePrecomputedTable.extract_date_string() logic:
+  # the release (fb_2026_01) is parsed from the filename for every FlyBase file.
+  version: {strategy: url_regex, pattern: 'fb_(\d{4}_\d{2})', vtype: date}
+  source_url: https://flybase.org/
   extract: false
-  url: 
+  url:
     - https://s3ftp.flybase.org/releases/current/precomputed_files/alleles/allele_genetic_interactions_fb_2026_01.tsv.gz
     - https://s3ftp.flybase.org/releases/current/precomputed_files/alleles/fbal_to_fbgn_fb_2026_01.tsv.gz
     - https://s3ftp.flybase.org/releases/current/precomputed_files/alleles/genotype_phenotype_data_fb_2026_01.tsv.gz
@@ -86,6 +93,7 @@ rna_central:
 
 string:
   name: STRING PPI
+  version: {strategy: url_regex, pattern: 'protein\.links\.(?:detailed\.)?(v[\d.]+)', vtype: semver}
   extract: false
   url:
     - https://stringdb-downloads.org/download/protein.links.v12.0/7227.protein.links.v12.0.txt.gz
@@ -93,6 +101,7 @@ string:
 
 tflink:
   name: TFLink
+  version: {strategy: url_regex, pattern: '_(v[\d.]+)\.tsv', vtype: semver}
   compress: gzip
   url: https://cdn.netbiol.org/tflink/download_files/TFLink_Drosophila_melanogaster_interactions_All_simpleFormat_v1.0.tsv
 

--- a/config/dmel/dmel_data_source_config.yaml
+++ b/config/dmel/dmel_data_source_config.yaml
@@ -27,7 +27,7 @@ ensembl:
   extract: false
   url:
     # - https://ftp.ebi.ac.uk/ensemblgenomes/pub/metazoa/current/gtf/drosophila_melanogaster/Drosophila_melanogaster.BDGP6.54.62.chr.gtf.gz
-    - https://ftp.ebi.ac.uk/ensemblgenomes/pub/metazoa/current/gtf/drosophila_melanogaster/Drosophila_melanogaster.BDGP6.54.62.gtf.gz
+    - https://ftp.ebi.ac.uk/ensemblgenomes/pub/metazoa/current/gtf/drosophila_melanogaster/Drosophila_melanogaster.BDGP6.54.63.gtf.gz
     - https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Invertebrates/Drosophila_melanogaster.gene_info.gz
   move_to:
     - Drosophila_melanogaster.gene_info.gz: ./aux_files/dmel/

--- a/config/hsa/hsa_data_source_config.yaml
+++ b/config/hsa/hsa_data_source_config.yaml
@@ -48,7 +48,7 @@ cCRE:
       files:
         - V4-hg38.Gene-Links.eQTLs.txt
 
-coxpresdb:
+coxpressdb:
   name: Coxpress DB
   version: {strategy: url_regex, pattern: '\.(v[\d-]+)\.', vtype: other}
   extract: true

--- a/config/hsa/hsa_data_source_config.yaml
+++ b/config/hsa/hsa_data_source_config.yaml
@@ -1,11 +1,13 @@
 ---
 abc:
   name: Activity-By-Contact (ABC)
+  version: {strategy: url_regex, pattern: '/abc/(v[\d.]+)/', vtype: semver}
   extract: false
   url: https://forgedb.cancer.gov/api/abc/v1.0/abc.forgedb.csv.gz
 
-alliance:  
+alliance:
   name: agr - alliance of genome resource
+  version: {strategy: url_regex, pattern: 'alliancegenome\.org/(\d+\.\d+\.\d+)/', vtype: semver}
   extract: false
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
@@ -21,11 +23,13 @@ bgee:
 
 cadd:
   name: Combined Annotation Dependent Depletion (CADD)
+  version: {strategy: url_regex, pattern: '/cadd/(v[\d.]+)/', vtype: semver}
   extract: false
   url: https://forgedb.cancer.gov/api/cadd/v1.0/cadd.forgedb.csv.gz
 
 catlas:
   name: CATLAS Single-Cell Chromatin Accessibility Atlas (v1, hg38)
+  version: {strategy: url_regex, pattern: 'catlas(v\d+)', vtype: sequential}
   url:
     cCRE_hg38.tsv.gz: https://decoder-genetics.wustl.edu/catlasv1/humanenhancer/data/cCRE_hg38.tsv.gz
     Cell_ontology.tsv: https://decoder-genetics.wustl.edu/catlasv1/humanenhancer/data/Cell_ontology.tsv
@@ -46,11 +50,14 @@ cCRE:
 
 coxpresdb:
   name: Coxpress DB
+  version: {strategy: url_regex, pattern: '\.(v[\d-]+)\.', vtype: other}
   extract: true
   url: https://zenodo.org/record/6861444/files/Hsa-u.v22-05.G16651-S245698.combat_pca.subagging.z.d.zip
 
 dbsnp:
   name: dbSNP
+  version: {strategy: url_regex, pattern: '_(b\d+)_', vtype: sequential}
+  checksum: false   # multi-GB VCFs — skip sha256 (HEAD metadata + version still recorded)
   extract: false
   url:
     - https://ftp.ncbi.nih.gov/snp/organisms/human_9606_b151_GRCh38p7/VCF/00-All.vcf.gz
@@ -69,6 +76,7 @@ dbvar:
 
 dgv:
   name: Database of Genomic Variants
+  version: {strategy: url_regex, pattern: 'variants_(\d{4}-\d{2}-\d{2})', vtype: date}
   compress: gzip
   # url: http://dgv.tcag.ca/dgv/docs/GRCh38_hg38_variants_2020-02-25.txt        # adapters use gzipped version.
   url: https://dgv.tcag.ca/dgv/docs/GRCh38_hg38_variants_2025-12-01.txt
@@ -214,11 +222,14 @@ gaf:
 
 gencode:            # About the file to be downloaded:	"It contains the comprehensive gene annotation on the reference chromosomes only"
   name: GENCODE v49
+  version: {strategy: url_regex, pattern: 'gencode\.(v\d+)\.', vtype: sequential}
+  source_url: https://www.gencodegenes.org/
   extract: false
-  url: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/latest_release/gencode.v49.annotation.gtf.gz       
+  url: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/latest_release/gencode.v49.annotation.gtf.gz
 
 gtex_eqtl:
   name: GTEx eQTL
+  version: {strategy: url_regex, pattern: 'GTEx_Analysis_(v\d+)', vtype: sequential}
   # bucket: adult-gtex
   # path: bulk-qtl/v8/single-tissue-cis-qtl/GTEx_Analysis_v8_eQTL.tar
   url: https://storage.googleapis.com/adult-gtex/bulk-qtl/v10/single-tissue-cis-qtl/GTEx_Analysis_v10_eQTL.tar
@@ -231,6 +242,7 @@ gwas:
 
 hocomoco:
   name: HOCOMOCOv11
+  version: {strategy: static, value: v11}
   extract_tar: true
   url:
     annotation: https://hocomoco11.autosome.org/final_bundle/hocomoco11/core/HUMAN/mono/HOCOMOCOv11_core_annotation_HUMAN_mono.tsv
@@ -238,14 +250,16 @@ hocomoco:
 
 hpo:
   name: Human Phenotype Ontology Phenotype and disease associations
-  url: 
+  version: {strategy: url_regex, pattern: 'releases/download/v(\d{4}-\d{2}-\d{2})/', vtype: date}
+  url:
   - https://github.com/obophenotype/human-phenotype-ontology/releases/download/v2025-11-24/genes_to_disease.txt
   - https://github.com/obophenotype/human-phenotype-ontology/releases/download/v2025-11-24/genes_to_phenotype.txt
 
 polyphen2:
   name: PolyPhen-2
+  version: {strategy: url_regex, pattern: 'polyphen-([\d.]+)-whess', vtype: semver}
   extract: true
-  url: https://genetics.bwh.harvard.edu/downloads/pph2/whess/polyphen-2.2.2-whess-2011_12.tab.gz        
+  url: https://genetics.bwh.harvard.edu/downloads/pph2/whess/polyphen-2.2.2-whess-2011_12.tab.gz
 
 reactome:
   name: Reactome
@@ -263,6 +277,7 @@ reactome:
 
 refseq:
   name: RefSeq Closest Gene
+  version: {strategy: url_regex, pattern: '/closest_gene/(v[\d.]+)/', vtype: semver}
   extract: false
   url: https://forgedb.cancer.gov/api/closest_gene/v1.0/closest_gene.forgedb.csv.gz
 
@@ -289,6 +304,7 @@ rna_central:
 
 string:
   name: STRING PPI
+  version: {strategy: url_regex, pattern: 'protein\.links\.(?:detailed\.)?(v[\d.]+)', vtype: semver}
   extract: false
   url:
     - https://stringdb-downloads.org/download/protein.links.v12.0/9606.protein.links.v12.0.txt.gz
@@ -304,6 +320,7 @@ tfbs:
 
 tflink:
   name: TFLink
+  version: {strategy: url_regex, pattern: '_(v[\d.]+)\.tsv', vtype: semver}
   extract: false
   url: https://cdn.netbiol.org/tflink/download_files/TFLink_Homo_sapiens_interactions_All_simpleFormat_v1.0.tsv.gz
 

--- a/config/mmu/mmu_data_source_config.yaml
+++ b/config/mmu/mmu_data_source_config.yaml
@@ -1,6 +1,7 @@
 # ---
-alliance:    
+alliance:
   name: Alliance of Genome Resources
+  version: {strategy: url_regex, pattern: 'alliancegenome\.org/(\d+\.\d+\.\d+)/', vtype: semver}
   extract: false
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
@@ -17,6 +18,7 @@ bgee:
 
 coxpressdb:
   name: Coxpress DB
+  version: {strategy: url_regex, pattern: '\.(v[\d-]+)\.', vtype: other}
   extract: true
   url: https://zenodo.org/record/6861444/files/Mmu-r.v22-05.G17008-S214753.combat_pca.subagging.z.d.zip
 
@@ -38,8 +40,10 @@ gaf:
 
 gencode:
   name: GENCODE Release M38 (GRCm39)
+  version: {strategy: url_regex, pattern: 'gencode\.(vM\d+)\.', vtype: sequential}
+  source_url: https://www.gencodegenes.org/
   extract: false
-  url: 
+  url:
     - https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_mouse/release_M38/gencode.vM38.chr_patch_hapl_scaff.annotation.gtf.gz
     - https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Mus_musculus.gene_info.gz
 
@@ -65,13 +69,15 @@ rna_central:
 
 string:
   name: STRING PPI
+  version: {strategy: url_regex, pattern: 'protein\.links\.(?:detailed\.)?(v[\d.]+)', vtype: semver}
   extract: false
-  url: 
+  url:
     - https://stringdb-downloads.org/download/protein.links.v12.0/10090.protein.links.v12.0.txt.gz
     - https://stringdb-downloads.org/download/protein.links.detailed.v12.0/10090.protein.links.detailed.v12.0.txt.gz
 
 tflink:
   name: TFLink
+  version: {strategy: url_regex, pattern: '_(v[\d.]+)\.tsv', vtype: semver}
   extract: false
   url: https://cdn.netbiol.org/tflink/download_files/TFLink_Mus_musculus_interactions_All_simpleFormat_v1.0.tsv.gz
 

--- a/config/rno/rno_data_source_config.yaml
+++ b/config/rno/rno_data_source_config.yaml
@@ -1,6 +1,7 @@
 # ---
-alliance:    
+alliance:
   name: Alliance of Genome Resources
+  version: {strategy: url_regex, pattern: 'alliancegenome\.org/(\d+\.\d+\.\d+)/', vtype: semver}
   extract: false
   url:
     - https://fms.alliancegenome.org/download/DISEASE-ALLIANCE_COMBINED.tsv.gz  # gene to disease
@@ -17,6 +18,7 @@ bgee:
 
 coxpressdb:
   name: Coxpress DB
+  version: {strategy: url_regex, pattern: '\.(v[\d-]+)\.', vtype: other}
   extract: true
   url: https://zenodo.org/record/6861444/files/Rno-u.v22-05.G16521-S21139.combat_pca.subagging.z.d.zip
 
@@ -26,8 +28,9 @@ coxpressdb:
     
 ensembl:
   name: Ensembl Assembly 8.v115
+  version: {strategy: url_regex, pattern: '(GRCr8\.[\d.]+)\.gtf', vtype: other}
   extract: false
-  url: 
+  url:
     - https://ftp.ensembl.org/pub/current/gtf/rattus_norvegicus/Rattus_norvegicus.GRCr8.115.gtf.gz
     - https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Rattus_norvegicus.gene_info.gz
 
@@ -64,14 +67,16 @@ rna_central:
 
 string:
   name: STRING PPI
+  version: {strategy: url_regex, pattern: 'protein\.links\.(?:detailed\.)?(v[\d.]+)', vtype: semver}
   extract: false
-  url: 
+  url:
     - https://stringdb-downloads.org/download/protein.links.v12.0/10116.protein.links.v12.0.txt.gz
     - https://stringdb-downloads.org/download/protein.links.detailed.v12.0/10116.protein.links.detailed.v12.0.txt.gz
 
 
 tflink:
   name: TFLink
+  version: {strategy: url_regex, pattern: '_(v[\d.]+)\.tsv', vtype: semver}
   compress: gzip
   url: https://cdn.netbiol.org/tflink/download_files/TFLink_Rattus_norvegicus_interactions_All_simpleFormat_v1.0.tsv
 

--- a/create_knowledge_graph.py
+++ b/create_knowledge_graph.py
@@ -33,6 +33,7 @@ from biocypher_metta.networkx_writer import NetworkXWriter
 from biocypher_metta.parquet_writer import ParquetWriter
 from biocypher_metta.processors import DBSNPProcessor
 from biocypher_metta.prolog_writer import PrologWriter
+from biocypher_metta.provenance import ProvenanceLookup
 from checkpoint_manager import CheckpointManager, prompt_resume_or_restart
 from config.yaml_loader import load_yaml_with_includes
 from schema_generator.generate_data_source_schemas import SchemaGenerator
@@ -345,7 +346,8 @@ def _has_bare_paths(adapters_dict: dict) -> bool:
 
 
 def _load_adapters_config(
-    config_path: Path, context: str, input_dir: Optional[Path] = None
+    config_path: Path, context: str, input_dir: Optional[Path] = None,
+    manifest_path: Optional[Path] = None,
 ) -> dict:
     with open(config_path, "r") as fp:
         try:
@@ -363,6 +365,20 @@ def _load_adapters_config(
             "Adapter config contains bare (un-prefixed) paths but no input_dir was set. "
             "Pass --input-dir or add 'input_dir:' to the config."
         )
+
+    # Attach dataset provenance from the download manifest, if available. Explicit
+    # --manifest wins; otherwise look for download_manifest.json beside input_dir.
+    chosen_manifest = manifest_path
+    if chosen_manifest is None and resolved is not None:
+        candidate = Path(resolved) / "download_manifest.json"
+        if candidate.exists():
+            chosen_manifest = candidate
+    if chosen_manifest is not None:
+        lookup = ProvenanceLookup(chosen_manifest)
+        if lookup:
+            matched = lookup.attach(adapters_dict)
+            logger.info(f"Attached provenance to {matched}/{len(adapters_dict)} adapters for {context}")
+
     return adapters_dict
 
 
@@ -565,9 +581,14 @@ def process_adapters(
         write_edges = adapters_dict[adapter_name]["edges"]
         outdir = adapters_dict[adapter_name]["outdir"]
 
+        # Dataset provenance: prefer the download manifest (single source of truth),
+        # fall back to the adapter's own attributes when no manifest entry exists.
+        # dataset_name stays adapter-derived: it drives the CSV 'source' column and
+        # version_manager's source discovery, so it must match what the adapter writes.
+        prov = adapters_dict[adapter_name].get("provenance") or {}
         dataset_name = getattr(adapter, "source", None)
-        version = getattr(adapter, "version", None)
-        source_url = getattr(adapter, "source_url", None)
+        version = prov.get("version") or getattr(adapter, "version", None)
+        source_url = prov.get("source_url") or getattr(adapter, "source_url", None)
 
         if dataset_name is None:
             logger.warning(
@@ -579,6 +600,10 @@ def process_adapters(
                 "name": dataset_name,
                 "version": version,
                 "url": source_url,
+                "date": prov.get("date"),
+                "citation": prov.get("citation"),
+                "license": prov.get("license"),
+                "checksums": prov.get("checksums"),
                 "nodes": set(),
                 "edges": set(),
                 "imported_on": str(date.today()),
@@ -966,6 +991,15 @@ def main(
             "Overrides the input_dir field declared in the config YAML."
         ),
     ),
+    manifest: Optional[Path] = typer.Option(
+        None,
+        "--manifest",
+        help=(
+            "Path to download_manifest.json for dataset provenance (version/url/checksum). "
+            "If omitted, looks for download_manifest.json beside the resolved input_dir. "
+            "Not used with --species all (each species auto-discovers its own manifest)."
+        ),
+    ),
 ):
     """
     Main function. Call individual adapters to download and process data. Build
@@ -1271,7 +1305,7 @@ def main(
             bc.overwrite = overwrite
 
         schema_dict = preprocess_schema(schema_config)
-        adapters_dict = _load_adapters_config(adapters_config, str(adapters_config), input_dir=input_dir)
+        adapters_dict = _load_adapters_config(adapters_config, str(adapters_config), input_dir=input_dir, manifest_path=manifest)
 
         if include_adapters:
             original_count = len(adapters_dict)

--- a/doc/dataset-versioning.md
+++ b/doc/dataset-versioning.md
@@ -269,4 +269,3 @@ same inputs), then rebuild with `--manifest`. Matching checksums guarantee ident
 
 - [biocypher_dataset_downloader/versioning/README.md](../biocypher_dataset_downloader/versioning/README.md) —
   the resolver framework and how to add a new strategy.
-- [doc/plans/dataset-versioning-provenance.md](plans/dataset-versioning-provenance.md) — the original design plan.

--- a/doc/dataset-versioning.md
+++ b/doc/dataset-versioning.md
@@ -1,0 +1,272 @@
+# Dataset Versioning & Provenance
+
+BioCypher-KG builds knowledge graphs from ~40 input datasets per species (GENCODE, dbSNP,
+Reactome, UniProt, STRING, GTEx, …). This document explains how the version and provenance of
+each dataset is captured, where it is stored, and how to declare it for a new source.
+
+## Why this exists
+
+Previously, dataset versions were hardcoded in individual adapters (`self.version = 'v49'`) and in
+config file paths. They drifted out of sync — for example two GENCODE adapters reading the *same*
+`gencode.v49` file reported `v49` and `v44` — and there was no single answer to "which version of
+each source produced this knowledge graph". That makes a build hard to reproduce or cite.
+
+Now there is **one source of truth**: the data-source config. A version flows along a single path:
+
+```
+config/<species>/<species>_data_source_config.yaml   (you declare how to find the version)
+        │   downloader resolves + records
+        ▼
+<output_dir>/download_manifest.json   +   <output_dir>/versions.json   (per species)
+        │   build reads it via --manifest
+        ▼
+<output_dir>/graph_info.json  → datasets[] (version, url, checksums, citation, license)
+        │   Neo4j loader reads graph_info
+        ▼
+(:KGVersion).source_provenance_json   (upstream version + checksums per KG version)
+```
+
+The design is declarative and lightweight: because our source URLs usually already embed the
+version (`gencode.v49`, `protein.links.v12.0`, `..._fb_2026_01.tsv`), a small regex over the URL
+captures it — no per-source scraper code is needed.
+
+## Declaring a source version
+
+Each entry in a `*_data_source_config.yaml` may carry an optional `version:` block plus optional
+provenance fields. Everything is backward-compatible — a source with no `version:` block defaults
+to the `http_head` strategy.
+
+### Strategies
+
+| Strategy | When to use | Fields |
+|---|---|---|
+| `url_regex` | The version is embedded in the download URL/filename (most sources) | `pattern` (regex with **one capture group**), `vtype` (optional), `url_index` (optional — which URL to match when several are declared) |
+| `static` | The source has a fixed version that isn't in the URL | `value` (the version string), `vtype` (optional) |
+| `http_head` | **Default.** No parseable version (e.g. a `current/` symlink); track changes instead | none — uses the file's `ETag` / `Last-Modified` / `Content-Length` as a change signature |
+
+`vtype` is a free-form classification (`semver`, `date`, `sequential`, `static`, `other`, …) and is
+recorded for reference only.
+
+### Extra provenance fields (all optional)
+
+| Field | Meaning |
+|---|---|
+| `source_url` | Human-facing landing page for the source (used in `graph_info.json` and the paper) |
+| `citation` | Citation string for the dataset |
+| `license` | License/terms string |
+| `checksum: false` | Skip sha256 for this source's files (use for multi-GB files like dbSNP VCFs) |
+
+### Examples (taken from the live configs)
+
+`url_regex` — version parsed from the URL:
+
+```yaml
+gencode:
+  name: GENCODE v49
+  version: {strategy: url_regex, pattern: 'gencode\.(v\d+)\.', vtype: sequential}
+  source_url: https://www.gencodegenes.org/
+  url: https://ftp.ebi.ac.uk/.../gencode.v49.annotation.gtf.gz
+```
+
+`static` — fixed version:
+
+```yaml
+hocomoco:
+  name: HOCOMOCOv11
+  version: {strategy: static, value: v11}
+```
+
+`url_regex` replacing per-adapter logic — the dmel FlyBase block reproduces what
+`FlybasePrecomputedTable.extract_date_string()` did, declaratively, for every FlyBase file:
+
+```yaml
+flybase:
+  name: Flybase 2026_01
+  version: {strategy: url_regex, pattern: 'fb_(\d{4}_\d{2})', vtype: date}
+```
+
+Skipping checksums on a huge source:
+
+```yaml
+dbsnp:
+  version: {strategy: url_regex, pattern: '_(b\d+)_', vtype: sequential}
+  checksum: false   # multi-GB VCFs — HEAD metadata + version still recorded
+```
+
+A source with **no** `version:` block (e.g. a `current/` symlink) falls back to `http_head`
+automatically — its version stays unknown but a change signature is recorded.
+
+> **Multi-species note.** The same logical source can carry a different version per species
+> (`alliance` is `8.3.0`, `bgee` uses a `current/` symlink, `ensembl`/`epd`/`flybase` differ). There
+> is no global registry — each `<species>_data_source_config.yaml` declares its own blocks, and the
+> manifest is written per species.
+
+## The download manifest
+
+Running the downloader writes two files into the download `--output-dir` (one pair **per species**):
+
+- **`download_manifest.json`** — the authoritative per-run record. Shape:
+
+  ```json
+  {
+    "manifest_version": 1,
+    "config_file": "config/hsa/hsa_data_source_config.yaml",
+    "generated_at": "2026-06-12T10:00:00",
+    "sources": {
+      "gencode": {
+        "name": "GENCODE v49",
+        "version": "v49",
+        "date": null,
+        "signature": null,
+        "vtype": "sequential",
+        "strategy": "url_regex",
+        "resolve_error": null,
+        "source_url": "https://www.gencodegenes.org/",
+        "citation": null,
+        "license": null,
+        "declared_url": "https://ftp.ebi.ac.uk/.../gencode.v49.annotation.gtf.gz",
+        "remote_metadata": { "<url>": {"last_modified": "...", "etag": "...", "content_length": "...", "checked_at": "..."} },
+        "files": [
+          {"rel_path": "gencode/gencode.v49.annotation.gtf", "sha256": "…", "size_bytes": 1481234567, "downloaded_at": "..."}
+        ]
+      }
+    }
+  }
+  ```
+
+- **`versions.json`** — an append-only history per source. A new row is appended only when the
+  resolved `version`/`signature` changes, so repeated runs don't bloat it:
+
+  ```json
+  { "gencode": [ {"retrieved": "2026-06-12T10:00:00", "version": "v49", "signature": null, "date": null, "vtype": "sequential"} ] }
+  ```
+
+### Checksums
+
+By default every downloaded file is sha256-hashed. Hashes are **carried forward** for files that
+didn't change between runs (matched by relative path + size), so large datasets aren't re-hashed
+each time. To skip hashing entirely:
+
+- `--no-checksum` on the download command (whole run), or
+- `checksum: false` on an individual source (e.g. dbSNP).
+
+Files relocated by `move_to` (e.g. dmel files moved to `aux_files/dmel/`) are still recorded.
+
+## Provenance at build time
+
+`create_knowledge_graph.py` reads the manifest so the generated graph carries authoritative
+versions instead of the hardcoded adapter attributes:
+
+```bash
+uv run python create_knowledge_graph.py \
+  --adapters-config config/hsa/hsa_adapters_config.yaml \
+  --schema-config   config/hsa/hsa_schema_config.yaml \
+  --output-dir      output_hsa \
+  --manifest        <download_dir>/download_manifest.json
+```
+
+If `--manifest` is omitted, the build looks for `download_manifest.json` beside the resolved
+`input_dir`. Provenance is matched to adapters **by `source_id`** — derived from the adapter
+entry's `outdir` first segment (`gencode/gene` → `gencode`), or an explicit `source_id:` field on
+the adapter entry. When a source isn't in the manifest, the build falls back to the adapter's own
+attributes, so nothing breaks.
+
+The resolved provenance lands in `graph_info.json` under each `datasets[]` entry:
+
+```json
+{
+  "name": "GENCODE",
+  "version": "v49",
+  "url": "https://www.gencodegenes.org/",
+  "date": null,
+  "citation": null,
+  "license": null,
+  "checksums": {"gencode/gencode.v49.annotation.gtf": "…"},
+  "nodes": ["gene", "transcript"],
+  "edges": ["transcribes_to"],
+  "imported_on": "2026-06-12"
+}
+```
+
+> Sample runs (`*_adapters_config_sample.yaml`) use bundled `./samples/...` data and have **no**
+> manifest — they run normally and fall back to adapter attributes. Provenance is a full-run feature.
+
+## Checking for stale or changed sources
+
+`check-versions` resolves each source's current version and compares it to the last recorded one:
+
+```bash
+# All species, table output
+uv run python -m biocypher_dataset_downloader.versioning.cli \
+  --config-dir config --versions-root <dir-with-per-species-versions>
+
+# One species, machine-readable
+uv run python -m biocypher_dataset_downloader.versioning.cli \
+  --species hsa --versions-root <…> --json
+
+# One source
+uv run python -m biocypher_dataset_downloader.versioning.cli --species hsa --source gencode --versions-root <…>
+```
+
+Options: `--species` (`hsa`/`dmel`/`cel`/`mmu`/`rno` or `all`, default `all`), `--source`,
+`--config-dir` (default `config`), `--versions-root` (`<root>/<species>/versions.json`), `--json`.
+
+Status meanings:
+
+| Status | Meaning |
+|---|---|
+| `up-to-date` | Resolved token matches the recorded one |
+| `CHANGED` | An `http_head` source's signature differs — a `current/` file was refreshed upstream |
+| `drift` | A resolved version differs from the recorded one — the config's pinned URL changed since the last download |
+| `unknown` | Pinned source with no recorded baseline; latest-release availability can't be determined here |
+| `error` | Resolution failed (e.g. regex matched nothing) |
+
+The command exits non-zero if any source is `CHANGED` or `drift`.
+
+> **Known limit.** A regex over a *pinned* URL can never reveal that a newer upstream release
+> exists — the URL still names the old version. Pinned sources are therefore reported `unknown`
+> rather than a misleading `up-to-date`. True latest-release discovery (a landing-page scraper or a
+> [bioversions](https://github.com/biopragmatics/bioversions) delegate) is a planned future add-on.
+
+### Scheduled CI
+
+`.github/workflows/check-dataset-versions.yml` runs `check-versions` weekly (and on manual
+dispatch), uploads the JSON report as an artifact, and opens an issue when sources are
+`CHANGED`/`drift`. It compares against committed baselines in `versioning/baselines/<species>/versions.json`.
+Until those baselines are seeded (copy a real download run's `versions.json` there), the job is a
+quiet no-op pass.
+
+## Neo4j lineage
+
+When the versioned Neo4j loader finalizes a build, each `KGVersion` node records the upstream
+provenance it was built from, read from `graph_info.json`:
+
+```
+(:KGVersion {version, ..., source_provenance_json})
+```
+
+`source_provenance_json` maps each dataset to `{upstream_version, source_url, checksums}`. Example
+query — find every KG version built from GENCODE v49:
+
+```cypher
+MATCH (v:KGVersion)
+WHERE apoc.convert.fromJsonMap(v.source_provenance_json).GENCODE.upstream_version = "v49"
+RETURN v.version, v.created_at
+```
+
+## Reproducing a published knowledge graph
+
+For a given KG build you have a complete, citable chain:
+
+1. `graph_info.json` `datasets[]` — the exact version, URL, and sha256 of every source used.
+2. `download_manifest.json` — the per-file checksums and HTTP metadata captured at download time.
+3. `(:KGVersion).source_provenance_json` — the same provenance attached to the loaded graph version.
+
+To reproduce: re-download with the same config (the manifest's `version`/sha256 confirm you got the
+same inputs), then rebuild with `--manifest`. Matching checksums guarantee identical inputs.
+
+## See also
+
+- [biocypher_dataset_downloader/versioning/README.md](../biocypher_dataset_downloader/versioning/README.md) —
+  the resolver framework and how to add a new strategy.
+- [doc/plans/dataset-versioning-provenance.md](plans/dataset-versioning-provenance.md) — the original design plan.

--- a/kg-service/version_manager.py
+++ b/kg-service/version_manager.py
@@ -270,11 +270,38 @@ class VersionManager:
         
         logger.info(f"✅ Created DatasetVersion nodes")
 
+    def read_source_provenance(self, output_dir) -> dict:
+        """Read upstream source provenance from the build's graph_info.json.
+
+        Returns {dataset_name: {upstream_version, source_url, checksums}} captured from
+        the download manifest at build time. Empty dict if graph_info.json is absent or
+        has no datasets — provenance is additive, never required.
+        """
+        graph_info_path = Path(output_dir) / "graph_info.json"
+        try:
+            with open(graph_info_path, "r") as f:
+                graph_info = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            logger.warning(f"No usable graph_info.json for provenance ({e}); skipping upstream lineage")
+            return {}
+
+        provenance = {}
+        for dataset in graph_info.get("datasets", []):
+            name = dataset.get("name")
+            if not name:
+                continue
+            provenance[name] = {
+                "upstream_version": dataset.get("version"),
+                "source_url": dataset.get("url"),
+                "checksums": dataset.get("checksums"),
+            }
+        return provenance
+
     def create_version_node(self, version: str, build_id: str,
                             changed: list, unchanged: list,
-                            dataset_versions: dict):
-        """Create global KGVersion node"""
-        
+                            dataset_versions: dict, source_provenance: dict = None):
+        """Create global KGVersion node, recording upstream source provenance (lineage)."""
+
         with self.driver.session() as session:
             session.run("""
                 CREATE (v:KGVersion {
@@ -284,7 +311,8 @@ class VersionManager:
                     created_at: $created_at,
                     changed_datasets: $changed,
                     unchanged_datasets: $unchanged,
-                    dataset_versions_json: $dataset_versions_json
+                    dataset_versions_json: $dataset_versions_json,
+                    source_provenance_json: $source_provenance_json
                 })
             """, version=version,
                  db_type=self.db_type,
@@ -292,7 +320,8 @@ class VersionManager:
                  created_at=datetime.utcnow().isoformat() + 'Z',
                  changed=changed,
                  unchanged=unchanged,
-                 dataset_versions_json=json.dumps(dataset_versions))
+                 dataset_versions_json=json.dumps(dataset_versions),
+                 source_provenance_json=json.dumps(source_provenance or {}))
 
         logger.info(f"✅ Created KGVersion node: {version}")
 
@@ -427,13 +456,17 @@ class VersionManager:
         # Create DatasetVersion nodes
         self.create_dataset_version_nodes(dataset_info)
 
+        # Read upstream source provenance (versions/urls/checksums) from graph_info.json
+        source_provenance = self.read_source_provenance(output_dir)
+
         # Create KGVersion node
         self.create_version_node(
             version=atomspace_version,
             build_id=build_id,
             changed=changed_datasets,
             unchanged=unchanged_datasets,
-            dataset_versions=dataset_versions
+            dataset_versions=dataset_versions,
+            source_provenance=source_provenance,
         )
 
         logger.info(f"✅ Version {atomspace_version} finalized!")

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -1,0 +1,81 @@
+"""Unit tests for build-time dataset provenance (biocypher_metta/provenance.py)."""
+
+import json
+
+from biocypher_metta.provenance import ProvenanceLookup, source_id_for_adapter
+
+
+def test_source_id_from_outdir_first_segment():
+    assert source_id_for_adapter({"outdir": "gencode/gene"}) == "gencode"
+    assert source_id_for_adapter({"outdir": "reactome"}) == "reactome"
+    assert source_id_for_adapter({"outdir": "/gtex/eqtl/"}) == "gtex"
+
+
+def test_explicit_source_id_overrides_outdir():
+    assert source_id_for_adapter({"source_id": "string", "outdir": "x/y"}) == "string"
+
+
+def test_source_id_none_when_unset():
+    assert source_id_for_adapter({}) is None
+    assert source_id_for_adapter({"outdir": ""}) is None
+
+
+def _write_manifest(tmp_path):
+    manifest = {
+        "sources": {
+            "gencode": {
+                "version": "v49",
+                "source_url": "https://www.gencodegenes.org/",
+                "date": "2026-01-01",
+                "citation": "Frankish 2021",
+                "license": "EBI",
+                "files": [{"rel_path": "gencode/x.gtf", "sha256": "abc123"}],
+            }
+        }
+    }
+    path = tmp_path / "download_manifest.json"
+    path.write_text(json.dumps(manifest))
+    return path
+
+
+def test_for_source_returns_full_provenance(tmp_path):
+    lookup = ProvenanceLookup(_write_manifest(tmp_path))
+    prov = lookup.for_source("gencode")
+    assert prov["version"] == "v49"
+    assert prov["source_url"] == "https://www.gencodegenes.org/"
+    assert prov["citation"] == "Frankish 2021"
+    assert prov["checksums"] == {"gencode/x.gtf": "abc123"}
+
+
+def test_for_source_unknown_returns_none(tmp_path):
+    lookup = ProvenanceLookup(_write_manifest(tmp_path))
+    assert lookup.for_source("not-a-source") is None
+    assert lookup.for_source(None) is None
+
+
+def test_attach_matches_by_source_id(tmp_path):
+    lookup = ProvenanceLookup(_write_manifest(tmp_path))
+    adapters = {
+        "gencode_gene": {"outdir": "gencode/gene"},
+        "gencode_exon": {"outdir": "gencode/exon"},
+        "unknown_src": {"outdir": "nope"},
+    }
+    matched = lookup.attach(adapters)
+    assert matched == 2  # both gencode adapters resolve to the same source
+    assert adapters["gencode_gene"]["provenance"]["version"] == "v49"
+    assert adapters["unknown_src"]["provenance"] is None
+
+
+def test_missing_manifest_is_falsy_and_safe(tmp_path):
+    lookup = ProvenanceLookup(tmp_path / "does-not-exist.json")
+    assert not lookup
+    assert lookup.for_source("gencode") is None
+    # attach must not raise even with no sources
+    assert lookup.attach({"a": {"outdir": "x"}}) == 0
+
+
+def test_invalid_manifest_json_is_falsy(tmp_path):
+    bad = tmp_path / "download_manifest.json"
+    bad.write_text("{not valid json")
+    lookup = ProvenanceLookup(bad)
+    assert not lookup

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -1,0 +1,276 @@
+"""Unit tests for the dataset version-resolution framework.
+
+Covers the three resolver strategies and the graceful-failure contract (getters
+never raise; errors land on ``VersionInfo.error``).
+"""
+
+import json
+
+import pytest
+
+from biocypher_dataset_downloader.versioning import resolve_source, iter_source_urls
+from biocypher_dataset_downloader.versioning.registry import build_getter
+from biocypher_dataset_downloader.versioning.strategies import (
+    StaticGetter,
+    UrlRegexGetter,
+    HttpHeadGetter,
+)
+
+
+def test_url_regex_extracts_gencode_version():
+    cfg = {
+        "name": "GENCODE v49",
+        "url": "https://ftp.ebi.ac.uk/.../gencode.v49.annotation.gtf.gz",
+        "version": {"strategy": "url_regex", "pattern": r"gencode\.(v\d+)\.", "vtype": "sequential"},
+    }
+    vi = resolve_source("gencode", cfg)
+    assert vi.version == "v49"
+    assert vi.vtype == "sequential"
+    assert vi.strategy == "url_regex"
+    assert vi.error is None
+
+
+def test_url_regex_extracts_flybase_release_from_filename():
+    # Reproduces dmel's extract_date_string() behaviour declaratively.
+    cfg = {
+        "url": ["https://s3ftp.flybase.org/releases/current/precomputed_files/alleles/fbal_to_fbgn_fb_2026_01.tsv.gz"],
+        "version": {"strategy": "url_regex", "pattern": r"fb_(\d{4}_\d{2})"},
+    }
+    vi = resolve_source("flybase", cfg)
+    assert vi.version == "2026_01"
+
+
+def test_url_regex_no_match_captures_error_without_raising():
+    cfg = {"url": "https://x/y.txt", "version": {"strategy": "url_regex", "pattern": r"(v\d+)"}}
+    vi = resolve_source("bad", cfg)
+    assert vi.version is None
+    assert vi.error is not None
+
+
+def test_static_getter_returns_declared_value():
+    cfg = {"url": "https://x/y", "version": {"strategy": "static", "value": "v11"}}
+    vi = resolve_source("hocomoco", cfg)
+    assert vi.version == "v11"
+    assert vi.vtype == "static"
+
+
+def test_static_without_value_errors_gracefully():
+    cfg = {"url": "https://x/y", "version": {"strategy": "static"}}
+    vi = resolve_source("x", cfg)
+    assert vi.version is None
+    assert vi.error is not None
+
+
+def test_iter_source_urls_handles_str_list_and_dict_shapes():
+    assert list(iter_source_urls({"url": "https://a/x.gz  # comment"})) == ["https://a/x.gz"]
+    assert list(iter_source_urls({"url": ["https://a/1", "https://a/2"]})) == ["https://a/1", "https://a/2"]
+    dict_cfg = {"url": {"f1.gz": "https://a/f1.gz", "f2.tsv": "https://a/f2.tsv"}}
+    assert sorted(iter_source_urls(dict_cfg)) == ["https://a/f1.gz", "https://a/f2.tsv"]
+
+
+def test_iter_source_urls_includes_special_keys():
+    cfg = {
+        "bed_url": "https://a/bed.tar.gz",
+        "zip_extract": [{"url": "https://a/z.zip", "files": ["x"]}],
+        "directories": {"d": "https://a/dir/"},
+    }
+    urls = set(iter_source_urls(cfg))
+    assert {"https://a/bed.tar.gz", "https://a/z.zip", "https://a/dir/"} <= urls
+
+
+def test_default_strategy_is_http_head():
+    g = build_getter("x", {"url": "https://a/x"})
+    assert g.strategy == "http_head"
+    assert isinstance(g, HttpHeadGetter)
+
+
+def test_unknown_strategy_falls_back_to_default():
+    g = build_getter("x", {"version": {"strategy": "does-not-exist"}})
+    assert isinstance(g, HttpHeadGetter)
+
+
+def test_http_head_signature_from_mocked_session():
+    class _Resp:
+        headers = {"ETag": '"abc123"', "Last-Modified": "Wed, 01 Jan 2026 00:00:00 GMT"}
+
+        def raise_for_status(self):
+            pass
+
+    class _Session:
+        def head(self, url, timeout=None, allow_redirects=None):
+            return _Resp()
+
+    cfg = {"url": "https://a/current/x.gz", "version": {"strategy": "http_head"}}
+    vi = build_getter("bgee", cfg, session=_Session()).get()
+    assert vi.signature == '"abc123"'
+    assert vi.version is None
+    assert vi.error is None
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: DownloadManager provenance manifest
+# ---------------------------------------------------------------------------
+
+import yaml
+
+from biocypher_dataset_downloader.download_manager import DownloadManager
+
+
+def _manager(tmp_path, sources, **kwargs):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(sources))
+    out = tmp_path / "out"
+    out.mkdir()
+    mgr = DownloadManager(str(cfg_path), out, **kwargs)
+    mgr._head_metadata = lambda url: None  # no network in tests
+    return mgr, out
+
+
+def _gencode_cfg():
+    return {
+        "name": "GENCODE v49",
+        "url": "https://ftp.ebi.ac.uk/x/gencode.v49.annotation.gtf.gz",
+        "version": {"strategy": "url_regex", "pattern": r"gencode\.(v\d+)\.", "vtype": "sequential"},
+        "source_url": "https://www.gencodegenes.org/",
+        "citation": "Frankish 2021",
+    }
+
+
+def test_manifest_records_version_and_checksum(tmp_path):
+    cfg = {"gencode": _gencode_cfg()}
+    mgr, out = _manager(tmp_path, cfg)
+    (out / "gencode").mkdir()
+    (out / "gencode" / "gencode.v49.annotation.gtf").write_text("chr1\tx\n" * 100)
+
+    mgr._record_source_manifest("gencode", cfg["gencode"])
+    mgr._write_manifest()
+
+    manifest = json.loads((out / "download_manifest.json").read_text())
+    g = manifest["sources"]["gencode"]
+    assert g["version"] == "v49"
+    assert g["vtype"] == "sequential"
+    assert g["source_url"] == "https://www.gencodegenes.org/"
+    assert g["citation"] == "Frankish 2021"
+    assert g["files"][0]["rel_path"] == "gencode/gencode.v49.annotation.gtf"
+    assert g["files"][0]["sha256"]
+
+    versions = json.loads((out / "versions.json").read_text())
+    assert len(versions["gencode"]) == 1
+    assert versions["gencode"][0]["version"] == "v49"
+
+
+def test_manifest_carries_forward_unchanged_hashes(tmp_path):
+    cfg = {"gencode": _gencode_cfg()}
+    mgr, out = _manager(tmp_path, cfg)
+    (out / "gencode").mkdir()
+    (out / "gencode" / "gencode.v49.annotation.gtf").write_text("chr1\tx\n" * 100)
+    mgr._record_source_manifest("gencode", cfg["gencode"])
+    mgr._write_manifest()
+    first_hash = json.loads((out / "download_manifest.json").read_text())["sources"]["gencode"]["files"][0]["sha256"]
+
+    # Second run: same file -> must reuse the recorded hash, never re-hash.
+    mgr2 = DownloadManager(str(tmp_path / "cfg.yaml"), out)
+    mgr2._head_metadata = lambda url: None
+
+    def _boom(_p):
+        raise AssertionError("should not re-hash an unchanged file")
+
+    mgr2._sha256 = _boom
+    mgr2._record_source_manifest("gencode", cfg["gencode"])
+    mgr2._write_manifest()
+
+    assert json.loads((out / "download_manifest.json").read_text())["sources"]["gencode"]["files"][0]["sha256"] == first_hash
+    # Unchanged version -> history not duplicated.
+    assert len(json.loads((out / "versions.json").read_text())["gencode"]) == 1
+
+
+def test_no_checksum_skips_sha256(tmp_path):
+    cfg = {"gencode": _gencode_cfg()}
+    mgr, out = _manager(tmp_path, cfg, compute_checksums=False)
+    (out / "gencode").mkdir()
+    (out / "gencode" / "gencode.v49.annotation.gtf").write_text("x\n")
+    mgr._record_source_manifest("gencode", cfg["gencode"])
+    assert mgr.manifest_sources["gencode"]["files"][0]["sha256"] is None
+
+
+def test_sample_subtree_excluded_from_manifest(tmp_path):
+    cfg = {"gencode": _gencode_cfg()}
+    mgr, out = _manager(tmp_path, cfg)
+    (out / "gencode").mkdir()
+    (out / "gencode" / "gencode.v49.annotation.gtf").write_text("x\n")
+    (out / "sample" / "gencode").mkdir(parents=True)
+    (out / "sample" / "gencode" / "gencode.v49.annotation.gtf").write_text("x\n")
+
+    mgr._record_source_manifest("gencode", cfg["gencode"])
+    rels = [f["rel_path"] for f in mgr.manifest_sources["gencode"]["files"]]
+    assert rels == ["gencode/gencode.v49.annotation.gtf"]
+
+
+# ---------------------------------------------------------------------------
+# Stage 5: staleness checker
+# ---------------------------------------------------------------------------
+
+from biocypher_dataset_downloader.versioning.cli import evaluate_source, check_versions_for_config
+
+
+def test_evaluate_pinned_source_matches_recorded_is_up_to_date():
+    cfg = {"url": "https://x/gencode.v49.x.gz", "version": {"strategy": "url_regex", "pattern": r"(v\d+)"}}
+    row = evaluate_source("gencode", cfg, {"version": "v49"})
+    assert row["current"] == "v49"
+    assert row["status"] == "up-to-date"
+
+
+def test_evaluate_pinned_source_version_mismatch_is_drift():
+    # Config URL now says v50 but the recorded download was v49 -> config drifted.
+    cfg = {"url": "https://x/gencode.v50.x.gz", "version": {"strategy": "url_regex", "pattern": r"(v\d+)"}}
+    row = evaluate_source("gencode", cfg, {"version": "v49"})
+    assert row["current"] == "v50"
+    assert row["status"] == "drift"
+
+
+def test_evaluate_no_baseline_is_unknown():
+    cfg = {"url": "https://x/gencode.v49.x.gz", "version": {"strategy": "url_regex", "pattern": r"(v\d+)"}}
+    row = evaluate_source("gencode", cfg, {})
+    assert row["status"] == "unknown"
+
+
+def test_evaluate_resolution_error_is_error():
+    cfg = {"url": "https://x/y.txt", "version": {"strategy": "url_regex", "pattern": r"(v\d+)"}}
+    row = evaluate_source("bad", cfg, {"version": "v1"})
+    assert row["status"] == "error"
+
+
+def test_evaluate_http_head_signature_change_is_changed():
+    class _Resp:
+        headers = {"ETag": '"new"'}
+
+        def raise_for_status(self):
+            pass
+
+    class _Session:
+        def head(self, url, timeout=None, allow_redirects=None):
+            return _Resp()
+
+    cfg = {"url": "https://x/current/y.gz", "version": {"strategy": "http_head"}}
+    row = evaluate_source("bgee", cfg, {"signature": '"old"'}, session=_Session())
+    assert row["status"] == "CHANGED"
+    row2 = evaluate_source("bgee", cfg, {"signature": '"new"'}, session=_Session())
+    assert row2["status"] == "up-to-date"
+
+
+def test_check_versions_for_config_reads_history(tmp_path):
+    cfg = {
+        "gencode": {"url": "https://x/gencode.v49.gz", "version": {"strategy": "url_regex", "pattern": r"(v\d+)"}},
+        "hocomoco": {"url": "https://x/h.txt", "version": {"strategy": "static", "value": "v11"}},
+        "name": "ignored-scalar",
+    }
+    cfg_path = tmp_path / "hsa_data_source_config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    versions = {"gencode": [{"version": "v49"}], "hocomoco": [{"version": "v10"}]}
+    vpath = tmp_path / "versions.json"
+    vpath.write_text(json.dumps(versions))
+
+    rows = {r["source"]: r for r in check_versions_for_config(cfg_path, vpath)}
+    assert "name" not in rows  # scalar config keys skipped
+    assert rows["gencode"]["status"] == "up-to-date"
+    assert rows["hocomoco"]["status"] == "drift"  # config says v11, recorded v10


### PR DESCRIPTION
## Summary
Adds a single source of truth for the version & provenance of every input dataset. Versions were
previously hardcoded across 32 adapters and drifted (two GENCODE adapters reading the same v49 file
reported `v49` and `v44`). Now the version is declared once in the data-source config and flows:

config → download manifest → graph_info.json → Neo4j KGVersion lineage.

The approach is declarative + lightweight: because source URLs usually embed the version
(`gencode.v49`, `protein.links.v12.0`, `…_fb_2026_01.tsv`), a small regex captures it — no
per-source scraper code.

## What's included
- **Resolver framework** (`biocypher_dataset_downloader/versioning/`): `url_regex`, `http_head`
  (default), and `static` strategies behind a getter that never raises.
- **Download manifest**: each download writes `download_manifest.json` + an append-only
  `versions.json` (per species) with version, sha256, and HTTP metadata. sha256 is carried forward
  for unchanged files; `--no-checksum` / per-source `checksum: false` opt out.
- **Build provenance**: `create_knowledge_graph.py --manifest` feeds versions into
  `graph_info.json` `datasets[]`, overriding hardcoded adapter attributes (matched by `source_id`).
- **Neo4j lineage**: each `KGVersion` records `source_provenance_json` (upstream version + sha256 +
  url per dataset).
- **Staleness checker**: `check-versions` CLI (`up-to-date`/`CHANGED`/`drift`/`unknown`/`error`,
  non-zero exit) + a weekly GitHub Action that opens an issue on change.
- **Config annotations**: `version:` blocks for 36 sources across all five species. The dmel
  FlyBase block replaces the per-adapter `extract_date_string()` logic declaratively.
- **Docs**: README section, full reference guide (`doc/dataset-versioning.md`), package README.

## Testing
- 28 unit tests (`test/test_versioning.py`, `test/test_provenance.py`).
- Live-verified: real download → manifest/versions.json, sha256 carry-forward, cross-invocation
  merge, `--no-checksum`, and `check-versions` drift detection with exit code 1.

## Known limitation
A regex over a *pinned* URL can't reveal a newer upstream release; pinned sources report `unknown`
rather than a false `up-to-date`. True latest-release discovery (a landing-page scraper or a
bioversions delegate) is a designed-for future add-on.

## Out of scope / follow-ups
- Removing the now-redundant hardcoded `self.version` lines from adapters (manifest overrides them).
- Seeding CI baselines under `versioning/baselines/<species>/versions.json`.
- `checksum: false` for the largest sources.

## Incidental fix (unblocks CI)

This PR also includes a small, unrelated fix to `disease_ontology_adapter.py`.

**Why it's here:** the `test-adapters` workflow runs the *full* sample adapter set
whenever `create_knowledge_graph.py` changes — which this PR does. That surfaced a
**pre-existing** gap: `disease_ontology` hard-`raise`d when `BIOPORTAL_API_KEY` was
unset, and CI doesn't provide that key, so the build failed at adapter 138/148. It
was not introduced by this PR; any PR touching the main script would hit it.

**Change:** when `BIOPORTAL_API_KEY` is absent, the adapter now logs a warning and
yields no nodes/edges instead of raising. Behavior is unchanged when the key is set
(`update_graph()` runs in `get_nodes`/`get_edges`, not `__init__`, so an empty
ontology set constructs safely). This unblocks CI without requiring a secret and is
safe for forks.