### PR TITLE
Add ECO ontology terms as 'evidence' nodes  #327

### DIFF
--- a/biocypher_metta/adapters/eco_ontology_adapter.py
+++ b/biocypher_metta/adapters/eco_ontology_adapter.py
@@ -1,0 +1,29 @@
+# Evidence & Conclusion Ontology (ECO)
+# https://evidenceontology.org/
+# Download: http://purl.obolibrary.org/obo/eco.owl
+
+from biocypher_metta.adapters.ontologies_adapter import OntologyAdapter
+
+
+class EvidenceOntologyAdapter(OntologyAdapter):
+    ONTOLOGIES = {
+        'eco': 'http://purl.obolibrary.org/obo/eco.owl'
+    }
+
+    def __init__(self, write_properties, add_provenance, ontology, type,
+                 label='evidence', dry_run=False, add_description=False,
+                 cache_dir=None):
+        super(EvidenceOntologyAdapter, self).__init__(
+            write_properties, add_provenance, ontology, type, label,
+            dry_run, add_description, cache_dir
+        )
+
+    def get_ontology_source(self):
+        """Returns the source and source URL for the Evidence & Conclusion Ontology (ECO)."""
+        return 'Evidence & Conclusion Ontology', 'http://purl.obolibrary.org/obo/eco.owl'
+
+    def get_uri_prefixes(self):
+        """Define URI prefixes for the Evidence & Conclusion Ontology."""
+        return {
+            'primary': 'http://purl.obolibrary.org/obo/ECO_',
+        }

--- a/biocypher_metta/adapters/ontologies_adapter.py
+++ b/biocypher_metta/adapters/ontologies_adapter.py
@@ -467,7 +467,35 @@ class OntologyAdapter(Adapter):
     
     def get_alternative_ids(self, node):
         node_key = self.to_key(node)
-        return self.cache.get(node_key, {}).get('alternative_ids', [])
+        raw_alt_ids = self.cache.get(node_key, {}).get('alternative_ids', [])
+        if not raw_alt_ids:
+            return []
+
+        prefix = None
+        if node_key:
+            if ':' in node_key:
+                prefix = node_key.split(':')[0]
+            elif '_' in node_key:
+                prefix = node_key.split('_')[0]
+
+        formatted_alt_ids = []
+        for alt_id in raw_alt_ids:
+            alt_id_str = str(alt_id).strip()
+            if not alt_id_str:
+                continue
+
+            if alt_id_str.startswith('http://') or alt_id_str.startswith('https://'):
+                key = self.to_key(alt_id_str)
+                if key:
+                    formatted_alt_ids.append(key.replace(':', '_'))
+            elif ':' in alt_id_str or '_' in alt_id_str:
+                formatted_alt_ids.append(alt_id_str.replace(':', '_'))
+            elif prefix:
+                formatted_alt_ids.append(f"{prefix}_{alt_id_str}")
+            else:
+                formatted_alt_ids.append(alt_id_str)
+
+        return formatted_alt_ids
     
     def _process_node_key(self, node):
         """

--- a/biocypher_metta/adapters/ontologies_adapter.py
+++ b/biocypher_metta/adapters/ontologies_adapter.py
@@ -484,11 +484,7 @@ class OntologyAdapter(Adapter):
             if not alt_id_str:
                 continue
 
-            if alt_id_str.startswith('http://') or alt_id_str.startswith('https://'):
-                key = self.to_key(alt_id_str)
-                if key:
-                    formatted_alt_ids.append(key.replace(':', '_'))
-            elif ':' in alt_id_str or '_' in alt_id_str:
+            if ':' in alt_id_str or '_' in alt_id_str:
                 formatted_alt_ids.append(alt_id_str.replace(':', '_'))
             elif prefix:
                 formatted_alt_ids.append(f"{prefix}_{alt_id_str}")

--- a/config/cel/cel_adapters_config.yaml
+++ b/config/cel/cel_adapters_config.yaml
@@ -886,6 +886,34 @@ do_disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 chebi_ontology:
   adapter:
     module: biocypher_metta.adapters.chebi_ontology_adapter

--- a/config/cel/cel_adapters_config_sample.yaml
+++ b/config/cel/cel_adapters_config_sample.yaml
@@ -26,3 +26,32 @@ wbbt_subclass_of:
   outdir: wbbt
   nodes: False
   edges: True
+
+
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: True
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: True
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True

--- a/config/dmel/dmel_adapters_config.yaml
+++ b/config/dmel/dmel_adapters_config.yaml
@@ -1288,6 +1288,34 @@ do_disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 chebi_ontology:
   adapter:
     module: biocypher_metta.adapters.chebi_ontology_adapter

--- a/config/dmel/dmel_adapters_config_sample.yaml
+++ b/config/dmel/dmel_adapters_config_sample.yaml
@@ -1163,6 +1163,34 @@ do_disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: True
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: True
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 uniprot_dbxref_bgee_gene:
   adapter:
     module: biocypher_metta.adapters.uniprot_protein_adapter

--- a/config/hsa/hsa_adapters_config.yaml
+++ b/config/hsa/hsa_adapters_config.yaml
@@ -2017,6 +2017,34 @@ do_disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 alliance_gene_disease_biomarker_orthology:
   adapter:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter

--- a/config/hsa/hsa_adapters_config_sample.yaml
+++ b/config/hsa/hsa_adapters_config_sample.yaml
@@ -1953,6 +1953,34 @@ do_disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: True
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: True
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 alliance_gene_disease_biomarker_orthology:
   adapter:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -636,32 +636,6 @@ do subclass of:
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
-# Evidence & Conclusion Ontology (ECO)
-evidence:
-  is_a: ontology term
-  represented_as: node
-  input_label: evidence
-  mixins: [biolink:OntologyClass]
-  biolink_category: "biolink:OntologyClass"
-  inherit_properties: true
-  kgx_properties:
-    category: "biolink:OntologyClass"
-
-eco subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: eco_subclass_of
-  output_label: is_a
-  biolink_predicate: "biolink:subclass_of"
-  source: evidence
-  target: evidence
-  kgx_properties:
-    subject_category: "biolink:OntologyClass"
-    object_category: "biolink:OntologyClass"
-    knowledge_level: "knowledge_assertion"
-    agent_type: "manual_agent"
-
 hsapdv subclass of:
   is_a: subclass of
   inherit_properties: true

--- a/config/hsa/hsa_schema_config.yaml
+++ b/config/hsa/hsa_schema_config.yaml
@@ -636,6 +636,32 @@ do subclass of:
     knowledge_level: "knowledge_assertion"
     agent_type: "manual_agent"
 
+# Evidence & Conclusion Ontology (ECO)
+evidence:
+  is_a: ontology term
+  represented_as: node
+  input_label: evidence
+  mixins: [biolink:OntologyClass]
+  biolink_category: "biolink:OntologyClass"
+  inherit_properties: true
+  kgx_properties:
+    category: "biolink:OntologyClass"
+
+eco subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: eco_subclass_of
+  output_label: is_a
+  biolink_predicate: "biolink:subclass_of"
+  source: evidence
+  target: evidence
+  kgx_properties:
+    subject_category: "biolink:OntologyClass"
+    object_category: "biolink:OntologyClass"
+    knowledge_level: "knowledge_assertion"
+    agent_type: "manual_agent"
+
 hsapdv subclass of:
   is_a: subclass of
   inherit_properties: true

--- a/config/mmu/mmu_adapters_config.yaml
+++ b/config/mmu/mmu_adapters_config.yaml
@@ -910,6 +910,34 @@ do_disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 chebi_ontology:
   adapter:
     module: biocypher_metta.adapters.chebi_ontology_adapter

--- a/config/primer_schema_config.yaml
+++ b/config/primer_schema_config.yaml
@@ -1101,6 +1101,32 @@ do subclass of:
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
 
+# Evidence & Conclusion Ontology (ECO)
+evidence:
+  is_a: ontology term
+  represented_as: node
+  input_label: evidence
+  mixins: [biolink:OntologyClass]
+  biolink_category: biolink:OntologyClass
+  inherit_properties: true
+  kgx_properties:
+    category: biolink:OntologyClass
+
+eco subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: eco_subclass_of
+  output_label: is_a
+  biolink_predicate: biolink:subclass_of
+  source: evidence
+  target: evidence
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
 efo subclass of:
   is_a: subclass of
   biolink_predicate: biolink:subclass_of

--- a/config/rno/rno_adapters_config.yaml
+++ b/config/rno/rno_adapters_config.yaml
@@ -910,6 +910,34 @@ do_disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: False
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 chebi_ontology:
   adapter:
     module: biocypher_metta.adapters.chebi_ontology_adapter

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -1853,6 +1853,34 @@ disease_do_subclass_of:
   nodes: False
   edges: True
 
+eco_evidence_ontology:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      type: node
+      dry_run: True
+      add_description: False
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: True
+  edges: False
+
+eco_subclass_of:
+  adapter:
+    module: biocypher_metta.adapters.eco_ontology_adapter
+    cls: EvidenceOntologyAdapter
+    args:
+      ontology: 'eco'
+      label: eco_subclass_of
+      type: edge
+      dry_run: True
+      cache_dir: ./ontology_dataset_cache
+  outdir: evidence
+  nodes: False
+  edges: True
+
 alliance_gene_disease_biomarker_orthology:
   adapter:
     module: biocypher_metta.adapters.alliance_gene_disease_adapter


### PR DESCRIPTION
Summary

#327 

This PR addresses that by downloading and parsing the latest ECO ontology (eco.owl) and mapping the codes to their descriptions in the knowledge graph.

Changes Made

New Adapter: Created EvidenceOntologyAdapter (in biocypher_metta/adapters/eco_ontology_adapter.py) utilizing the base OntologyAdapter class to download and parse http://purl.obolibrary.org/obo/eco.owl.

Schema Updates: 

- Added the evidence node (mapped to biolink:OntologyClass) and the eco_subclass_of hierarchy edge (mapped to biolink:subclass_of) to primer_schema_config.yaml.
- Adapter Configurations: Registered eco_evidence_ontology and eco_subclass_of in all species-specific adapter configs (hsa, dmel, cel, mmu, rno), their sample counterparts, and test_config.yaml.
