### PR TITLE
Automatically build a reactome_reaction_exporter_All_species.txt file  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,4 +182,8 @@ output_human/
 aux_files/hsa/catlas/*.pkl
 samples/hsa/catlasv1/cCRE_hg38.tsv.gz
 samples/reactome/interactors/reactome.all_species.interactions.tab-delimited.txt
+
+# Reactome full reaction exporter (72 MB+ — generate via `export-reactome` CLI command)
+
+data/reactome_reaction_exporter_All_species.txt
 doc/plans

--- a/biocypher_dataset_downloader/README.md
+++ b/biocypher_dataset_downloader/README.md
@@ -1,0 +1,33 @@
+# BioCypher Dataset Downloader & Reactome Exporter
+
+This directory contains tools for downloading biomedical data sources and exporting full Reactome reaction dataset files for all species.
+
+## Reactome All-Species Reaction Exporter
+
+The full `reactome_reaction_exporter_All_species.txt` dataset contains ~732,000+ reaction entries across all species (~72 MB). Because of its size, it is excluded from git version control via `.gitignore`.
+
+### Sample Dataset
+A 1,000-row sample dataset is provided in the repository for development, unit testing, and sample runs:
+```
+samples/reactome/reactome_reaction_exporter_All_species_sample.txt
+```
+
+### Generating the Full All-Species File
+
+To build the full `reactome_reaction_exporter_All_species.txt` file on demand, query the Reactome Neo4j graph database using the `export-reactome` CLI command.
+
+#### Step 1: Start the Reactome Neo4j GraphDB Container
+```bash
+docker run -d --name reactome-neo4j -p 8687:7687 public.ecr.aws/reactome/graphdb:latest
+```
+
+#### Step 2: Run the Exporter
+```bash
+python biocypher_dataset_downloader/download_data.py export-reactome \
+    --output-dir ./data \
+    --neo4j-uri "bolt://localhost:8687" \
+    --neo4j-user "neo4j" \
+    --neo4j-password "neo4j"
+```
+
+The exported file will be saved to `./data/reactome_reaction_exporter_All_species.txt`.

--- a/biocypher_dataset_downloader/download_data.py
+++ b/biocypher_dataset_downloader/download_data.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 from typing_extensions import Annotated
 from biocypher_dataset_downloader.download_manager import DownloadManager
+from biocypher_dataset_downloader.reactome_exporter import export_reactome_reactions
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 app = typer.Typer()
@@ -36,6 +37,25 @@ def download_data(
             manager.download_all()
     except Exception as e:
         logging.error(f"Download failed: {e}")
+        raise
+
+
+@app.command()
+def export_reactome(
+    output_dir: Annotated[Path, typer.Option(dir_okay=True)],
+    neo4j_uri: str = typer.Option("bolt://localhost:7687", help="Neo4j URI"),
+    neo4j_user: str = typer.Option("neo4j", help="Neo4j username"),
+    neo4j_password: str = typer.Option("neo4j", help="Neo4j password"),
+    ref_db: str = typer.Option("UniProt", help="Reference database display name")
+):
+    """
+    Connect to a Reactome Neo4j graph database and generate the reactome_reaction_exporter_All_species.txt file.
+    """
+    output_file = output_dir / "reactome_reaction_exporter_All_species.txt"
+    try:
+        export_reactome_reactions(output_file, neo4j_uri, neo4j_user, neo4j_password, ref_db)
+    except Exception as e:
+        logging.error(f"Reactome export failed: {e}")
         raise
 
 

--- a/biocypher_dataset_downloader/reactome_exporter.py
+++ b/biocypher_dataset_downloader/reactome_exporter.py
@@ -1,0 +1,71 @@
+import csv
+import logging
+from pathlib import Path
+from neo4j import GraphDatabase
+
+logger = logging.getLogger(__name__)
+
+QUERY_IDS = """
+MATCH (rle:ReactionLikeEvent)
+OPTIONAL MATCH (rle)-[:input|hasComponent|hasMember|hasCandidate|proteinMarker|RNAMarker*]->(pe:PhysicalEntity),
+               (pe)-[:referenceEntity]->(re:ReferenceEntity)-[:referenceDatabase]->(rd:ReferenceDatabase{displayName:$refDb})
+WITH rle, COLLECT(DISTINCT CASE pe WHEN NULL THEN NULL ELSE {uniprot: re.identifier, type:'input'} END) AS ps_input
+OPTIONAL MATCH (rle)-[:output|hasComponent|hasMember|hasCandidate|proteinMarker|RNAMarker*]->(pe:PhysicalEntity),
+               (pe)-[:referenceEntity]->(re:ReferenceEntity)-[:referenceDatabase]->(rd:ReferenceDatabase{displayName:$refDb})
+WITH rle, ps_input, COLLECT(DISTINCT CASE pe WHEN NULL THEN NULL ELSE {uniprot: re.identifier, type:'output'} END) AS ps_output
+OPTIONAL MATCH (rle)-[:catalystActivity|physicalEntity|hasComponent|hasMember|hasCandidate|proteinMarker|RNAMarker*]->(pe:PhysicalEntity),
+               (pe)-[:referenceEntity]->(re:ReferenceEntity)-[:referenceDatabase]->(rd:ReferenceDatabase{displayName:$refDb})
+WITH rle, ps_input, ps_output, COLLECT(DISTINCT CASE pe WHEN NULL THEN NULL ELSE {uniprot: re.identifier, type:'catalyst'} END) AS ps_catalyst
+OPTIONAL MATCH (rle)-[:regulatedBy]->(:NegativeRegulation)-[:regulator|hasComponent|hasMember|hasCandidate|proteinMarker|RNAMarker*]->(pe:PhysicalEntity),
+               (pe)-[:referenceEntity]->(re:ReferenceEntity)-[:referenceDatabase]->(rd:ReferenceDatabase{displayName:$refDb})
+WITH rle, ps_input, ps_output, ps_catalyst, COLLECT(DISTINCT CASE pe WHEN NULL THEN NULL ELSE {uniprot: re.identifier, type:'negative'} END) AS ps_negative
+OPTIONAL MATCH (rle)-[:regulatedBy]->(:PositiveRegulation)-[:regulator|hasComponent|hasMember|hasCandidate|proteinMarker|RNAMarker*]->(pe:PhysicalEntity),
+               (pe)-[:referenceEntity]->(re:ReferenceEntity)-[:referenceDatabase]->(rd:ReferenceDatabase{displayName:$refDb})
+WITH rle, ps_input, ps_output, ps_catalyst, ps_negative, COLLECT(DISTINCT CASE pe WHEN NULL THEN NULL ELSE {uniprot: re.identifier, type:'positive'} END) AS ps_positive
+WITH rle, ps_input + ps_output + ps_catalyst + ps_negative + ps_positive AS ps
+MATCH path=(p:Pathway)-[:hasEvent]->(rle)
+UNWIND ps AS part
+WITH p, rle, part
+WHERE part IS NOT NULL
+RETURN p.stId AS pathway_id, rle.stId AS reaction_id, rle.displayName as reaction_name, part.uniprot as uniprot_acc, collect(part.type) as role_in_reaction
+ORDER BY pathway_id, reaction_id, uniprot_acc
+"""
+
+def export_reactome_reactions(output_file: Path, neo4j_uri: str, neo4j_user: str, neo4j_password: str, ref_db: str = "UniProt"):
+    """
+    Connects to a Reactome Neo4j graph database and exports the reaction data
+    to a TSV file for all species.
+    """
+    logger.info(f"Connecting to Neo4j at {neo4j_uri} to generate Reactome export...")
+    try:
+        driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+    except Exception as e:
+        logger.error(f"Failed to connect to Neo4j: {e}")
+        raise
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with driver.session() as session:
+            logger.info("Executing Cypher query...")
+            result = session.run(QUERY_IDS, refDb=ref_db)
+            
+            with open(output_file, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.writer(f, delimiter='\t')
+                writer.writerow(["pathway_id", "reaction_id", "reaction_name", "uniprot_acc", "role_in_reaction"])
+                
+                count = 0
+                for record in result:
+                    pathway_id = record["pathway_id"]
+                    reaction_id = record["reaction_id"]
+                    reaction_name = record["reaction_name"]
+                    uniprot_acc = record["uniprot_acc"]
+                    role_in_reaction = ", ".join(record["role_in_reaction"]) if record["role_in_reaction"] else ""
+                    
+                    if uniprot_acc: 
+                        writer.writerow([pathway_id, reaction_id, reaction_name, uniprot_acc, f"[{role_in_reaction}]"])
+                        count += 1
+                        
+            logger.info(f"Export completed. {count} rows written to {output_file}")
+    finally:
+        driver.close()


### PR DESCRIPTION
Summary

#326 

Adds a script to generate the reactome_reaction_exporter_All_species.txt file by querying the Reactome Neo4j graph database directly. This file was previously only available for Homo sapiens via the Reactome [data-export](https://github.com/reactome/dataexport/blob/main/src/main/java/org/reactome/server/export/tasks/SequenceExporter.java) Java tool. The all-species version is now reproducible programmatically by connecting to the official Reactome Neo4j graph database (e.g. via Docker image public.ecr.aws/reactome/graphdb:latest).

Changes

1.  biocypher_dataset_downloader/reactome_exporter.py (new file)

Translates the original Reactome Cypher query into Python. Key differences from the Java version:

- Removes the speciesName filter to cover all species (not just Homo sapiens)
- Filters out NULL parts before writing rows (rows without a valid UniProt accession are excluded)
- Outputs a tab-separated .txt file with columns: pathway_id, reaction_id, reaction_name, uniprot_acc, role_in_reaction

2. biocypher_dataset_downloader/download_data.py (modified)

Adds a new export-reactome Typer sub-command that wraps the exporter, with options for:

--output-dir — directory to write the output file into
--neo4j-uri — Neo4j bolt URI (default: bolt://localhost:7687)
--neo4j-user / --neo4j-password — credentials
--ref-db — reference database name (default: UniProt)

# Start the Reactome Neo4j Docker container
docker run -d --name reactome-neo4j -p 8687:7687 public.ecr.aws/reactome/graphdb:latest

# Run the exporter
PYTHONPATH=$PWD python biocypher_dataset_downloader/download_data.py export-reactome \
  --output-dir ./data \
  --neo4j-uri "bolt://localhost:8687" \
  --neo4j-user "neo4j" \
  --neo4j-password "neo4j"
Output is written to <output-dir>/reactome_reaction_exporter_All_species.txt.